### PR TITLE
Don't show back faces in is:holofoil

### DIFF
--- a/search-engine/lib/condition/condition_is_holofoil.rb
+++ b/search-engine/lib/condition/condition_is_holofoil.rb
@@ -3,6 +3,7 @@ class ConditionIsHolofoil < ConditionSimple
     return false unless card.frame == "m15"
     return true if card.set_code == "ust" and card.rarity == "basic"
     return false unless %W[rare mythic special].include?(card.rarity)
+    return false if card.back?
     return false if card.types.include?("contraption")
     true
   end


### PR DESCRIPTION
DFCs only have a holofoil stamp on the front.