### PR TITLE
Add is:brawler condition

### DIFF
--- a/frontend/app/views/help/syntax.html.haml
+++ b/frontend/app/views/help/syntax.html.haml
@@ -22,6 +22,7 @@
       = search_help "t:plane", "search Plane cards"
       = search_help "t:vryn", "search Plane cards with type Vryn"
       = search_help "is:commander", "search cards you can play as commanders (legendary creatures or planeswalkers with ability saying so)"
+      = search_help "is:brawler", "search cards you can play as Brawl commanders (legendary creatures or planeswalkers)"
       = search_help "is:historic", "search for historic cards (legendary, artifact, and/or Saga)"
 
     %h4 Search by Oracle text

--- a/search-engine/lib/condition/condition_is_brawler.rb
+++ b/search-engine/lib/condition/condition_is_brawler.rb
@@ -1,0 +1,11 @@
+class ConditionIsBrawler < ConditionSimple
+  def match?(card)
+    return false if card.secondary?
+    return true if card.types.include?("legendary") and (card.types.include?("creature") or card.types.include?("planeswalker"))
+    false
+  end
+
+  def to_s
+    "is:brawler"
+  end
+end

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -149,7 +149,7 @@ class QueryTokenizer
         op = "=" if op == ":"
         mana = s[2]
         tokens << [:test, ConditionMana.new(op, mana)]
-      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth)\b/i)
+      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth|brawler)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         cond = s[2].capitalize
         cond = "Timeshifted" if cond == "Colorshifted"


### PR DESCRIPTION
Like `is:commander` but includes planeswalkers. Does not inherently restrict by format (to allow searches for formats like Eternal Brawl or Custom Brawl).