### PR TITLE
LCI: Report the front id of DFC cards

### DIFF
--- a/data/boosters/lci-collector.yaml
+++ b/data/boosters/lci-collector.yaml
@@ -51,16 +51,16 @@ sheets:
       rate: 1
   jurrasic_world:
     any:
-    - rawquery: "e:rex -t:basic -promo:embossed"
+    - rawquery: "e:rex -t:basic -promo:embossed is:front"
       rate: 1
-    - rawquery: "e:rex t:basic -promo:embossed"
+    - rawquery: "e:rex t:basic -promo:embossed is:front"
       rate: 4
   foil_jurrasic_world:
     foil: true
     any:
-    - rawquery: "e:rex -t:basic -promo:embossed"
+    - rawquery: "e:rex -t:basic -promo:embossed is:front"
       rate: 1
-    - rawquery: "e:rex t:basic -promo:embossed"
+    - rawquery: "e:rex t:basic -promo:embossed is:front"
       rate: 4
   emblem_jurrasic_world:
     foil: true


### PR DESCRIPTION
Fix mtgjson/mtg-sealed-content#154.

Not sure if this is a work around or there is a better fix* in the mtgjson export, open to ideas and suggestions.

*=the goal would make sure that the top face is the one being reported