### PR TITLE
Move “Gallery of all printings” link to the printings section

### DIFF
--- a/frontend/app/views/card/_card_row_full.html.haml
+++ b/frontend/app/views/card/_card_row_full.html.haml
@@ -38,8 +38,6 @@
 
     %h5 Links
     %ul
-      %li.infolabel
-        = link_to "Gallery of all printings", card_gallery_path(card)
       - if card.gatherer_link.present?
         %li.infolabel
           %a{href: card.gatherer_link}

--- a/frontend/app/views/card/_printings_full.html.haml
+++ b/frontend/app/views/card/_printings_full.html.haml
@@ -42,3 +42,5 @@
               = link_to_card(printing) do
                 = printing.number
         %span.rarity= "(#{rarity})"
+%p.infolabel
+  = link_to "Gallery of all printings", card_gallery_path(card)


### PR DESCRIPTION
I think it makes more sense to have it there.