### PR TITLE
Fix crash in color indicator count condition

### DIFF
--- a/search-engine/lib/condition/condition_color_count_expr.rb
+++ b/search-engine/lib/condition/condition_color_count_expr.rb
@@ -9,8 +9,7 @@ class ConditionColorCountExpr < ConditionSimple
     if @a == "c"
       a = card.colors.size
     elsif @a == "in"
-      a = card.color_indicator_set
-      return false unless a
+      a = (card.color_indicator_set || Set[]).size
     else
       a = card.color_identity.size
     end

--- a/search-engine/lib/condition/condition_color_count_expr.rb
+++ b/search-engine/lib/condition/condition_color_count_expr.rb
@@ -10,6 +10,7 @@ class ConditionColorCountExpr < ConditionSimple
       a = card.colors.size
     elsif @a == "in"
       a = card.color_indicator_set
+      return false unless a
     else
       a = card.color_identity.size
     end


### PR DESCRIPTION
For cards without color indicators, it would try to compare against nil.

I'm not sure if this is how it should work, since I'd consider a card without a color indicator to be `in<1`, but this way it's consistent with `in<W` for now.