### PR TITLE
Add "set type" condition and add options to firstprint/lastprint conditions

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -124,6 +124,26 @@
       = search_help %Q[f:edh], "cards legal in Commander format"
       = search_help %Q[f:"innistrad block"], "cards legal in Innistrad Block Constructed format"
 
+    %h4 Search by set type
+    %div Set type includes both individual types of sets (like expansions, core sets, or duel decks) and broader categories (booster sets, multiplayer sets.)
+    %ul
+      = search_help "st:ex", "cards from standard expert-level expansions"
+      = search_help "st:core", "core sets"
+      = search_help "st:box", "boxed sets like the Anthologies box"
+      = search_help "st:ftv", "From The Vault sets"
+      = search_help "st:arc", "Archenemy sets"
+      = search_help "st:cmd", "Commander sets"
+      = search_help "st:cns", "Conspiracy sets"
+      = search_help "st:pc", "Planechase sets"
+      = search_help "st:rep", "Reprint sets like Chronicles or Modern Masters"
+      = search_help "st:st", "Introductory/starter sets"
+      = search_help "st:pds", "Premium Deck Series"
+      = search_help "st:masters", "Online Masters sets"
+      = search_help "st:multi", "All types of multiplayer sets"
+      = search_help "st:booster", "All sets sold in booster packs"
+      = search_help "st:fixed", "Non-deck sets with predetermined contents"
+      = search_help "st:deck", "All sets consisting of pre-built decks"
+
     %h4 Search by watermark
     %ul
       = search_help "w:izzet", "cards with Izzet watermark (Return to Ravnica block)"
@@ -170,14 +190,16 @@
     %h4 Search by printing time
     %div For printing time you can use set code, set name, or full date in more or less any format as long as it includes 4-digit year somewhere.
 
-    %div firstprint: operator can be somewhat confusing, as a lot of cards which you'd technically consider to come out in a set technically came out in a Prerelease (dated one week before) or a Duel Deck (a few weeks before) that set. Online-only sets are included too.
+    %div firstprint/lastprint: these commands have three options as to which sets are included. By default, they exclude promo printings and online-only reprint sets. With an added !, only the first or last printing in a core or expansion set is counted. Finally, with an added *, all sets and promos of any type are considered.
 
     %ul
       = search_help "year=2003", "cards printed in year 2003"
       = search_help "year<=1995", "cards printed in year 1995 or before"
-      = search_help "print>ktk", "cards printed after release of Khans of Tarkir"
+      = search_help "print>m10", "cards printed after release of Magic 2010"
       = search_help %Q[print="29 September 2012"], "cards printed on 29 September 2012 (Return to Ravnica prerelease)"
-      = search_help "firstprint=m10", "cards first printed in Magic 2010 set"
+      = search_help "firstprint=ktk", "cards first printed in Khans of Tarkir (this includes cards released as pre-release promos, but not those previewed in Duel Decks: Speed vs Cunning)"
+      = search_help "firstprint!=ktk", "cards first printed in Khans of Tarkir, counting core/expansion printings only"
+      = search_help "firstprint*=ktk", "cards first printed in Khans of Tarkir, excluding pre-release promos and DD previews"
       = search_help "lastprint=m10", "cards last printed in Magic 2010 set"
       = search_help "lastprint<lw", "cards last printed in in Lorwyn set or earlier"
 

--- a/lib/card.rb
+++ b/lib/card.rb
@@ -78,7 +78,7 @@ class Card
   def first_release_date(filter="all")
     case filter
       when "full"
-        @printings.select{|pr| pr.set_type != 'promo'}.map(&:release_date).compact.min
+        @printings.select{|pr| !%w(promo masters).include?(pr.set_type)}.map(&:release_date).compact.min
       when "expert"
         @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.min
       else
@@ -89,7 +89,7 @@ class Card
   def last_release_date(filter="all")
     case filter
       when "full"
-        @printings.select{|pr| pr.set_type != 'promo'}.map(&:release_date).compact.max
+        @printings.select{|pr| !%w(promo masters).include?(pr.set_type)}.map(&:release_date).compact.max
       when "expert"
         @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.max
       else

--- a/lib/card.rb
+++ b/lib/card.rb
@@ -78,7 +78,8 @@ class Card
   def first_release_date(filter="all")
     case filter
       when "full"
-        @printings.select{|pr| !%w(promo masters).include?(pr.set_type)}.map(&:release_date).compact.min
+        @printings.select{|pr| !%w(promo masters).include?(pr.set_type) && pr.set_code != 'tpr'}.map(&:release_date)
+          .compact.min
       when "expert"
         @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.min
       else
@@ -89,7 +90,8 @@ class Card
   def last_release_date(filter="all")
     case filter
       when "full"
-        @printings.select{|pr| !%w(promo masters).include?(pr.set_type)}.map(&:release_date).compact.max
+        @printings.select{|pr| !%w(promo masters).include?(pr.set_type) && pr.set_code != 'tpr'}.map(&:release_date)
+          .compact.max
       when "expert"
         @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.max
       else

--- a/lib/card.rb
+++ b/lib/card.rb
@@ -75,12 +75,26 @@ class Card
     Format.all_legalities(self, date)
   end
 
-  def first_release_date
-    @printings.map(&:release_date).compact.min
+  def first_release_date(filter="all")
+    case filter
+      when "full"
+        @printings.select{|pr| pr.set_type != 'promo'}.map(&:release_date).compact.min
+      when "expert"
+        @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.min
+      else
+        @printings.map(&:release_date).compact.min
+    end
   end
 
-  def last_release_date
-    @printings.map(&:release_date).compact.max
+  def last_release_date(filter="all")
+    case filter
+      when "full"
+        @printings.select{|pr| pr.set_type != 'promo'}.map(&:release_date).compact.max
+      when "expert"
+        @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.max
+      else
+        @printings.map(&:release_date).compact.max
+    end
   end
 
   private

--- a/lib/card.rb
+++ b/lib/card.rb
@@ -76,27 +76,11 @@ class Card
   end
 
   def first_release_date(filter="all")
-    case filter
-      when "full"
-        @printings.select{|pr| !%w(promo masters).include?(pr.set_type) && pr.set_code != 'tpr'}.map(&:release_date)
-          .compact.min
-      when "expert"
-        @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.min
-      else
-        @printings.map(&:release_date).compact.min
-    end
+    @printings.select{|pr| verify_set_type(pr, filter)}.map(&:release_date).compact.min
   end
 
   def last_release_date(filter="all")
-    case filter
-      when "full"
-        @printings.select{|pr| !%w(promo masters).include?(pr.set_type) && pr.set_code != 'tpr'}.map(&:release_date)
-          .compact.max
-      when "expert"
-        @printings.select{|pr| %w(core expansion).include?(pr.set_type)}.map(&:release_date).compact.max
-      else
-        @printings.map(&:release_date).compact.max
-    end
+    @printings.select{|pr| verify_set_type(pr, filter)}.map(&:release_date).compact.max
   end
 
   private
@@ -162,5 +146,16 @@ class Card
       ci << tci if tci
     end
     ci.uniq.join
+  end
+
+  def verify_set_type(pr, type)
+    case type
+      when "full"
+        !%w(promo masters).include?(pr.set_type) && pr.set_code != 'tpr'
+      when "expert"
+        %w(core expansion).include?(pr.set_type)
+      else
+        true
+    end
   end
 end

--- a/lib/card_printing.rb
+++ b/lib/card_printing.rb
@@ -47,6 +47,10 @@ class CardPrinting
     @data["rarity"]
   end
 
+  def set_type
+    @set.type
+  end
+
   def frame
     @frame ||= begin
       eight_edition_release_date = Date.parse("2003-07-28")

--- a/lib/condition/condition_firstprint.rb
+++ b/lib/condition/condition_firstprint.rb
@@ -9,7 +9,7 @@ class ConditionFirstprint < ConditionPrint
     if max_date
       card.card.printings.map(&:release_date).compact.select{|d| d <= max_date}.min
     else
-      card.first_release_date
+      card.card.first_release_date @type
     end
   end
 end

--- a/lib/condition/condition_lastprint.rb
+++ b/lib/condition/condition_lastprint.rb
@@ -7,9 +7,9 @@ class ConditionLastprint < ConditionPrint
 
   def get_date(card, max_date)
     if max_date
-      card.printings.map(&:release_date).compact.select{|d| d <= max_date}.max
+      card.card.printings.map(&:release_date).compact.select{|d| d <= max_date}.max
     else
-      card.last_release_date
+      card.card.last_release_date @type
     end
   end
 end

--- a/lib/condition/condition_print.rb
+++ b/lib/condition/condition_print.rb
@@ -18,7 +18,11 @@ class ConditionPrint < Condition
     query_date, precision = parse_query_date(db)
     if query_date
       max_date = db.resolve_time(@time)
-      db.printings.select{|card| match_date?(get_date(card, max_date), query_date, precision)}.to_set
+      ps = db.printings.select{|card| match_date?(get_date(card, max_date), query_date, precision)}.to_set
+
+      # avoid getting an and un confused
+      ps.select!{|printing| printing.set_code == @date} unless @date.is_a?(Date) || @op != '='
+      ps
     else
       db.printings.to_set
     end

--- a/lib/condition/condition_print.rb
+++ b/lib/condition/condition_print.rb
@@ -1,7 +1,7 @@
 # This condition checks printing, first/lastprinted check card.
 # Should they check same thing?
 class ConditionPrint < Condition
-  def initialize(op, date, type)
+  def initialize(op, date, type = '')
     @op = op
     # Just for ConditionPrint#==
     if date.is_a?(Date)
@@ -21,7 +21,7 @@ class ConditionPrint < Condition
       ps = db.printings.select{|card| match_date?(get_date(card, max_date), query_date, precision)}.to_set
 
       # avoid getting an and un confused
-      ps.select!{|printing| printing.set_code == @date} unless @date.is_a?(Date) || @op != '='
+      ps.select!{|printing| printing.set_code == @date} if %w(an un).include?(@date)
       ps
     else
       db.printings.to_set

--- a/lib/condition/condition_print.rb
+++ b/lib/condition/condition_print.rb
@@ -1,7 +1,7 @@
 # This condition checks printing, first/lastprinted check card.
 # Should they check same thing?
 class ConditionPrint < Condition
-  def initialize(op, date)
+  def initialize(op, date, type)
     @op = op
     # Just for ConditionPrint#==
     if date.is_a?(Date)
@@ -9,6 +9,9 @@ class ConditionPrint < Condition
     else
       @date = date
     end
+    types = {'' => 'full', '*' => 'all', '!' => 'expert'}
+    types.default('full')
+    @type = types[type]
   end
 
   def search(db)

--- a/lib/condition/condition_set_type.rb
+++ b/lib/condition/condition_set_type.rb
@@ -1,0 +1,65 @@
+class ConditionSetType < Condition
+  def initialize(set_type)
+    set_type = normalize_name(set_type)
+    @set_type = deabbreviate(set_type)
+  end
+
+  # For sets and blocks:
+  # "in" is code for "Invasion", don't substring match "Innistrad" etc.
+  # "Mirrodin" is name for "Mirrodin", don't substring match "Scars of Mirrodin"
+  def search(db)
+    matching_sets(db).map(&:printings).inject(Set[], &:|)
+  end
+
+  def to_s
+    "st:#{maybe_quote(@set_type)}"
+  end
+
+  private
+
+  def matching_sets(db)
+    type_list = get_type_list(@set_type)
+    sets = Set[]
+    db.sets.each do |set_code, set|
+      # CMA is a fixed set so
+      if set.code == "cma"
+        if type_list.include?("fixed")
+          sets << set
+        elsif type_list.include?("commander") and !type_list.include?("deck")
+          sets << set
+        end
+        next
+      end
+
+      if type_list.include?(set.type)
+        sets << set
+      end
+    end
+    sets
+  end
+
+  def deabbreviate(set_type)
+    set_type = "expansion" if set_type == "ex"
+    set_type = "from the vault" if set_type == "ftv"
+    set_type = "archenemy" if set_type == "arc"
+    set_type = "commander" if set_type == "cmd"
+    set_type = "conspiracy" if set_type == "cns"
+    set_type = "duel deck" if set_type == "dd"
+    set_type = "reprint" if set_type == "rep"
+    set_type = "masters" if set_type == "me"
+    set_type = "starter" if set_type == "st"
+    set_type = "premium deck" if set_type == "pds"
+    set_type = "planechase" if set_type == "pc"
+    set_type
+  end
+
+  def get_type_list(set_type)
+    type_list = [set_type]
+    if set_type == "multi" then type_list = %W(archenemy commander conspiracy planechase vanguard multi)
+    elsif set_type == "booster" then type_list = %W(expansion conspiracy reprint core masters starter un booster)
+    elsif set_type == "fixed" then type_list = %W(from\ the\ vault vanguard fixed)
+    elsif set_type == "deck" then type_list = %W(archenemy commander duel\ deck premium\ deck planechase box deck)
+    end
+    type_list
+  end
+end

--- a/lib/condition/condition_set_type.rb
+++ b/lib/condition/condition_set_type.rb
@@ -21,7 +21,7 @@ class ConditionSetType < Condition
     type_list = get_type_list(@set_type)
     sets = Set[]
     db.sets.each do |set_code, set|
-      # CMA is a fixed set so
+      # CMA is a fixed set so include it for commander or fixed but not for deck
       if set.code == "cma"
         if type_list.include?("fixed")
           sets << set
@@ -29,6 +29,13 @@ class ConditionSetType < Condition
           sets << set
         end
         next
+      end
+
+      # starter sets fall into several categories
+      if (set.code == "clash" and type_list.include?("deck")) ||
+        (%w(p3k po po2 st).include?(set.code) and type_list.include?("booster")) ||
+        (%w(st2k w16 itp).include?(set.code) and type_list.include?("fixed"))
+        sets << set
       end
 
       if type_list.include?(set.type)
@@ -56,7 +63,7 @@ class ConditionSetType < Condition
   def get_type_list(set_type)
     type_list = [set_type]
     if set_type == "multi" then type_list = %W(archenemy commander conspiracy planechase vanguard multi)
-    elsif set_type == "booster" then type_list = %W(expansion conspiracy reprint core masters starter un booster)
+    elsif set_type == "booster" then type_list = %W(expansion conspiracy reprint core masters un booster)
     elsif set_type == "fixed" then type_list = %W(from\ the\ vault vanguard fixed)
     elsif set_type == "deck" then type_list = %W(archenemy commander duel\ deck premium\ deck planechase box deck)
     end

--- a/lib/condition/condition_set_type.rb
+++ b/lib/condition/condition_set_type.rb
@@ -38,6 +38,15 @@ class ConditionSetType < Condition
         sets << set
       end
 
+      # file tempest remastered with "masters" sets
+      if set.code == "tpr"
+        if type_list.include?("masters")
+          sets << set
+        else
+          next
+        end
+      end
+
       if type_list.include?(set.type)
         sets << set
       end

--- a/lib/query_parser.rb
+++ b/lib/query_parser.rb
@@ -67,9 +67,9 @@ private
         @tokens << [:test, ConditionColorIdentity.new(s[1])]
       elsif s.scan(/c!([wubrgcml]+)/i)
         @tokens << [:test, ConditionColorsExclusive.new(s[1])]
-      elsif s.scan(/(print|firstprint|lastprint)\s*(>=|>|<=|<|=)\s*(?:"(.*?)"|(\w+))/)
+      elsif s.scan(/(print|firstprint|lastprint)([!\*]?)\s*(>=|>|<=|<|=)\s*(?:"(.*?)"|(\w+))/)
         klass = Kernel.const_get("Condition#{s[1].capitalize}")
-        @tokens << [:test, klass.new(s[2], s[3] || s[4])]
+        @tokens << [:test, klass.new(s[3], s[4] || s[5], s[2])]
       elsif s.scan(/r:(\w+)/)
         @tokens << [:test, ConditionRarity.new(s[1])]
       elsif s.scan(/(pow|loyalty|tou|cmc|year)\s*(>=|>|<=|<|=)\s*(pow\b|tou\b|cmc\b|loyalty\b|year\b|[²\d\.\-\*\+½]+)/i)

--- a/lib/query_parser.rb
+++ b/lib/query_parser.rb
@@ -59,6 +59,8 @@ private
         @tokens << [:test, ConditionFormat.new(s[1] || s[2])]
       elsif s.scan(/b:(?:"(.*?)"|(\w+))/i)
         @tokens << [:test, ConditionBlock.new(s[1] || s[2])]
+      elsif s.scan(/st:(?:"(.*?)"|(\w+))/i)
+        @tokens << [:test, ConditionSetType.new(s[1] || s[2])]
       elsif s.scan(/c:([wubrgcml]+)/i)
         @tokens << [:test, ConditionColors.new(s[1])]
       elsif s.scan(/ci:([wubrgcml]+)/i)

--- a/test/test_full.rb
+++ b/test/test_full.rb
@@ -89,7 +89,7 @@ class CardDatabaseFullTest < Minitest::Test
     assert_search_results "t:jace firstprint=2012", "Jace, Architect of Thought"
 
     # This is fairly silly, as it includes prerelease promos etc.
-    assert_search_results "e:ktk firstprint<ktk",
+    assert_search_results "e:ktk firstprint*<ktk",
       "Abzan Ascendancy", "Act of Treason", "Anafenza, the Foremost",
       "Ankle Shanker", "Arc Lightning", "Avalanche Tusker", "Bloodsoaked Champion",
       "Bloodstained Mire", "Butcher of the Horde", "Cancel", "Crackling Doom",
@@ -107,7 +107,7 @@ class CardDatabaseFullTest < Minitest::Test
       "Trumpet Blast", "Utter End", "Villainous Wealth", "Windstorm", "Windswept Heath",
       "Wooded Foothills", "Zurgo Helmsmasher"
 
-    assert_search_results "e:ktk lastprint>ktk",
+    assert_search_results "e:ktk lastprint*>ktk",
       "Act of Treason", "Ainok Tracker", "Altar of the Brood", "Arc Lightning", "Bloodfell Caves", "Bloodstained Mire", "Blossoming Sands", "Briber's Purse", "Debilitating Injury", "Disdainful Stroke", "Dismal Backwater", "Dragonscale Boon", "Dutiful Return", "Flooded Strand", "Forest", "Ghostfire Blade", "Grim Haruspex", "Hordeling Outburst", "Incremental Growth", "Island", "Jeering Instigator", "Jungle Hollow", "Mountain", "Mystic of the Hidden Way", "Naturalize", "Plains", "Polluted Delta", "Ride Down", "Rugged Highlands", "Ruthless Ripper", "Scoured Barrens", "Shatter", "Smite the Monstrous", "Sultai Charm", "Summit Prowler", "Suspension Field", "Swamp", "Swiftwater Cliffs", "Thornwood Falls", "Throttle", "Tormenting Voice", "Tranquil Cove", "Watcher of the Roost", "Weave Fate", "Wind-Scarred Crag", "Windstorm", "Windswept Heath", "Wooded Foothills"
   end
 
@@ -116,7 +116,7 @@ class CardDatabaseFullTest < Minitest::Test
   end
 
   def test_lastprint
-    assert_search_results "t:planeswalker lastprint<=roe", "Chandra Ablaze", "Sarkhan the Mad"
+    assert_search_results "t:planeswalker lastprint*<=roe", "Chandra Ablaze", "Sarkhan the Mad"
     assert_search_results "t:planeswalker lastprint<=2011",
       "Ajani Goldmane", "Ajani Vengeant", "Chandra Ablaze", "Elspeth Tirel",
       "Garruk Relentless", "Garruk, the Veil-Cursed", "Gideon Jura", "Liliana of the Veil",

--- a/test/test_printed.rb
+++ b/test/test_printed.rb
@@ -1,0 +1,53 @@
+require_relative "test_helper"
+
+class PrintedTest < Minitest::Test
+  def setup
+    @db = load_database
+  end
+
+  def test_first_printed
+    # included in "all" and "full" sets, not in "expert"
+    assert_search_results "firstprint=fvr", "Sword of Body and Mind"
+    assert_search_results "firstprint*=fvr", "Sword of Body and Mind"
+    assert_search_results "firstprint!=fvr"
+
+    # all new ktk cards -> minus dd:svc -> minus pre-re promos
+    assert_count_results "firstprint!=ktk", 231
+    assert_count_results "firstprint=ktk", 223
+    assert_count_results "firstprint*=ktk", 187
+
+    assert_search_results "firstprint=be",
+      "Circle of Protection: Black",
+      "Volcanic Island"
+  end
+
+  def test_last_printed
+    # cards not reprinted into std since rv -> minus commander cards -> minus online MED cards
+    assert_count_results "lastprint!=rv", 44
+    assert_count_results "lastprint=rv", 39
+    assert_count_results "lastprint*=rv", 13
+
+    # everything that hasn't been printed since fvr
+    assert_search_results "lastprint=fvr",
+      "Black Vise",
+      "Ivory Tower",
+      "Jester's Cap",
+      "Karn, Silver Golem",
+      "Masticore",
+      "Memory Jar",
+      "Sundering Titan",
+      "Zuran Orb"
+    # excludes cards reprinted in vintage masters
+    assert_search_results "lastprint*=fvr",
+      "Black Vise",
+      "Jester's Cap",
+      "Sundering Titan",
+      "Zuran Orb"
+    # no results in ! query since fvr isn't a core or expansion
+    assert_search_results "lastprint!=fvr"
+
+    assert_count_results "lastprint!=un", 27
+    assert_count_results "lastprint=un", 25
+    assert_count_results "lastprint=un", 5
+  end
+end

--- a/test/test_printed.rb
+++ b/test/test_printed.rb
@@ -35,6 +35,7 @@ class PrintedTest < Minitest::Test
       "Karn, Silver Golem",
       "Masticore",
       "Memory Jar",
+      "Mox Diamond",
       "Sundering Titan",
       "Zuran Orb"
     # excludes cards reprinted in vintage masters
@@ -48,6 +49,26 @@ class PrintedTest < Minitest::Test
 
     assert_count_results "lastprint!=un", 27
     assert_count_results "lastprint=un", 25
-    assert_count_results "lastprint=un", 5
+    assert_count_results "lastprint*=un", 5
+  end
+
+  def test_unique_scenarios
+    # all reserved list cards that have been reprinted in paper nonetheless
+    assert_search_results "(lastprint>ud is:reserved) OR (lastprint*>ud st:promo is:reserved)",
+      "Deranged Hermit",
+      "Intuition",
+      "Karn, Silver Golem",
+      "Lightning Dragon",
+      "Masticore",
+      "Memory Jar",
+      "Morphling",
+      "Mox Diamond",
+      "Phyrexian Dreadnought",
+      "Phyrexian Negator",
+      "Powder Keg",
+      "Survival of the Fittest",
+      "Thawing Glaciers",
+      "Wheel of Fortune",
+      "Yawgmoth's Will"
   end
 end

--- a/test/test_set_type.rb
+++ b/test/test_set_type.rb
@@ -1,0 +1,43 @@
+require_relative "test_helper"
+
+class SetTypeTest < Minitest::Test
+  def setup
+    @db = load_database
+  end
+
+  def test_basic_types
+    assert_search_results('angel of wrath st:ftv', "Akroma, Angel of Wrath")
+    assert_search_results('angel of wrath st:dd', "Akroma, Angel of Wrath")
+    assert_search_results('angel of wrath st:expansion', "Akroma, Angel of Wrath")
+    assert_search_results('armageddon st:masters', "Armageddon", "Armageddon Clock")
+    assert_search_results('armageddon st:reprint', "Armageddon")
+    assert_search_results('armageddon st:core', "Armageddon", "Armageddon Clock")
+    assert_search_results('armageddon st:starter', "Armageddon")
+  end
+
+  def test_abbreviations
+    assert_search_equal('st:cmd', 'st:commander')
+    assert_search_equal('st:ex', 'st:expansion')
+    assert_search_equal('st:ftv', 'st:"from the vault"')
+    assert_search_equal('st:arc', 'st:archenemy')
+    assert_search_equal('st:cns', 'st:conspiracy')
+    assert_search_equal('st:dd', 'st:"duel deck"')
+    assert_search_equal('st:rep', 'st:reprint')
+    assert_search_equal('st:me', 'st:masters')
+    assert_search_equal('st:starter', 'st:st')
+    assert_search_equal('st:pds', 'st:"premium deck"')
+    assert_search_equal('st:pc', 'st:planechase')
+  end
+
+  def test_cma_exception
+    assert_search_results('desertion st:fixed', "Desertion")
+    assert_search_results('desertion st:cmd', "Desertion")
+    assert_search_exclude('desertion st:deck', "Desertion")
+  end
+
+  def test_starter_sets
+    assert_search_results('alert shu st:booster', "Alert Shu Infantry")
+    assert_search_results('knight errant st:fixed', "Knight Errant")
+  end
+
+end


### PR DESCRIPTION
This does two things:
1. Adds a new condition called "set type." This allows you to narrow a search based on either the set type as defined in mtgjson ("expansion", "core," "from the vault," etc.) or one of several broader categories (multiplayer, booster sets, etc.) This is based on the logic for the set and block conditions; it primarily uses the imported set type from mtgjson, but overrides it for a couple unique cases.
2. Updates the firstprint/lastprint conditions to add a set of options for which sets "count" as a first or last printing. With this change, by default both will exclude promos and online-only sets; there are also syntax options for including all sets ("firstprint*=") and including only core and expansion sets ("firstprint!=") This does change the existing behavior, so it could be changed to make "all" the default as it is now, but I think this proposed default is much closer to what people will typically want. This change also fixes an existing bug, where because Unlimited and Arabian Nights have the same printing date listed in mtgjson these conditions currently confuse them for one another (as seen in [this search](http://mtg.wtf/card?q=firstprint%3Dun).) 

Also included are tests to verify the behavior of both pieces of functionality (updated as needed to account for changes to firstprint/lastprint default functionality) and an update to the frontend syntax page describing both.

This is a decent chunk of functionality which changes how some current searches work, so I can certainly modify it as needed.
