### PR TITLE
Show color indicator reminder text before intrinsic mana ability reminder text

### DIFF
--- a/frontend/app/views/card/_card.html.haml
+++ b/frontend/app/views/card/_card.html.haml
@@ -7,10 +7,10 @@
 
 - if card.color_indicator.present? or card.text.present? or card.reminder_text.present?
   .oracle
-    - if card.reminder_text
-      .reminder_text= format_oracle_text(card.reminder_text)
     - if card.color_indicator.present?
       .color_indicator= "(Color indicator: #{card.name} is #{card.color_indicator})"
+    - if card.reminder_text
+      .reminder_text= format_oracle_text(card.reminder_text)
     - if card.text.present?
       = format_oracle_text(card.text)
 


### PR DESCRIPTION
Since color indicator reminder text is being displayed before rules text, it should also be displayed before reminder text for intrinsic mana abilities from basic land types. As far as I can tell, this only affects Dryad Arbor, but it still bothered me :P