### PR TITLE
CLB: Filter out foil EA cards

### DIFF
--- a/data/boosters/clb-collector.yaml
+++ b/data/boosters/clb-collector.yaml
@@ -23,9 +23,9 @@ sheets:
     use: common_uncommon
     count: 50
   extended_commander:
-    filter: "e:clb number:607-645"
+    filter: "e:clb number:607-645 -alt:(e:clb number:646-657)"
     use: rare_mythic
-    count: 39
+    count: 26
   extended_rare_mythic:
     filter: "e:clb number:553-606"
     use: rare_mythic


### PR DESCRIPTION
I've gotten a report that we include too many cards in the collector booster for CLB

https://docs.google.com/spreadsheets/d/1vXSBHt0cJAFhkU404hfOlXTSANaLT1Z3Becjixf6aXs/edit#gid=1240952972

the cards in yellow appear in the sample boosters not the collector boosters, and the wotc article confirms that
> 1 Non-foil extended-art rare or mythic rare from the Commander Legends: Battle for Baldur's Gate set
> 1 Non-foil extended-art rare or mythic rare from Commander Legends: Battle for Baldur's Gate Commander set

however
1. https://mtg.wtf/card?q=e%3Aclb+number%3A553-606+-is%3Afoil returns an empty set
2. i don't know where the non-ea mythic foils (like Durnan of the Yawning Portal) come from

@taw can you advise?
cc @axxroytovu 