### PR TITLE
Adding variable support to the mana cost condition

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -77,6 +77,17 @@
       = search_help "mana>={2/r}", "cards with mana cost including {2/r} Shadowmoor hybrid mana"
       = search_help "mana={p/r}", "cards with mana cost equal {p/r} Phyrexian mana"
 
+    %div This search supports variable symbols: "m", "n", and "o" each represent a single mana of any color but must each differ from the others; "h" represents a single hybrid mana.
+
+    %ul
+      = search_help "mana=m", "cards with mana cost of exactly 1 colored mana, of any color"
+      = search_help "mana>mm", "cards that cost at least two mana of any one color"
+      = search_help "mana={m}{n}", "cards that cost at exactly one mana each of any two colors"
+      = search_help "mana={m}{m}{n}{n}{n}{o}{o}", "cards that cost exactly two mana each of two colors and three of a third"
+      = search_help "mana={w}{w}{n}{n}{n}{o}{o}", "cards that cost two white mana, two of any one other color, and three of a third color"
+      = search_help "mana=hh", "cards that cost exactly two hybrid mana"
+      = search_help "mana>h", "cards with at least one hybrid mana in their mana cost"
+
     %h4 Search by power, toughness, and loyalty
     %ul
       = search_help "pow=4", "creature cards with power 4"

--- a/lib/condition/condition_mana.rb
+++ b/lib/condition/condition_mana.rb
@@ -113,8 +113,8 @@ class ConditionMana < ConditionSimple
   end
 
   def resolve_variable_mana(card_mana, query_mana)
-    card_mana.sort_by {|_key, value| value}
-    query_mana.sort_by {|_key, value| value}
+    card_mana = card_mana.sort_by {|key, value| [value, key]}.to_h
+    query_mana = query_mana.sort_by {|key, value| [value, key]}.to_h
     q_mana = Hash.new(0)
     colors = %w(w u b r g c)
     hybrids = %w(uw bu br gr gw bw bg gu ru rw)
@@ -124,7 +124,9 @@ class ConditionMana < ConditionSimple
         when 'm','n','o'
           matched = false
           card_mana.each do |card_color, card_count|
-            if colors.include?(card_color) and !q_mana.keys.include?(card_color)
+            if colors.include?(card_color) &&
+              !q_mana.keys.include?(card_color) &&
+              !query_mana.keys.include?(card_color)
               q_mana[card_color] = count
               matched = true
               break
@@ -134,7 +136,9 @@ class ConditionMana < ConditionSimple
         when 'h'
           matched = false
           card_mana.each do |card_color, card_count|
-            if hybrids.include?(card_color) and !q_mana.keys.include?(card_color)
+            if hybrids.include?(card_color) &&
+              !q_mana.keys.include?(card_color) &&
+              !query_mana.keys.include?(card_color)
               q_mana[card_color] = count
               matched = true
               break

--- a/lib/query_parser.rb
+++ b/lib/query_parser.rb
@@ -72,7 +72,7 @@ private
         @tokens << [:test, ConditionRarity.new(s[1])]
       elsif s.scan(/(pow|loyalty|tou|cmc|year)\s*(>=|>|<=|<|=)\s*(pow\b|tou\b|cmc\b|loyalty\b|year\b|[²\d\.\-\*\+½]+)/i)
         @tokens << [:test, ConditionExpr.new(s[1].downcase, s[2], s[3].downcase)]
-      elsif s.scan(/mana\s*(>=|>|<=|<|=)\s*((?:[\dwubrgxyzc]|\{.*?\})+)/i)
+      elsif s.scan(/mana\s*(>=|>|<=|<|=)\s*((?:[\dwubrgxyzchmno]|\{.*?\})+)/i)
         @tokens << [:test, ConditionMana.new(s[1], s[2])]
       elsif s.scan(/(is|not):(vanilla|spell|permanent|funny|timeshifted|reserved|multipart|promo)\b/i)
         @tokens << [:not] if s[1].downcase == "not"

--- a/test/test_full.rb
+++ b/test/test_full.rb
@@ -312,6 +312,17 @@ class CardDatabaseFullTest < Minitest::Test
     assert_count_results "is:promo", 1047
   end
 
+  def test_mana_variables
+    assert_search_equal "b:ravnica guildmage mana=HH", "b:ravnica guildmage c:m cmc=2"
+    assert_search_equal "e:rtr mana=H", "e:rtr c:m cmc=1"
+    assert_search_results "mana>MMMMM",
+      "B.F.M. (Big Furry Monster)",
+      "Khalni Hydra",
+      "Primalcrux"
+    assert_count_results "e:ktk (charm OR ascendancy) mana=MNO", 10
+    assert_count_results "e:ktk mana=MNO", 15
+  end
+
   def test_stemming
     assert_search_equal "vision", "visions"
   end

--- a/test/test_full.rb
+++ b/test/test_full.rb
@@ -313,14 +313,25 @@ class CardDatabaseFullTest < Minitest::Test
   end
 
   def test_mana_variables
-    assert_search_equal "b:ravnica guildmage mana=HH", "b:ravnica guildmage c:m cmc=2"
-    assert_search_equal "e:rtr mana=H", "e:rtr c:m cmc=1"
-    assert_search_results "mana>MMMMM",
+    assert_search_equal "b:ravnica guildmage mana=hh", "b:ravnica guildmage c:m cmc=2"
+    assert_search_equal "e:rtr mana=h", "e:rtr c:m cmc=1"
+    assert_search_results "mana>mmmmm",
       "B.F.M. (Big Furry Monster)",
       "Khalni Hydra",
       "Primalcrux"
-    assert_count_results "e:ktk (charm OR ascendancy) mana=MNO", 10
-    assert_count_results "e:ktk mana=MNO", 15
+    assert_count_results "e:ktk (charm OR ascendancy) mana=mno", 10
+    assert_count_results "e:ktk mana=mno", 15
+    assert_search_results "mana=mmnnnoo",
+      "Brilliant Ultimatum",
+      "Clarion Ultimatum",
+      "Cruel Ultimatum",
+      "Titanic Ultimatum",
+      "Violent Ultimatum"
+    assert_search_results "mana=wwmmmnn",
+      "Brilliant Ultimatum",
+      "Titanic Ultimatum"
+    assert_search_equal "mana=mmnnnoo", "mana=nnooomm"
+    assert_search_equal "mana>nnnnn", "mana>ooooo"
   end
 
   def test_stemming

--- a/test/test_full.rb
+++ b/test/test_full.rb
@@ -332,6 +332,8 @@ class CardDatabaseFullTest < Minitest::Test
       "Titanic Ultimatum"
     assert_search_equal "mana=mmnnnoo", "mana=nnooomm"
     assert_search_equal "mana>nnnnn", "mana>ooooo"
+    assert_search_equal "mana=mno", "mana={m}{n}{o}"
+    assert_count_results "mana>=mh", 15
   end
 
   def test_stemming


### PR DESCRIPTION
This adds support for variables in the mana search, inspired by the internal R&D code letters Mark Rosewater has mentioned in the past. "{m}," "{n}," and "{o}" each match any single color of mana, while "{h}" matches any single hybrid symbol. They can be combined, so "mana={m}{n}{o}" will find any card with a cost of exactly one of three different colors of mana, while "mana>={m}{h}" will find every card with at least one colored mana and one hybrid mana in its cost.

This also includes tests to verify this functionality and updates the syntax page of the frontend app to describe how it works. 