### PR TITLE
Add --exact-names option to find_cards

### DIFF
--- a/search-engine/Gemfile
+++ b/search-engine/Gemfile
@@ -7,3 +7,4 @@ gem "pry"
 gem "rspec", require: false, group: :test
 gem "simplecov", require: false, group: :test
 gem "pathname-glob"
+gem "trollop"

--- a/search-engine/bin/find_cards
+++ b/search-engine/bin/find_cards
@@ -1,18 +1,11 @@
 #!/usr/bin/env ruby
 
+require 'trollop'
 require_relative "../lib/cli_frontend"
 
-# If it gets any more complex than this, just use trollop
-if ARGV[0] == "-v"
-  ARGV.shift
-  verbose = true
-else
-  verbose = false
+opts = Trollop::options do
+  opt :exact_names, "don't normalize card names like Séance"
+  opt :verbose, "print more info about each card", :short => 'v'
 end
 
-if ARGV.size == 0
-  STDERR.puts "Usage: #{$0} [-v] <query>"
-  exit 1
-end
-
-CLIFrontend.new.run!(verbose, ARGV.join(" "))
+CLIFrontend.new.run!(opts[:verbose], opts[:exact_names], ARGV.join(" "))

--- a/search-engine/lib/card.rb
+++ b/search-engine/lib/card.rb
@@ -11,7 +11,7 @@ class Card
   attr_reader :data, :printings
   attr_writer :printings # For db subset
 
-  attr_reader :name, :names, :layout, :colors, :mana_cost, :reserved, :types
+  attr_reader :name, :exact_name, :names, :layout, :colors, :mana_cost, :reserved, :types
   attr_reader :partial_color_identity, :cmc, :text, :power, :toughness, :loyalty, :extra
   attr_reader :hand, :life, :rulings, :secondary, :foreign_names, :foreign_names_normalized, :stemmed_name
   attr_reader :mana_hash, :typeline, :funny, :color_indicator, :related
@@ -20,6 +20,7 @@ class Card
   def initialize(data)
     @printings = []
     @name = normalize_name(data["name"])
+    @exact_name = data["name"]
     @stemmed_name = @name.downcase.gsub(/s\b/, "").tr("-", " ")
     @names = data["names"]&.map{|n| normalize_name(n)}
     @layout = data["layout"]

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -68,7 +68,7 @@ class CardPrinting
   %W[block_code block_name online_only?].each do |m|
     eval("def #{m}; @set.#{m}; end")
   end
-  %W[name names layout colors mana_cost reserved types cmc text power
+  %W[name exact_name names layout colors mana_cost reserved types cmc text power
     toughness loyalty extra color_identity has_multiple_parts? typeline
     first_release_date last_release_date printings life hand rulings
     secondary foreign_names foreign_names_normalized mana_hash funny color_indicator

--- a/search-engine/lib/cli_frontend.rb
+++ b/search-engine/lib/cli_frontend.rb
@@ -5,7 +5,7 @@ class CLIFrontend
     @db = CardDatabase.load
   end
 
-  def run!(verbose, query_string)
+  def run!(verbose, exact_names, query_string)
     query = Query.new(query_string)
     results = @db.search(query)
 
@@ -15,13 +15,15 @@ class CLIFrontend
     end
 
     if verbose
-      print_results!(results)
+      print_results!(results, exact_names)
+    elsif exact_names
+      puts results.printings.map(&:exact_name).uniq
     else
       puts results.card_names
     end
   end
 
-  def print_results!(results)
+  def print_results!(results, exact_names)
     cards = {}
     results.printings.each do |card_printing|
       (cards[card_printing.name] ||= []) << card_printing
@@ -39,7 +41,7 @@ class CLIFrontend
           end
         end
       end
-      puts [card.name, card.mana_cost].compact.join(" ")
+      puts [exact_names ? card.exact_name : card.name, card.mana_cost].compact.join(" ")
       puts "[#{codes.join(" ")}]"
       puts card.typeline
       puts "#{card.reminder_text}" if card.reminder_text


### PR DESCRIPTION
This adds an `--exact-names` option to the `find_cards` script to disable card name normalization for better interoperability in scripting. This is required to fix fenhl/json-to-mse#9. It has been tested both with and without `-v` (which as a bonus is also available as `--verbose` now).