### PR TITLE
Add is:keywordsoup condition

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -248,6 +248,7 @@
       = search_help "is:battleland", "all 5 battlelands"
       = search_help "is:battleland t:island", "both blue battlelands"
       = search_help "is:augment", "all 13 augment cards from Unstable"
+      = search_help "is:keywordsoup", "cards that list a large number of keywords"
 
     %h4 Search by reserved list status
     %ul

--- a/search-engine/lib/condition/condition_is_keywordsoup.rb
+++ b/search-engine/lib/condition/condition_is_keywordsoup.rb
@@ -1,0 +1,25 @@
+class ConditionIsKeywordsoup < Condition
+  def search(db)
+    # A card goes on this list if it lists a large number of keywords in a single sentence, and the keywords aren't ordered canonically.
+    # A good indicator of this is that haste is listed before trample.
+    names = [
+      "animus of predation",
+      "cairn wanderer",
+      "concerted effort",
+      "death-mask duplicant",
+      "greater morphling",
+      "majestic myriarch",
+      "odric, lunarch marshal",
+      "soulflayer",
+    ]
+
+    names
+      .map{|n| db.cards[n]}
+      .flat_map{|card| card ? card.printings : []}
+      .to_set
+  end
+
+  def to_s
+    "is:keywordsoup"
+  end
+end

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -149,7 +149,7 @@ class QueryTokenizer
         op = "=" if op == ":"
         mana = s[2]
         tokens << [:test, ConditionMana.new(op, mana)]
-      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth)\b/i)
+      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth|keywordsoup)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         cond = s[2].capitalize
         cond = "Timeshifted" if cond == "Colorshifted"

--- a/search-engine/spec/nicknames_spec.rb
+++ b/search-engine/spec/nicknames_spec.rb
@@ -244,7 +244,7 @@ describe "Card nicknames" do
       "Soulflayer"
     assert_search_results "is:keywordsoup",
       *cards_matching{|c|
-        return false if c.name == "Urza, Academy Headmaster"
+        c.name != "Urza, Academy Headmaster" and
         ["deathtouch", "defender", "double strike", "enchant", "equip", "first strike", "flash", "flying", "haste", "hexproof", "indestructible", "intimidate", "landwalk", "lifelink", "protection", "reach", "shroud", "trample", "vigilance"].count {
           |keyword| c.text.downcase.include? keyword
         } > 6

--- a/search-engine/spec/nicknames_spec.rb
+++ b/search-engine/spec/nicknames_spec.rb
@@ -244,6 +244,7 @@ describe "Card nicknames" do
       "Soulflayer"
     assert_search_results "is:keywordsoup",
       *cards_matching{|c|
+        return false if c.name == "Urza, Academy Headmaster"
         ["deathtouch", "defender", "double strike", "enchant", "equip", "first strike", "flash", "flying", "haste", "hexproof", "indestructible", "intimidate", "landwalk", "lifelink", "protection", "reach", "shroud", "trample", "vigilance"].count {
           |keyword| c.text.downcase.include? keyword
         } > 6

--- a/search-engine/spec/nicknames_spec.rb
+++ b/search-engine/spec/nicknames_spec.rb
@@ -229,4 +229,23 @@ describe "Card nicknames" do
     assert_search_equal "is:battleland",
       'o:"~ enters the battlefield tapped unless you control two or more basic lands."'
   end
+
+  # A card that lists a lot of keywords in a single list, in an order that's different from the canonical keyword order
+  # This definition is more strict than some people use the term “keyword soup”, but it is useful for figuring out relative order of keywords by filtering these cards out
+  it "is:keywordsoup" do
+    assert_search_results "is:keywordsoup",
+      "Animus of Predation",
+      "Cairn Wanderer",
+      "Concerted Effort",
+      "Death-Mask Duplicant",
+      "Greater Morphling",
+      "Majestic Myriarch",
+      "Odric, Lunarch Marshal",
+      "Soulflayer"
+    assert_search_results "is:keywordsoup",
+      *cards_matching{|c|
+        ["deathtouch", "defender", "double strike", "enchant", "equip", "first strike", "flash", "flying", "haste", "hexproof", "indestructible", "intimidate", "landwalk", "lifelink", "protection", "reach", "shroud", "trample", "vigilance"].count {
+          |keyword| c.text.downcase.include? keyword
+        } > 6
+      }
 end

--- a/search-engine/spec/nicknames_spec.rb
+++ b/search-engine/spec/nicknames_spec.rb
@@ -248,4 +248,5 @@ describe "Card nicknames" do
           |keyword| c.text.downcase.include? keyword
         } > 6
       }
+  end
 end


### PR DESCRIPTION
This condition finds cards that list a lot of keywords in a single list, and do so in an order that's different from the canonical keyword order. A good indicator of a keyword soup card is that it lists haste before trample (e.g. Akroma's Memorial is not a keyword soup card). This definition is more strict than some people use the term “keyword soup”, but it is useful for figuring out relative order of keywords by filtering these cards out. The condition is currently hardcoded as a list of cards like `is:scryland` and friends.