### PR TITLE
Add missing `optimist` dependency to Gemfile

### DIFF
--- a/search-engine/Gemfile
+++ b/search-engine/Gemfile
@@ -10,3 +10,4 @@ gem "pathname-glob"
 gem "memory_profiler", require: false, group: :test
 gem "fastimage"
 gem "calc"
+gem "optimist"


### PR DESCRIPTION
Optimist is used in `search-engine\bin\open_packs`, but wasn't included in the Gemfile