### PR TITLE
CSS for dark mode

### DIFF
--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 // Custom bootstrap variables must be set or imported before bootstrap itself.
 @import "bootstrap";
+@import "dark";
 @import "famfamfam-flags";
 @import "mana";
 @import "select2";
@@ -21,6 +22,9 @@
 }
 a.site_logo {
   color: black;
+  @media (prefers-color-scheme: dark) {
+    color: #dedad6;
+  }
 }
 ul {
   padding: 0px 0px 0px 20px;
@@ -79,6 +83,9 @@ form.search {
 
 .infolabel {
   color: #444;
+  @media (prefers-color-scheme: dark) {
+    color: #bbb;
+  }
   font-size: small;
 }
 
@@ -111,6 +118,9 @@ form.search {
   }
   .infolabel {
     color: #444;
+    @media (prefers-color-scheme: dark) {
+      color: #bbb;
+    }
     font-size: small;
   }
   .typeline {
@@ -146,12 +156,21 @@ form.search {
   }
   .legality-legal {
     background-color: #8f8;
+    @media (prefers-color-scheme: dark) {
+      background-color: #080;
+    }
   }
   .legality-banned {
     background-color: #f88;
+    @media (prefers-color-scheme: dark) {
+      background-color: #800;
+    }
   }
   .legality-restricted {
     background-color: #fa4;
+    @media (prefers-color-scheme: dark) {
+      background-color: #880;
+    }
   }
 }
 .foreign_names {
@@ -160,13 +179,22 @@ form.search {
 
 .printings_list {
   color: #888;
+  @media (prefers-color-scheme: dark) {
+    color: #bbb;
+  }
   font-size: small;
   .selected {
     font-weight: bold;
     color: black;
+    @media (prefers-color-scheme: dark) {
+      color: #dedad6;
+    }
   }
   .matching {
     color: black;
+    @media (prefers-color-scheme: dark) {
+      color: #dedad6;
+    }
   }
   .not_matching a {
     color: inherit;
@@ -177,14 +205,23 @@ form.search {
 
 .printings_box {
   color: #888;
+  @media (prefers-color-scheme: dark) {
+    color: #bbb;
+  }
   max-width: 200px;
   font-size: xx-small;
   .selected {
     font-weight: bold;
     color: black;
+    @media (prefers-color-scheme: dark) {
+      color: #dedad6;
+    }
   }
   .matching {
     color: black;
+    @media (prefers-color-scheme: dark) {
+      color: #dedad6;
+    }
   }
   .not_matching a {
     color: inherit;
@@ -341,6 +378,10 @@ form.search {
   font-style: italic;
   background-color: #ccc;
   color: black;
+  @media (prefers-color-scheme: dark) {
+    background-color: #333;
+    color: #dedad6;
+  }
   text-align: center;
   height: 100%;
   width: 100%;
@@ -356,6 +397,14 @@ form.search {
 }
 h3 .manacost {
   font-size: 19.6px;
+}
+@media (prefers-color-scheme: dark) {
+  .mana-loyalty-up,
+  .mana-loyalty-down,
+  .mana-loyalty-zero,
+  .mana-loyalty-start {
+    color: #505050;
+  }
 }
 .decklist {
   border: 1px solid black;

--- a/frontend/app/assets/stylesheets/dark.scss
+++ b/frontend/app/assets/stylesheets/dark.scss
@@ -1,0 +1,30 @@
+@media (prefers-color-scheme: dark) {
+  body,
+  .form-control,
+  .form-control:focus {
+    background-color: black;
+  }
+
+  body {
+    color: #dedad6;
+  }
+
+  a {
+    color: #007bff;
+  }
+
+  a:hover {
+    color: #00a0ff;
+  }
+
+  .alert-danger {
+    color: #f8d7da;
+    background-color: #721c24;
+    border-color: #6f0b15;
+  }
+
+  .form-control,
+  .form-control:focus {
+    color: #a8afb6;
+  }
+}


### PR DESCRIPTION
This is the CSS for #112, currently implemented via `prefers-color-scheme` only since I don't know how you plan to implement the manual toggle.

Sealed page and deck upload form need some work, e.g. the decklist text area still has a white background.