### PR TITLE
Advanced color indicator queries

### DIFF
--- a/search-engine/lib/card.rb
+++ b/search-engine/lib/card.rb
@@ -14,7 +14,7 @@ class Card
   attr_reader :name, :names, :layout, :colors, :mana_cost, :reserved, :types
   attr_reader :partial_color_identity, :cmc, :text, :text_normalized, :power, :toughness, :loyalty, :extra
   attr_reader :hand, :life, :rulings, :foreign_names, :foreign_names_normalized, :stemmed_name
-  attr_reader :mana_hash, :typeline, :funny, :color_indicator, :related
+  attr_reader :mana_hash, :typeline, :funny, :color_indicator, :color_indicator_set, :related
   attr_reader :reminder_text, :augment, :display_power, :display_toughness, :display_mana_cost
 
   def initialize(data)
@@ -257,8 +257,10 @@ class Card
 
     if colors_inferred_from_mana_cost.sort == actual_colors.sort
       @color_indicator = nil
+      @color_indicator_set = Set[]
     else
       @color_indicator = color_indicator_name(actual_colors)
+      @color_indicator_set = actual_colors.to_set
     end
   end
 

--- a/search-engine/lib/condition/condition_color_count_expr.rb
+++ b/search-engine/lib/condition/condition_color_count_expr.rb
@@ -8,6 +8,8 @@ class ConditionColorCountExpr < ConditionSimple
   def match?(card)
     if @a == "c"
       a = card.colors.size
+    elsif @a == "in"
+      a = card.color_indicator_set
     else
       a = card.color_identity.size
     end

--- a/search-engine/lib/condition/condition_color_expr.rb
+++ b/search-engine/lib/condition/condition_color_expr.rb
@@ -8,6 +8,8 @@ class ConditionColorExpr < ConditionSimple
   def match?(card)
     if @a == "c"
       a = card.colors.chars.to_set
+    elsif @a == "in"
+      a = card.color_indicator_set
     else
       a = card.color_identity.chars.to_set
     end

--- a/search-engine/lib/condition/condition_color_indicator_any.rb
+++ b/search-engine/lib/condition/condition_color_indicator_any.rb
@@ -1,0 +1,10 @@
+class ConditionColorIndicatorAny < ConditionSimple
+  # Matches cards with a color indicator
+  def match?(card)
+    card.color_indicator
+  end
+
+  def to_s
+    "in:*"
+  end
+end

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -113,6 +113,8 @@ class QueryTokenizer
         tokens << [:test, ConditionColors.new(parse_color(s[1] || s[2]))]
       elsif s.scan(/(?:ci|id)\s*[:!]\s*(?:"(.*?)"|(\w+))/i)
         tokens << [:test, ConditionColorIdentity.new(parse_color(s[1] || s[2]))]
+      elsif s.scan(/(?:in)\s*:\s*\*/i)
+        tokens << [:test, ConditionColorIndicatorAny.new]
       elsif s.scan(/(?:in)\s*[:=]\s*(?:"(.*?)"|(\w+))/i)
         tokens << [:test, ConditionColorIndicator.new(parse_color(s[1] || s[2]))]
       elsif s.scan(/c!(?:"(.*?)"|(\w+))/i)
@@ -140,9 +142,9 @@ class QueryTokenizer
         b = s[3].downcase
         b = aliases[b] || b
         tokens << [:test, ConditionExpr.new(a, op, b)]
-      elsif s.scan(/(c|ci)\s*(>=|>|<=|<|=)\s*(?:"(\d+)"|(\d+))/i)
+      elsif s.scan(/(c|ci|in)\s*(>=|>|<=|<|=)\s*(?:"(\d+)"|(\d+))/i)
         tokens << [:test, ConditionColorCountExpr.new(s[1].downcase, s[2], s[3] || s[4])]
-      elsif s.scan(/(c|ci)\s*(>=|>|<=|<|=)\s*(?:"(.*?)"|(\w+))/i)
+      elsif s.scan(/(c|ci|in)\s*(>=|>|<=|<|=)\s*(?:"(.*?)"|(\w+))/i)
         tokens << [:test, ConditionColorExpr.new(s[1].downcase, s[2], parse_color(s[3] || s[4]))]
       elsif s.scan(/(?:mana|m)\s*(>=|>|<=|<|=|:|!=)\s*((?:[\dwubrgxyzchmno]|\{.*?\})*)/i)
         op = s[1]


### PR DESCRIPTION
This adds:

* Support for color indicators in color expression and color count conditions, e.g. `in>=U` or `in=2`
* The condition `in:*`, which matches cards with color indicators

**TODO:** document on syntax help page, add tests