### PR TITLE
Respect reduced motion setting when hovering over cards

### DIFF
--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -237,6 +237,9 @@ form.search {
     }
 
     transition: 0.5s ease;
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
     backface-visibility: hidden;
     -webkit-backface-visibility: hidden;
 


### PR DESCRIPTION
This CSS rule removes the animation from the hover interaction on special card layouts when an appropriate accessibility setting is enabled.