### PR TITLE
Fix errata sets being counted as not:funny

### DIFF
--- a/indexer/lib/patches/patch_funny.rb
+++ b/indexer/lib/patches/patch_funny.rb
@@ -1,8 +1,9 @@
 class PatchFunny < Patch
   def call
+    errata_sets = @sets.select{|set| set["type"] == "errata"}.map{|set| set["code"].downcase}
     funny_sets = %W[uh ug uqc hho arena rep ust]
     each_card do |name, printings|
-      funny = printings.all?{|card| funny_sets.include?(card["set_code"]) }
+      funny = printings.all?{|card| funny_sets.include?(card["set_code"]) || errata_sets.include?(card["set_code"]) }
 
       if funny
         printings.each do |printing|


### PR DESCRIPTION
This bug causes [Richard Garfield, Ph.D.](https://loreseeker.fenhl.net/card/uh/44/Richard-Garfield-Ph-D) to be counted as `not:funny` in my fork since I've applied errata to the card.