### PR TITLE
Add is:errata condition

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -30,6 +30,7 @@
       = search_help %Q[o:"destroy target creature"], %Q[search cards with "destroy target creature" in Oracle text]
       = search_help "o:flying", %Q[search cards with "flying" in Oracle text - without cards with rearch simply in reminder text like ones with reach ability]
       = search_help %Q[o:"when ~ enters the battlefield"], %Q[You can use ~ as placeholder for name of the card]
+      = search_help "is:errata", %Q[search card printings whose printed text does not match current Oracle text (reminder text is ignored)]
 
     %h4 Search by edition
     %ul

--- a/indexer/lib/indexer.rb
+++ b/indexer/lib/indexer.rb
@@ -110,6 +110,7 @@ class Indexer
       "timeshifted",
       "number",
       "multiverseid",
+      "originalText",
     ).merge(
       "artist" => format_artist(card_data["artist"]),
       "rarity" => format_rarity(card_data["rarity"]),

--- a/indexer/lib/indexer.rb
+++ b/indexer/lib/indexer.rb
@@ -111,6 +111,7 @@ class Indexer
       "number",
       "multiverseid",
       "originalText",
+      "originalType",
     ).merge(
       "artist" => format_artist(card_data["artist"]),
       "rarity" => format_rarity(card_data["rarity"]),

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -1,6 +1,6 @@
 class CardPrinting
   attr_reader :card, :set, :date, :release_date
-  attr_reader :watermark, :rarity, :artist_name, :multiverseid, :number, :frame, :flavor, :border, :timeshifted
+  attr_reader :watermark, :rarity, :artist_name, :multiverseid, :number, :frame, :flavor, :border, :timeshifted, :printed_text
   attr_reader :rarity_code
 
   # Performance cache of derived information
@@ -23,6 +23,10 @@ class CardPrinting
     @flavor = data["flavor"] || ""
     @border = data["border"] || @set.border
     @timeshifted = data["timeshifted"] || false
+    @printed_text = (data["originalText"] || "").gsub("Æ", "Ae").tr("Äàáâäèéêíõöúûü’\u2212", "Aaaaaeeeioouuu'-")
+    unless card.funny
+      @printed_text = @printed_text.gsub(/\([^\(\)]*\)/, "")
+    end
     rarity = data["rarity"]
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"
     @frame = begin

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -27,7 +27,7 @@ class CardPrinting
     unless card.funny
       @printed_text = @printed_text.gsub(/\([^\(\)]*\)/, "")
     end
-    @printed_typeline = data["originalType"] || ""
+    @printed_typeline = (data["originalType"] || "").tr("\u2014", "-")
     rarity = data["rarity"]
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"
     @frame = begin

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -1,6 +1,6 @@
 class CardPrinting
   attr_reader :card, :set, :date, :release_date
-  attr_reader :watermark, :rarity, :artist_name, :multiverseid, :number, :frame, :flavor, :border, :timeshifted, :printed_text
+  attr_reader :watermark, :rarity, :artist_name, :multiverseid, :number, :frame, :flavor, :border, :timeshifted, :printed_text, :printed_typeline
   attr_reader :rarity_code
 
   # Performance cache of derived information
@@ -27,6 +27,7 @@ class CardPrinting
     unless card.funny
       @printed_text = @printed_text.gsub(/\([^\(\)]*\)/, "")
     end
+    @printed_typeline = data["originalType"] || ""
     rarity = data["rarity"]
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"
     @frame = begin

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -27,6 +27,7 @@ class CardPrinting
     unless card.funny
       @printed_text = @printed_text.gsub(/\([^\(\)]*\)/, "")
     end
+    @printed_text = @printed_text.sub(/\s*\z/, "").sub(/\A\s*/, "")
     @printed_typeline = (data["originalType"] || "").tr("\u2014", "-")
     rarity = data["rarity"]
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"

--- a/search-engine/lib/condition/condition_is_errata.rb
+++ b/search-engine/lib/condition/condition_is_errata.rb
@@ -1,6 +1,8 @@
 class ConditionIsErrata < ConditionSimple
   def match?(printing)
-    printing.printed_text != printing.card.text
+    return true if printing.printed_typeline != printing.card.typeline
+    return true if printing.printed_text != printing.card.text
+    false
   end
 
   def to_s

--- a/search-engine/lib/condition/condition_is_errata.rb
+++ b/search-engine/lib/condition/condition_is_errata.rb
@@ -1,0 +1,9 @@
+class ConditionIsErrata < ConditionSimple
+  def match?(printing)
+    printing.printed_text != printing.card.text
+  end
+
+  def to_s
+    "is:errata"
+  end
+end

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -139,7 +139,7 @@ class QueryTokenizer
         op = "=" if op == ":"
         mana = s[2]
         tokens << [:test, ConditionMana.new(op, mana)]
-      elsif s.scan(/(is|not)[:=](vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique)\b/i)
+      elsif s.scan(/(is|not)[:=](vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|errata)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         cond = s[2].capitalize
         cond = "Timeshifted" if cond == "Colorshifted"


### PR DESCRIPTION
This condition compares Oracle text with printed text, filtering for cards where the two differ.

**TODO:**

- [ ] Test if it works.
- [ ] MTG JSON docs say:
  > This field is not available for promo cards.

  So promos are currently false positives. Probably better than having them as false negatives?
- [ ] Errata to the card name (Ae cards)
- [x] Errata to the type line (`"originalType"` field)
- [ ] Figure out why all planeswalkers are false positives