### PR TITLE
Add syntax to shuffle search results

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -281,3 +281,4 @@
       = search_help "sort:cmc", "sort results by converted mana cost (highest first)"
       = search_help "sort:pow", "sort results by power (highest first)"
       = search_help "sort:tou", "sort results by toughness (highest first)"
+      = search_help "sort:rand", "shuffle results"

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -45,6 +45,8 @@ class Query
         [c.power ? 0 : 1, -c.power.to_i]
       when "tou"
         [c.toughness ? 0 : 1, -c.toughness.to_i]
+      when "rand"
+        [rand]
       else # "name" or unknown key
         []
       end + [


### PR DESCRIPTION
This PR adds the `sort:rand` operator, which randomly shuffles the search results. Can be used as a sort of “random card button” feature, except that instead of pressing the button again you can just scroll down to the next card.