### PR TITLE
LTR first draft

### DIFF
--- a/data/boosters/ltr.yaml
+++ b/data/boosters/ltr.yaml
@@ -1,0 +1,13 @@
+# https://magic.wizards.com/en/news/feature/collecting-the-lord-of-the-rings-tales-of-middle-earth
+pack:
+- basic: 1
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  chance: 2
+- basic: 1
+  common: 9
+  uncommon: 3
+  rare_mythic: 1
+  foil: 1
+  chance: 1


### PR DESCRIPTION
Hi,
Apparently draft boosters of LTR are quite simple for once. They actually seem to follow a pretty straightforward 10 3 1 implementation.

The only wrinkle comes from showcase and borderless cards which are the only booster fun treatments happening for draft boosters. They don't however specify the rates at which borderless and showcase cards appear, so I left them out for now.

All the info are available here: https://magic.wizards.com/en/news/feature/collecting-the-lord-of-the-rings-tales-of-middle-earth