### PR TITLE
Fix dark mode background color in checklist view

### DIFF
--- a/frontend/app/assets/stylesheets/application.scss
+++ b/frontend/app/assets/stylesheets/application.scss
@@ -467,6 +467,9 @@ h3 .manacost {
   a { color: inherit; }
   tr:nth-child(even) {
     background-color: #d8d8d8;
+    @media (prefers-color-scheme: dark) {
+      background-color: #272727;
+    }
   }
   td, th {
     padding: 1px 2px 1px 2px;


### PR DESCRIPTION
The light mode background color is basically the same as the dark mode text color, so this makes the even rows readable.