### PR TITLE
Fix error message for PatchFrame

### DIFF
--- a/indexer/lib/patches/patch_frame.rb
+++ b/indexer/lib/patches/patch_frame.rb
@@ -15,7 +15,7 @@ class PatchFrame < Patch
         card["frame"] = "future"
       else
         card["frame"] = "m15"
-        puts "Unknown frame version: #{card["frame"].inspect}"
+        puts "Unknown frame version: #{fv.inspect}"
       end
     end
   end


### PR DESCRIPTION
Without this patch, it would always say `Unknown frame version: "m15"`.