### PR TITLE
UNF: Exclude galaxyfoil from box toppers

### DIFF
--- a/data/boosters/unf-box-topper.yaml
+++ b/data/boosters/unf-box-topper.yaml
@@ -5,4 +5,4 @@ pack:
 sheets:
   foil_shockland:
     foil: true
-    rawquery: "e:unf is:shockland"
+    rawquery: "e:unf is:shockland -is:galaxyfoil"


### PR DESCRIPTION
They were never meant to be in this product.

Fixes https://github.com/mtgjson/mtg-sealed-content/issues/109