### PR TITLE
Add Happy Holidays to the list of "funny" sets

### DIFF
--- a/lib/condition/condition_is_funny.rb
+++ b/lib/condition/condition_is_funny.rb
@@ -3,7 +3,7 @@ class ConditionIsFunny < ConditionSimple
   # Basic lands here aren't exactly funny
   # Shouldn't it just test border:silver ?
   def match?(card)
-    %W[uh ug uqc].include?(card.set_code)
+    %W[uh ug uqc hho].include?(card.set_code)
   end
 
   def to_s

--- a/test/test_full.rb
+++ b/test/test_full.rb
@@ -312,6 +312,23 @@ class CardDatabaseFullTest < Minitest::Test
     assert_count_results "is:promo", 1047
   end
 
+  def test_is_funny
+    assert_search_results "abyss is:funny", "Zzzyxas's Abyss"
+    assert_search_results "abyss not:funny",
+      "Abyssal Gatekeeper",
+      "Abyssal Horror",
+      "Abyssal Hunter",
+      "Abyssal Nightstalker",
+      "Abyssal Nocturnus",
+      "Abyssal Persecutor",
+      "Abyssal Specter",
+      "Magus of the Abyss",
+      "Reaper from the Abyss",
+      "The Abyss"
+    assert_search_results "snow is:funny", "Snow Mercy"
+    assert_search_results "tiger is:funny", "Paper Tiger", "Stocking Tiger"
+  end
+
   def test_stemming
     assert_search_equal "vision", "visions"
   end


### PR DESCRIPTION
So: after it became clear that magiccards.info wasn't going to keep updating much if at all anymore, I had been thinking pretty strongly about building my own site that duplicated and enhanced the search syntax in Rails, but... since I discovered that you'd already done that exact thing quite effectively, I figured I'd just submit some PRs to this project instead. 

This is the first and simplest of three, just a bug fix to include the Happy Holidays promo set into the "is:funny" category (as it currently is on magiccards.info.) I also added tests to verify this functionality.