### PR TITLE
Fix error in is:foil condition

### DIFF
--- a/search-engine/lib/condition/condition_is_foil.rb
+++ b/search-engine/lib/condition/condition_is_foil.rb
@@ -1,4 +1,4 @@
-class ConditionIsfoil < ConditionSimple
+class ConditionIsFoil < ConditionSimple
   def match?(card)
     ["foilonly", "both"].include?(card.foiling)
   end


### PR DESCRIPTION
Incorrect capitalization of the class name caused an error when `is:foil` was used.