### PR TITLE
Stopped the human exporter from writing repeated sheets

### DIFF
--- a/bin/human_export_sealed_data
+++ b/bin/human_export_sealed_data
@@ -60,9 +60,13 @@ class HumanExportSealedData
         end
       end
       file.puts "sheets:"
+      sdone = []
       sheets.each do |sheet|
-        file.puts "  #{sheet.name}:"
-        write_sheet(file, sheet)
+        if not sdone.include?(sheet.name)
+          file.puts "  #{sheet.name}:"
+          write_sheet(file, sheet)
+          sdone << sheet.name
+        end
       end
     end
   end


### PR DESCRIPTION
Stopped the human readable exporter from writing repeated sheets for different booster variations

Sheets are shared between all booster variations