### PR TITLE
Multiple booster fixes

### DIFF
--- a/data/boosters/lci-box-topper-foil.yaml
+++ b/data/boosters/lci-box-topper-foil.yaml
@@ -5,4 +5,4 @@ pack:
 sheets:
   foil_topper:
     foil: true
-    rawquery: "e:ltc number:101-120"
+    rawquery: "e:lcc number:101-120"

--- a/data/boosters/lci-box-topper.yaml
+++ b/data/boosters/lci-box-topper.yaml
@@ -4,4 +4,4 @@ pack:
   topper: 1
 sheets:
   topper:
-    rawquery: "e:ltc number:101-120"
+    rawquery: "e:lcc number:101-120"

--- a/data/boosters/ltr-collector-special.yaml
+++ b/data/boosters/ltr-collector-special.yaml
@@ -98,7 +98,11 @@ sheets:
       count: 4
   serialized_topper:
     foil: true
-    rawquery: "e:ltc number:/z/ -(Sol Ring)"
+    any:
+    - rawquery: "e:ltc number:/z/ -(Sol Ring)"
+      rate: 1
+    - rawquery: "e:ltc number:378-407 -number:/z/ -alt:(e:ltc number:/z/)"
+      rate: 1
   hildebrant_u:
     rawquery: "e:ltc number:515-534 r:u"
   silver_hildebrant_u:
@@ -123,4 +127,8 @@ sheets:
       rate: 1
   serialized_poster: 
     foil: true
-    rawquery: "e:ltr alt:(number:731-750) number:/z/"
+    any:
+    - rawquery: "e:ltr alt:(e:ltr number:731-750) number:/z/"
+      rate: 1
+    - rawquery: "e:ltr number:731-750 -alt:(e:ltr number:/z/)"
+      rate: 1


### PR DESCRIPTION
Fixed lci box toppers referencing the wrong set
Added a stopgap for LTR special edition collector boosters to prevent them from crashing