### PR TITLE
Fix patch_playtest_cards for Ruby 2.5 compatibility

### DIFF
--- a/indexer/lib/patches/patch_playtest_cards.rb
+++ b/indexer/lib/patches/patch_playtest_cards.rb
@@ -6,7 +6,8 @@ class PatchPlaytestCards < Patch
       "Liberate",
       "Start",
       "Smelt",
-    ].to_h{|n| [n, "#{n} (CMB1)"]}
+    ].map{|n| [n, "#{n} (CMB1)"]}
+    .to_h
     name_map.default_proc = proc{|ht, x| x}
 
     each_printing do |card|


### PR DESCRIPTION
`to_h{block}` seems to be a Ruby 2.6 feature.