### PR TITLE
Fix erroneous data on mh3 play boosters

### DIFF
--- a/data/boosters/mh3-play.yaml
+++ b/data/boosters/mh3-play.yaml
@@ -31,9 +31,9 @@ sheets:
     rawquery: "e:mh3 number:304-319 -number:309"
   foil_land:
     foil: true
-    rawquery: "e:mh3 number:304-319"
+    rawquery: "e:mh3 number:304-319 -number:309"
   new_uncommon:
-    query: "r:u -is:reprint -(Snow-Covered Wastes)"
+    query: "r:u -is:reprint"
   new_rare_mythic:
     any:
     - rawquery: "r:r -is:reprint -is:foilonly {two_instances}"


### PR DESCRIPTION
Removes the full-art snow covered wastes from the foil-land sheet, and adds the regular snow wastes to the uncommon slot (as per https://magic.wizards.com/en/news/feature/collecting-modern-horizons-3 and #361)