### PR TITLE
Add frame:modern and frame:m15 queries

### DIFF
--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -27,15 +27,18 @@ class CardPrinting
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"
     @frame = begin
       eight_edition_release_date = Date.new(2003,7,28)
+      m15_release_date = Date.new(2014,7,18)
       if @release_date < eight_edition_release_date
         "old"
       elsif @set.code == "tsts"
         "old"
       elsif @timeshifted and @set.code == "fut"
         "future"
-      else
+      elsif @release_date < m15_release_date
         # Were there any 8e+ old frame printings?
-        "new"
+        "modern"
+      else
+        "m15"
       end
     end
 

--- a/search-engine/lib/condition/condition_frame.rb
+++ b/search-engine/lib/condition/condition_frame.rb
@@ -4,6 +4,7 @@ class ConditionFrame < ConditionSimple
   end
 
   def match?(card)
+    return card.frame == "modern" || card.frame == "m15" if @frame == "new"
     card.frame == @frame
   end
 

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -121,7 +121,7 @@ class QueryTokenizer
         tokens << [:test, ConditionLayout.new(s[2])]
       elsif s.scan(/layout[:=](normal|leveler|vanguard|dfc|double-faced|token|split|flip|plane|scheme|phenomenon|meld|aftermath)/i)
         tokens << [:test, ConditionLayout.new(s[1])]
-      elsif s.scan(/(is|frame|not)[:=](old|new|future)\b/i)
+      elsif s.scan(/(is|frame|not)[:=](old|new|future|modern|m15)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         tokens << [:test, ConditionFrame.new(s[2].downcase)]
       elsif s.scan(/(is|not)[:=](black-bordered|silver-bordered|white-bordered)\b/i)


### PR DESCRIPTION
The card frame attribute now differentiates between the pre-M15 “modern” frame and the “m15” frame. For backwards compatibility, `frame:new` is true for both of these.