### PR TITLE
Add some perspective to DFC hover animation

### DIFF
--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -212,6 +212,7 @@ form.search {
 .card_picture_container {
   position: relative;
   perspective: 1000px;
+  z-index: 0;
 
   .foil_layer {
     position: absolute;
@@ -230,7 +231,6 @@ form.search {
     left: 0;
     top: 0;
     position: relative;
-    z-index: 0;
 
     img {
       width: 100%;
@@ -240,9 +240,6 @@ form.search {
     backface-visibility: hidden;
     -webkit-backface-visibility: hidden;
 
-    &:hover {
-      z-index: 1;
-    }
     &.flip:hover {
       transform: rotateZ(180deg);
     }
@@ -293,6 +290,9 @@ form.search {
       }
     }
   }
+  &:hover {
+    z-index: 1;
+  }
   & .dfc,
   & .dfc_back {
   }
@@ -328,15 +328,12 @@ form.search {
   }
   &:hover .melded {
     transform: rotateY(180deg);
-    z-index: 1;
   }
   &:hover .meld0 {
     transform: translateY(-30%) rotateY(360deg);
-    z-index: 1;
   }
   &:hover .meld1 {
     transform: translateY(72%) rotateY(360deg);
-    z-index: 1;
   }
 }
 .picture_missing {

--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -211,6 +211,7 @@ form.search {
 }
 .card_picture_container {
   position: relative;
+  perspective: 1000px;
 
   .foil_layer {
     position: absolute;
@@ -292,16 +293,27 @@ form.search {
       }
     }
   }
-  & .dfc {
+  & .dfc,
+  & .dfc_back {
   }
   &:hover .dfc {
+    transform: rotateY(-180deg);
+  }
+  &:hover .dfc_back {
     transform: rotateY(180deg);
   }
   & .dfc_reverse {
     position: absolute;
+    transform: rotateY(-180deg);
+  }
+  & .dfc_back_reverse {
+    position: absolute;
     transform: rotateY(180deg);
   }
   &:hover .dfc_reverse {
+    transform: rotateY(-360deg);
+  }
+  &:hover .dfc_back_reverse {
     transform: rotateY(360deg);
   }
   & .melded {

--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -320,11 +320,11 @@ form.search {
   }
   & .meld0 {
     position: absolute;
-    transform: rotateY(180deg);
+    transform: translateY(0) rotateY(180deg); // the translateY(0) is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1499862
   }
   & .meld1 {
     position: absolute;
-    transform: rotateY(180deg);
+    transform: translateY(0) rotateY(180deg); // the translateY(0) is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1499862
   }
   &:hover .melded {
     transform: rotateY(180deg);

--- a/frontend/app/views/card/_picture.html.haml
+++ b/frontend/app/views/card/_picture.html.haml
@@ -15,8 +15,12 @@
     - elsif card.layout == "aftermath"
       = render partial: "card/card_picture", locals: { card: card, foil: foil, card_layout: "aftermath" }
     - elsif card.layout == "double-faced" and card.others.size == 1
-      = render partial: "card/card_picture", locals: { card: card, foil: foil, card_layout: "dfc" }
-      = render partial: "card/card_picture", locals: { card: card.others[0], foil: foil, card_layout: "dfc_reverse" }
+      - if card.secondary?
+        = render partial: "card/card_picture", locals: { card: card, foil: foil, card_layout: "dfc_back" }
+        = render partial: "card/card_picture", locals: { card: card.others[0], foil: foil, card_layout: "dfc_back_reverse" }
+      - else
+        = render partial: "card/card_picture", locals: { card: card, foil: foil, card_layout: "dfc" }
+        = render partial: "card/card_picture", locals: { card: card.others[0], foil: foil, card_layout: "dfc_reverse" }
     - elsif card.layout == "meld" and card.others.size == 1
       = render partial: "card/card_picture", locals: { card: card, foil: foil, card_layout: "dfc" }
       = render partial: "card/card_picture", locals: { card: card.others[0], foil: foil, card_layout: "dfc_reverse" }


### PR DESCRIPTION
I think this makes it a bit clearer what's happening, and looks a bit nicer. I've updated the `rotateY` CSS rules to make sure rotation is consistent. Hovering over a DFC front face to view the back flips the card right to left, as if you were following the little arrow in the frame. Hovering over a back face to view the front flips the card left to right. This adds a bit of additional visual distinction.

Unfortunately, there seems to be a bug in Firefox which is causing the animation for hovering over the combined meld back face to appear incorrectly. The animation looks correct in Chrome. I will see if I can find a workaround for this bug.