### PR TITLE
Fix boosters broken by new color balance

### DIFF
--- a/data/boosters/README.md
+++ b/data/boosters/README.md
@@ -172,6 +172,8 @@ Example from [afr.yaml](afr.yaml) to define the rare/mythic slot with showcase c
       chance: 20
 ```
 
+It's best practice to avoid mixing `use` and `any-rate` because it can behave unintuitively. Better practice is to use either `query\rawquery` instead of `use`, or `any-chance` instead of `any-rate` when possible.
+
 #### Filter
 
 Filters can be applied to `query` and `use` subsheets to adjust their context.

--- a/data/boosters/dmu.yaml
+++ b/data/boosters/dmu.yaml
@@ -65,7 +65,7 @@ sheets:
     foil: true
     any:
     - any: 
-      - use: common
+      - query: "r:c"
         rate: 1
       - use: basic
         rate: 1

--- a/data/boosters/mom.yaml
+++ b/data/boosters/mom.yaml
@@ -86,7 +86,7 @@ sheets:
     foil: true
     any:
     - any:
-      - use: common
+      - query: "r:c"
         rate: 1
         count: 116
       - use: basic

--- a/data/boosters/neo-set.yaml
+++ b/data/boosters/neo-set.yaml
@@ -39,7 +39,7 @@ sheets:
   wildcard:
     any:
     - any:
-      - use: common
+      - query: "r:c"
         rate: 1
       - query: "r:b is:fullart"
         rate: 1

--- a/search-engine/lib/pack_factory.rb
+++ b/search-engine/lib/pack_factory.rb
@@ -54,7 +54,7 @@ class PackFactory
       #raise_sheet_error "No balanced support for any" if balanced
       if subsheets.all?{|s| s["rate"]}
         rates = subsheets.map{|d| d.delete("rate")}
-        sheets = subsheets.map{|d| build_sheet(d.merge("foil" => foil)) }
+        sheets = subsheets.map{|d| build_sheet(d.merge("foil" => foil, "balanced" => false)) }
         chances = rates.zip(sheets).map{|r,s| r*s.elements.size}
         build_sheet_from_subsheets(sheets, chances, kind: kind)
       elsif subsheets.all?{|s| s["chance"]}


### PR DESCRIPTION
Because of new color-balancing, color balanced sheets cannot be used as a subsheet inside "any/rate". "any/chance" works fine.