### PR TITLE
Add yesterday's Pioneer B&R changes

### DIFF
--- a/search-engine/lib/ban_list/pioneer.rb
+++ b/search-engine/lib/ban_list/pioneer.rb
@@ -7,4 +7,12 @@ BanList.for_format("pioneer") do
     "Windswept Heath" => "banned",
     "Wooded Foothills" => "banned",
   )
+
+  change(
+    "2019-11-04",
+    "https://magic.wizards.com/en/articles/archive/news/november-4-2019-pioneer-banned-announcement",
+    "Felidar Guardian" => "banned",
+    "Leyline of Abundance" => "banned",
+    "Oath of Nissa" => "banned",
+  )
 end


### PR DESCRIPTION
**Pioneer:**

* Felidar Guardian is banned.
* Leyline of Abundance is banned.
* Oath of Nissa is banned.

[Source](https://magic.wizards.com/en/articles/archive/news/november-4-2019-pioneer-banned-announcement)