### PR TITLE
Fix foil only deck cards when indexing

### DIFF
--- a/deck_indexer/lib/deck_indexer.rb
+++ b/deck_indexer/lib/deck_indexer.rb
@@ -220,7 +220,14 @@ class DeckIndexer
 
   def index_card(card, deck)
     printing = resolve_card(card, deck)
-    [card["count"], printing[0], printing[1]["number"]] + (card["foil"] ? ["foil"] : [])
+
+    set_code = printing[0]
+    printing_card = printing[1]
+
+    foil_res = (card["foil"] || printing_card["foiling"] == "foilonly") ?
+      ["foil"] : []
+    
+    [card["count"], set_code, printing_card["number"]] + foil_res
   end
 
   def index_deck(deck)


### PR DESCRIPTION
When a card printing is chosen for a deck card and is only foil, the indexer marks it as non foil. 

This PR takes into account the foiling property so that it is auto-fixed in this situation.

The alternative could be to throw an error when this situation is encountered so that it is fixed in the precons repository, But given that it is foil only, and the default is to put non foil, this solution might be ok.

This solves the issue of the 40K precons Collector's Edition deck cards being marked as non foil, where all should be foil.