### PR TITLE
Add support for GRN and RNA to booster generator

### DIFF
--- a/search-engine/lib/card_sheet_factory.rb
+++ b/search-engine/lib/card_sheet_factory.rb
@@ -398,4 +398,12 @@ class CardSheetFactory
       [from_query('e:cns -is:draft r:mythic', 10, foil: foil), 1],
     )
   end
+
+  def grn_common(set_code)
+    from_query("e:#{set_code} r:common not:guildgate")
+  end
+
+  def grn_land(set_code)
+    from_query("e:#{set_code} is:guildgate", 10)
+  end
 end

--- a/search-engine/lib/condition/condition_is_guildgate.rb
+++ b/search-engine/lib/condition/condition_is_guildgate.rb
@@ -1,0 +1,25 @@
+class ConditionIsGuildgate < Condition
+  def search(db)
+    names = [
+      "azorius guildgate",
+      "dimir guildgate",
+      "rakdos guildgate",
+      "gruul guildgate",
+      "selesnya guildgate",
+      "orzhov guildgate",
+      "izzet guildgate",
+      "golgari guildgate",
+      "boros guildgate",
+      "simic guildgate",
+    ]
+
+    names
+      .map{|n| db.cards[n]}
+      .flat_map{|card| card ? card.printings : []}
+      .to_set
+  end
+
+  def to_s
+    "is:guildgate"
+  end
+end

--- a/search-engine/lib/pack_factory.rb
+++ b/search-engine/lib/pack_factory.rb
@@ -181,6 +181,9 @@ class PackFactory
         build_pack_with_random_foil(set_code, :foil, :common, {basic: 1, common: 10, dom_nonlegendary_uncommon: 2, dom_legendary_uncommon: 1, dom_legendary_rare_mythic: 1}) => 36*23,
         build_pack_with_random_foil(set_code, :foil, :common, {basic: 1, common: 10, dom_nonlegendary_uncommon: 2, dom_legendary_uncommon: 1, dom_nonlegendary_rare_mythic: 1}) => (121-36)*144,
       )
+    when "grn", "rna"
+      # assuming RNA will use the same rules as GRN
+      build_pack_with_random_foil(set_code, :foil, :grn_common, {grn_common: 10, uncommon: 3, rare_or_mythic: 1, grn_land: 1})
     # These are just approximations, they actually used nonstandard sheets
     when "al", "be", "un", "rv", "ia"
       build_pack(set_code, {common_or_basic: 11, uncommon: 3, rare: 1})

--- a/search-engine/lib/query_tokenizer.rb
+++ b/search-engine/lib/query_tokenizer.rb
@@ -151,7 +151,7 @@ class QueryTokenizer
         op = "=" if op == ":"
         mana = s[2]
         tokens << [:test, ConditionMana.new(op, mana)]
-      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth|brawler|keywordsoup)\b/i)
+      elsif s.scan(/(is|not)\s*[:=]\s*(vanilla|spell|permanent|funny|timeshifted|colorshifted|reserved|multipart|promo|primary|secondary|front|back|commander|digital|reprint|fetchland|shockland|dual|fastland|bounceland|gainland|filterland|checkland|manland|scryland|battleland|guildgate|augment|unique|booster|draft|historic|holofoil|foilonly|nonfoilonly|foil|nonfoil|foilboth|brawler|keywordsoup)\b/i)
         tokens << [:not] if s[1].downcase == "not"
         cond = s[2].capitalize
         cond = "Timeshifted" if cond == "Colorshifted"

--- a/search-engine/spec/nicknames_spec.rb
+++ b/search-engine/spec/nicknames_spec.rb
@@ -230,6 +230,23 @@ describe "Card nicknames" do
       'o:"~ enters the battlefield tapped unless you control two or more basic lands."'
   end
 
+  # There are other Gates (only one as of GRN), Guildgate specifically refers to the original double-cycle
+  it "is:guildgate" do
+    assert_search_results "is:guildgate",
+      "Azorius Guildgate",
+      "Dimir Guildgate",
+      "Rakdos Guildgate",
+      "Gruul Guildgate",
+      "Selesnya Guildgate",
+      "Orzhov Guildgate",
+      "Izzet Guildgate",
+      "Golgari Guildgate",
+      "Boros Guildgate",
+      "Simic Guildgate"
+    assert_search_equal "is:guildgate",
+      't:Gate ci=2'
+  end
+
   # A card that lists a lot of keywords in a single list, in an order that's different from the canonical keyword order
   # This definition is more strict than some people use the term “keyword soup”, but it is useful for figuring out relative order of keywords by filtering these cards out
   it "is:keywordsoup" do


### PR DESCRIPTION
Based on assumptions in https://github.com/taw/magic-search-engine/issues/106#issuecomment-421253300, as well as the assumption that RNA boosters will have the same layout as GRN ones. To make the logic work, a query to find the Guildgates specifically (as opposed to any land with the Gate subtype) was needed; this has been added as `is:guildgate`.