### PR TITLE
Add `related:` prefix

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -242,7 +242,7 @@
     %div If a card is related to another card (e.g. the card names the other card, or vice versa), you can use that in your search.
 
     %ul
-      = search_help "related:type:artifact", "cards related to artifacts"
+      = search_help "related:t:artifact", "cards related to artifacts"
       = search_help "related:f:vintage", "cards related to any Vintage-legal card"
 
     %h4 Search by alternative printing

--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -238,6 +238,13 @@
       = search_help "cmc=2 other:color:w", "cards parts with converted mana cost 2, for which other side is white"
       = search_help "cmc=2 part:color:w", "cards parts with converted mana cost 2, for which either side is white"
 
+    %h4 Search by related card
+    %div If a card is related to another card (e.g. the card names the other card, or vice versa), you can use that in your search.
+
+    %ul
+      = search_help "related:type:artifact", "cards related to artifacts"
+      = search_help "related:f:vintage", "cards related to any Vintage-legal card"
+
     %h4 Search by alternative printing
     %div Every card printing is treated as separate object, so you can't search for cards which were printing in both Magic 2010 and Magic 2011 with e:m10 e:m11. There's special syntax for that.
     %ul

--- a/lib/condition/condition_related.rb
+++ b/lib/condition/condition_related.rb
@@ -1,0 +1,18 @@
+class ConditionRelated < Condition
+  def initialize(cond)
+    @cond = cond
+  end
+
+  def search(db)
+    @cond.search(db).map{|c| c.related ? Set[*c.related] : Set[]}.inject(Set[], &:|)
+  end
+
+  def metadata!(key, value)
+    super
+    @cond.metadata!(key, value)
+  end
+
+  def to_s
+    "related:#{@cond}"
+  end
+end

--- a/lib/query_parser.rb
+++ b/lib/query_parser.rb
@@ -125,7 +125,7 @@ private
       subquery
     when :close
       return
-    when :not, :other, :part, :alt
+    when :not, :other, :part, :related, :alt
       tok, = @tokens.shift
       cond = parse_cond
       if cond

--- a/lib/query_tokenizer.rb
+++ b/lib/query_tokenizer.rb
@@ -101,6 +101,8 @@ class QueryTokenizer
         tokens << [:other]
       elsif s.scan(/part:/)
         tokens << [:part]
+      elsif s.scan(/related:/)
+        tokens << [:related]
       elsif s.scan(/alt:/)
         tokens << [:alt]
       elsif s.scan(/not\b/)


### PR DESCRIPTION
This allows searching by related cards, similar to how `other:` allows searching by other parts of the card.

**Not tested.**