### PR TITLE
Use frameEffects instead of frameEffect

### DIFF
--- a/indexer/lib/indexer.rb
+++ b/indexer/lib/indexer.rb
@@ -232,7 +232,7 @@ class Indexer
           "exclude_from_boosters",
           "flavor",
           "foiling",
-          "frame_effect",
+          "frame_effects",
           "frame",
           "fullart",
           "mtgo",

--- a/indexer/lib/patches/patch_mtgjson_versions.rb
+++ b/indexer/lib/patches/patch_mtgjson_versions.rb
@@ -116,6 +116,8 @@ class PatchMtgjsonVersions < Patch
 
       if card["frameEffects"]
         card["frame_effects"] = card.delete("frameEffects")
+      elsif card["frameEffect"]
+        card["frame_effects"] = [card.delete("frameEffect")]
       end
 
       card["oversized"] = card.delete("isOversized")

--- a/indexer/lib/patches/patch_mtgjson_versions.rb
+++ b/indexer/lib/patches/patch_mtgjson_versions.rb
@@ -114,8 +114,8 @@ class PatchMtgjsonVersions < Patch
         card["border"] = card.delete("borderColor")
       end
 
-      if card["frameEffect"]
-        card["frame_effect"] = card.delete("frameEffect")
+      if card["frameEffects"]
+        card["frame_effects"] = card.delete("frameEffects")
       end
 
       card["oversized"] = card.delete("isOversized")

--- a/search-engine/lib/card_printing.rb
+++ b/search-engine/lib/card_printing.rb
@@ -1,7 +1,7 @@
 class CardPrinting
   attr_reader :card, :set, :date, :release_date
   attr_reader :watermark, :rarity, :artist_name, :multiverseid, :number, :frame, :flavor, :flavor_normalized, :border
-  attr_reader :rarity_code, :print_sheet, :partner, :oversized, :frame_effect, :foiling, :spotlight
+  attr_reader :rarity_code, :print_sheet, :partner, :oversized, :frame_effects, :foiling, :spotlight
   attr_reader :textless, :fullart
 
   # Performance cache of derived information
@@ -31,7 +31,7 @@ class CardPrinting
     @foiling = data["foiling"]
     @border = data["border"] || @set.border
     @frame = data["frame"]
-    @frame_effect = data["frame_effect"]
+    @frame_effects = data["frame_effects"]
     rarity = data["rarity"]
     @rarity_code = %W[basic common uncommon rare mythic special].index(rarity) or raise "Unknown rarity #{rarity}"
     @exclude_from_boosters = data["exclude_from_boosters"]

--- a/search-engine/lib/condition/condition_frame_effect.rb
+++ b/search-engine/lib/condition/condition_frame_effect.rb
@@ -4,7 +4,7 @@ class ConditionFrameEffect < ConditionSimple
   end
 
   def match?(card)
-    card.frame_effect == @frame_effect
+    card.frame_effects.include?(@frame_effect)
   end
 
   def to_s

--- a/search-engine/lib/condition/condition_is_colorshifted.rb
+++ b/search-engine/lib/condition/condition_is_colorshifted.rb
@@ -1,6 +1,6 @@
 class ConditionIsColorshifted < ConditionSimple
   def match?(card)
-    card.frame_effect == "colorshifted"
+    card.frame_effects.include?("colorshifted")
   end
 
   def to_s


### PR DESCRIPTION
**Do not merge** until an MTG JSON rebuild with mtgjson/mtgjson#464 is released.

This replaces all usage of `frameEffect` (string) with `frameEffects` (array of strings) and adjusts conditions accordingly.