### PR TITLE
Update is:split to match aftermath cards

### DIFF
--- a/search-engine/lib/condition/condition_layout.rb
+++ b/search-engine/lib/condition/condition_layout.rb
@@ -1,14 +1,17 @@
 class ConditionLayout < ConditionSimple
-  def initialize(layout)
+  def initialize(is, layout)
+    @is = is
     @layout = layout.downcase
     @layout = "double-faced" if @layout == "dfc"
   end
 
   def match?(card)
+    return true if @is && @layout == "split" && card.layout == "aftermath"
     card.layout == @layout
   end
 
   def to_s
+    return "is:#{@layout}" if @is
     "layout:#{@layout}"
   end
 end

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -151,9 +151,9 @@ class QueryTokenizer
         tokens << [:test, klass.new]
       elsif s.scan(/(is|not)[:=](split|flip|dfc|meld|aftermath)\b/i)
         tokens << [:not] if s[1].downcase == "not"
-        tokens << [:test, ConditionLayout.new(s[2])]
+        tokens << [:test, ConditionLayout.new(true, s[2])]
       elsif s.scan(/layout[:=](normal|leveler|vanguard|dfc|double-faced|token|split|flip|plane|scheme|phenomenon|meld|aftermath)/i)
-        tokens << [:test, ConditionLayout.new(s[1])]
+        tokens << [:test, ConditionLayout.new(false, s[1])]
       elsif s.scan(/(is|frame|not)[:=](old|new|future|modern|m15)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         tokens << [:test, ConditionFrame.new(s[2].downcase)]


### PR DESCRIPTION
Aftermath cards are split cards, so `is:split` should match them. This pull request fixes this while leaving `layout:split` unchanged to match MTG JSON's documentation.