### PR TITLE
Add FIN Collector Boosters

### DIFF
--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -27,12 +27,25 @@ pack:
 queries:
   uncommon_without_cid: "r:u -cid"
   regular_cid: "e:{set} cid -frame:extendedart"
+  adventure_lands: "e:{set} number:310-314"
   artist: "e:{set} number:315-323,577"
   woodblock: "e:{set} number:324-373"
+  character: "e:{set} number:374-405"
   extended_art_legends: "e:{set} number:421-518"
   surge_foil_character: "e:{set} number:519-550"
   boosterfun: "e:{set} number:310-420,577" # Doesn't include extended-art legends
+  borderless_traveling_chocobo: "e:{set} number:406"
+  colored_chocobo: "e:{set} number:551-551d"
+
   secret_rendezvous: "e:FIC number:217-219"
+  fic_base_commanders: "e:FIC number:1-8"
+  fic_extended_art: "e:FIC number:101-193"
+  # 101-193: Extended art (28 rares, 57 legendary rares, 8 legendary mythics)
+  # 194-200: borderless sagas (7)
+  # 201-208: borderless character / borderless commanders (8)
+  # 209-216: surge foil borderless character / borderless commanders (8)
+  # 217-219: Secret Rendezvous (the ones that appear in Collector Booster)
+
 
 sheets:
   foil_common:
@@ -112,15 +125,15 @@ sheets:
         # TODO: Put the numbers in the queries section
         chance: 29 # 2.9%
         count: 7
-      - rawquery: "e:fic number:201-208" # FIC borderless character
+      - rawquery: "e:fic (number:201-208 or number:1-8)" # FIC borderless character
         chance: 33 # 3.3%
-        # count: 16 # TODO: Wizards says 16 but I can only find 8
+        count: 16 # 
       - rawquery: "e:fic number:101-193 r:r" # FIC extended-art rares, combining legendary and non-legendary
         chance: 352 # 35.2% = 11.6% + 23.6%
         count: 85
-      - rawquery: "e:fic number:101-193 r:m" # FIC extended-art mythic rares
+      - rawquery: "({fic_extended_art} or {fic_base_commanders}) r:m" # FIC extended-art mythic rares
         chance: 16 # 1.6%
-        count: 8
+        count: 16
 
   foil_boosterfun_rare_mythic:
     foil: true
@@ -132,7 +145,7 @@ sheets:
       - rawquery: "e:fic number:101-128" # FIC exteded-art rares non legendary creatures
         chance: 58 # 5.8%
         count: 28
-      - rawquery: "e:fic number:201-208" # FIC borderless character
+      - rawquery: "e:fic number:201-208" # FIC borderless character # TODO: I think this is wrong, it's the extended art non legendary ones
         chance: 8 # 0.8%
         count: 8
       - rawquery: "e:fic number:209-216" # FIC surge foil borderless character
@@ -168,26 +181,20 @@ sheets:
         chance: 365 # 36.5%
         count: 29
       - rawquery: "{woodblock} r:m" # Borderless woodblock mythic rare
-        chance: 56 # 5.6%
+        chance: 38 # 3.8%
         count: 6
-        # TODO:  1 of 26 Traditional foil main set borderless rares (31.6%) or 9 mythic rares (5.6%)
-      # - rawquery:
-      #   chance:
-      #   count: 26
-      # - rawquery: 
-      #   chance:
-      #   count: 9
+      - rawquery: "({character} or {adventure_lands}) r:r"
+        chance: 316 # 31.6%
+        count: 25 # TODO: Wizards says it's 26
+      - rawquery: "({character} or {borderless_traveling_chocobo}) r:m"
+        chance: 56 # 5.6%
+        count: 9
       - rawquery: "{surge_foil_character} r:r" # Surge foil rare borderless character 
         chance: 151 # 15.1%
         count: 20
       - rawquery: "{surge_foil_character} r:m" # Surge foil mythic rare borderless character 
         chance: 30 # 3%
         count: 8
-      # TODO: Add Colorful Traveling Chocobo in yellow, green, blue, pink, or black (less than 1%)
-      
-      # - rawquery:
-      #   chance:
-      #   count:
-
-  
-
+      - rawquery: "{colored_chocobo}" # Technically the black chocobo should be rarer than the rest
+        chance: 3 # 0.3%
+        count: 5

--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -24,19 +24,15 @@ pack:
 
   foil_boosterfun_rare_mythic_2: 1 # TODO: Find better name
 
-
 queries:
   uncommon_without_cid: "r:u -cid"
   regular_cid: "e:{set} cid -frame:extendedart"
   artist: "e:{set} number:315-323,577"
   woodblock: "e:{set} number:324-373"
-
   extended_art_legends: "e:{set} number:421-518"
   surge_foil_character: "e:{set} number:519-550"
-
-  secret_rendezvous: "e:FIC number:217-219"
-
   boosterfun: "e:{set} number:310-420,577" # Doesn't include extended-art legends
+  secret_rendezvous: "e:FIC number:217-219"
 
 sheets:
   foil_common:
@@ -92,39 +88,38 @@ sheets:
 
   foil_rare_mythic:
     any:
-    - query: "r:r" # Regular rare
-      chance: 8775 # 87.75%
-      count: 74
-    - query: "r:m"  # Regular mythic
-      chance: 1225 # 12.25%
-      count: 20
+      - query: "r:r" # Regular rare
+        chance: 8775 # 87.75%
+        count: 74
+      - query: "r:m"  # Regular mythic
+        chance: 1225 # 12.25%
+        count: 20
 
   non_foil_boosterfun_rare_mythic: # TODO: Think name
     any:
-      - rawquery: "e:fin {boosterfun} r:r" # Non-foil main set Booster Fun rare
-        chance:
-      - rawquery: "e:fin {boosterfun} r:m" # Non-foil main set Booster Fun mythic rare
-        chance:
+      - rawquery: "{boosterfun} r:r" # Non-foil main set Booster Fun rare
+        chance: 231 # 23.1%
+      - rawquery: "{boosterfun} r:m" # Non-foil main set Booster Fun mythic rare
+        chance: 38 # 3.8%
         count: 22
       - rawquery: "{extended_art_legends} r:r" # Non-foil extended-art legendary rares
-        chance: 
+        chance: 182 # 18.2%
         count: 44
       - rawquery: "{extended_art_legends} r:m" # Non-foil extended-art legendary mythic rares
-        chance: 
+        chance: 29 # 2.9%
         count: 14
       - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
         # TODO: Put the numbers in the queries section
-        chance: # 2.9%
+        chance: 29 # 2.9%
         count: 7
-      - rawquery: "e:fic number:194-200" # FIC 
-        chance: # 3.3%
-        count: 16 # Wizards says 16 but I can only find 8
-
+      - rawquery: "e:fic number:201-208" # FIC borderless character
+        chance: 33 # 3.3%
+        # count: 16 # TODO: Wizards says 16 but I can only find 8
       - rawquery: "e:fic number:101-193 r:r" # FIC extended-art rares, combining legendary and non-legendary
-        chance: # 11.6% + 23.6%
+        chance: 352 # 35.2% = 11.6% + 23.6%
         count: 85
       - rawquery: "e:fic number:101-193 r:m" # FIC extended-art mythic rares
-        chance: # 1.6%
+        chance: 16 # 1.6%
         count: 8
 
   foil_boosterfun_rare_mythic:
@@ -132,16 +127,16 @@ sheets:
     any:
       - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
         # TODO: Put the numbers in the queries section
-        chance: # 2.9%
+        chance: 14 # 1.4%
         count: 7
       - rawquery: "e:fic number:101-128" # FIC exteded-art rares non legendary creatures
-        chance: 
+        chance: 58 # 5.8%
         count: 28
-      - rawquery: "e:fic number:194-200" # FIC borderless character
-        chance:
+      - rawquery: "e:fic number:201-208" # FIC borderless character
+        chance: 8 # 0.8%
         count: 8
-      - rawquery: "e:fic number:194-200" # FIC surge foil borderless character
-        chance: 
+      - rawquery: "e:fic number:209-216" # FIC surge foil borderless character
+        chance: 10 # 1%
         count: 8
 
   non_foil_through_the_ages:

--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -1,0 +1,198 @@
+# Data from: https://magic.wizards.com/en/news/feature/collecting-final-fantasy
+# And https://magic.wizards.com/en/products/final-fantasy/card-image-gallery
+
+pack:
+  foil_common: 3
+  foil_uncommon: 1
+  boosterfun_common_uncommon: 1
+  foil_boostefun_common_uncommon: 1
+  foil_basic: 1
+  foil_rare_mythic: 1
+  boosterfun_rare_mythic_slot: # TODO: Double check this is correct
+    - non_foil_boosterfun_rare_mythic: 3
+      chance: 1
+      # chance: ? # TODO: Calculate
+    - non_foil_boosterfun_rare_mythic: 2
+      foil_boosterfun_rare_mythic: 1
+      chance: 1
+      # chance: ? # TODO: Calculate
+  through_the_ages:
+    - non_foil_through_the_ages: 1
+      chance: 1 # 50%
+    - foil_through_the_ages: 1
+      chance: 1 # 50%
+
+  foil_boosterfun_rare_mythic_2: 1 # TODO: Find better name
+
+
+queries:
+  uncommon_without_cid: "r:u -cid"
+  regular_cid: "e:{set} cid -frame:extendedart"
+  artist: "e:{set} number:315-323,577"
+  woodblock: "e:{set} number:324-373"
+
+  extended_art_legends: "e:{set} number:421-518"
+  surge_foil_character: "e:{set} number:519-550"
+
+  secret_rendezvous: "e:FIC number:217-219"
+
+  boosterfun: "e:{set} number:310-420,577" # Doesn't include extended-art legends
+
+sheets:
+  foil_common:
+    foil: true
+    query: "r:c -t:basic"
+    count: 90
+
+  foil_uncommon:
+    foil: true
+    any:
+    - query: "{uncommon_without_cid}"
+      chance: 107676 # 99.7% (997/1000) * 108/109 = 107676/109000
+      count: 108
+    - rawquery: "{regular_cid}"
+      chance: 997 # 99.7% * 0.9% = 997/109000
+      count: 15
+
+  boosterfun_common_uncommon:
+    any:
+      - rawquery: "r:u {extended_art_legends}" # Extended art legendary uncommon
+        chance: 667
+        count: 40
+      - rawquery: "{woodblock} r:c" # Main set Booster Fun common
+        chance: 50
+        count: 3
+      - rawquery: "{woodblock} r:u" # Main set Booster Fun uncommon
+        chance: 267
+        count: 12 # TODO: Wizards says 13 here? Which is the 13th booster fun uncommon?
+      - rawquery: "{secret_rendezvous}" # Alternate-art Secret Rendezvous
+        chance: 16
+        count: 3
+
+  foil_boostefun_common_uncommon:
+    foil: true
+    any:
+      - rawquery: "{woodblock} r:c" # Main set Booster Fun common
+        chance: 1375
+        count: 3
+      - rawquery: "{woodblock} r:u" # Main set Booster Fun uncommon
+        chance: 7275
+        count: 12 # TODO: Wizards says 13 here? Which is the 13th booster fun uncommon?
+      - rawquery: "{secret_rendezvous}" # Alternate-art Secret Rendezvous
+        chance: 450
+        count: 3
+      - rawquery: "{surge_foil_character} r:u" # Surge foil uncommon borderless character
+        chance: 900
+        count: 4
+
+  foil_basic:
+    foil: true
+    rawquery: "e:{set} t:basic number<519" # Basic lands
+    count: 16
+
+  foil_rare_mythic:
+    any:
+    - query: "r:r" # Regular rare
+      chance: 8775 # 87.75%
+      count: 74
+    - query: "r:m"  # Regular mythic
+      chance: 1225 # 12.25%
+      count: 20
+
+  non_foil_boosterfun_rare_mythic: # TODO: Think name
+    any:
+      - rawquery: "e:fin {boosterfun} r:r" # Non-foil main set Booster Fun rare
+        chance:
+      - rawquery: "e:fin {boosterfun} r:m" # Non-foil main set Booster Fun mythic rare
+        chance:
+        count: 22
+      - rawquery: "{extended_art_legends} r:r" # Non-foil extended-art legendary rares
+        chance: 
+        count: 44
+      - rawquery: "{extended_art_legends} r:m" # Non-foil extended-art legendary mythic rares
+        chance: 
+        count: 14
+      - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
+        # TODO: Put the numbers in the queries section
+        chance: # 2.9%
+        count: 7
+      - rawquery: "e:fic number:194-200" # FIC 
+        chance: # 3.3%
+        count: 16 # Wizards says 16 but I can only find 8
+
+      - rawquery: "e:fic number:101-193 r:r" # FIC extended-art rares, combining legendary and non-legendary
+        chance: # 11.6% + 23.6%
+        count: 85
+      - rawquery: "e:fic number:101-193 r:m" # FIC extended-art mythic rares
+        chance: # 1.6%
+        count: 8
+
+  foil_boosterfun_rare_mythic:
+    foil: true
+    any:
+      - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
+        # TODO: Put the numbers in the queries section
+        chance: # 2.9%
+        count: 7
+      - rawquery: "e:fic number:101-128" # FIC exteded-art rares non legendary creatures
+        chance: 
+        count: 28
+      - rawquery: "e:fic number:194-200" # FIC borderless character
+        chance:
+        count: 8
+      - rawquery: "e:fic number:194-200" # FIC surge foil borderless character
+        chance: 
+        count: 8
+
+  non_foil_through_the_ages:
+    any:
+      - rawquery: "e:fca r:u" # Uncommons FCA
+        chance: 683 # 68.3%
+        count: 17
+      - rawquery: "e:fca r:r -is:alchemy" # Rares FCA
+        chance: 257 # 25.7%
+        count: 32
+      - rawquery: "e:fca r:m" # Mythics FCA
+        chance: 60 # 6%
+        count: 15
+  foil_through_the_ages:
+    foil: true
+    use: non_foil_through_the_ages
+
+
+  foil_boosterfun_rare_mythic_2:
+    foil: true # TODO: Does this work if we have surge foils in this sheet?
+    any:
+      - rawquery: "{artist} r:r" # Artist rare
+        chance: 19 # 1.9%
+        count: 3
+      - rawquery: "{artist} r:m" # Artist mythic rare
+        chance: 22 # 2.2%
+        count: 7
+      - rawquery: "{woodblock} r:r" # Borderless woodblock rare
+        chance: 365 # 36.5%
+        count: 29
+      - rawquery: "{woodblock} r:m" # Borderless woodblock mythic rare
+        chance: 56 # 5.6%
+        count: 6
+        # TODO:  1 of 26 Traditional foil main set borderless rares (31.6%) or 9 mythic rares (5.6%)
+      # - rawquery:
+      #   chance:
+      #   count: 26
+      # - rawquery: 
+      #   chance:
+      #   count: 9
+      - rawquery: "{surge_foil_character} r:r" # Surge foil rare borderless character 
+        chance: 151 # 15.1%
+        count: 20
+      - rawquery: "{surge_foil_character} r:m" # Surge foil mythic rare borderless character 
+        chance: 30 # 3%
+        count: 8
+      # TODO: Add Colorful Traveling Chocobo in yellow, green, blue, pink, or black (less than 1%)
+      
+      # - rawquery:
+      #   chance:
+      #   count:
+
+  
+

--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -5,24 +5,21 @@ pack:
   foil_common: 3
   foil_uncommon: 1
   boosterfun_common_uncommon: 1
-  foil_boostefun_common_uncommon: 1
+  foil_boosterfun_common_uncommon: 1
   foil_basic: 1
   foil_rare_mythic: 1
-  boosterfun_rare_mythic_slot: # TODO: Double check this is correct
+  boosterfun_rare_mythic_slot:
     - non_foil_boosterfun_rare_mythic: 3
-      chance: 1
-      # chance: ? # TODO: Calculate
+      chance: 753571 # 75.3571%
     - non_foil_boosterfun_rare_mythic: 2
-      foil_boosterfun_rare_mythic: 1
-      chance: 1
-      # chance: ? # TODO: Calculate
+      fic_foil_boosterfun_rare_mythic: 1
+      chance: 246429 # 24.6429%
   through_the_ages:
     - non_foil_through_the_ages: 1
       chance: 1 # 50%
     - foil_through_the_ages: 1
       chance: 1 # 50%
-
-  foil_boosterfun_rare_mythic_2: 1 # TODO: Find better name
+  foil_boosterfun_rare_mythic: 1
 
 queries:
   uncommon_without_cid: "r:u -cid"
@@ -36,17 +33,14 @@ queries:
   boosterfun: "e:{set} number:310-420,577" # Doesn't include extended-art legends
   borderless_traveling_chocobo: "e:{set} number:406"
   colored_chocobo: "e:{set} number:551-551d"
-
-  secret_rendezvous: "e:FIC number:217-219"
   fic_base_commanders: "e:FIC number:1-8"
   fic_extended_art: "e:FIC number:101-193"
-  # 101-193: Extended art (28 rares, 57 legendary rares, 8 legendary mythics)
-  # 194-200: borderless sagas (7)
-  # 201-208: borderless character / borderless commanders (8)
-  # 209-216: surge foil borderless character / borderless commanders (8)
-  # 217-219: Secret Rendezvous (the ones that appear in Collector Booster)
-
-
+  fic_borderless_sagas: "e:FIC number:194-200"
+  fic_borderless_character: "e:FIC number:201-208"
+  fic_surge_foil_borderless_character: "e:FIC number:209-216"
+  fic_secret_rendezvous: "e:FIC number:217-219"
+  fic_extended_art_rares_non_legendary_creatures: "e:FIC number:101-128"
+ 
 sheets:
   foil_common:
     foil: true
@@ -74,11 +68,11 @@ sheets:
       - rawquery: "{woodblock} r:u" # Main set Booster Fun uncommon
         chance: 267
         count: 12 # TODO: Wizards says 13 here? Which is the 13th booster fun uncommon?
-      - rawquery: "{secret_rendezvous}" # Alternate-art Secret Rendezvous
+      - rawquery: "{fic_secret_rendezvous}" # Alternate-art Secret Rendezvous
         chance: 16
         count: 3
 
-  foil_boostefun_common_uncommon:
+  foil_boosterfun_common_uncommon:
     foil: true
     any:
       - rawquery: "{woodblock} r:c" # Main set Booster Fun common
@@ -87,7 +81,7 @@ sheets:
       - rawquery: "{woodblock} r:u" # Main set Booster Fun uncommon
         chance: 7275
         count: 12 # TODO: Wizards says 13 here? Which is the 13th booster fun uncommon?
-      - rawquery: "{secret_rendezvous}" # Alternate-art Secret Rendezvous
+      - rawquery: "{fic_secret_rendezvous}" # Alternate-art Secret Rendezvous
         chance: 450
         count: 3
       - rawquery: "{surge_foil_character} r:u" # Surge foil uncommon borderless character
@@ -108,7 +102,7 @@ sheets:
         chance: 1225 # 12.25%
         count: 20
 
-  non_foil_boosterfun_rare_mythic: # TODO: Think name
+  non_foil_boosterfun_rare_mythic:
     any:
       - rawquery: "{boosterfun} r:r" # Non-foil main set Booster Fun rare
         chance: 231 # 23.1%
@@ -121,34 +115,32 @@ sheets:
       - rawquery: "{extended_art_legends} r:m" # Non-foil extended-art legendary mythic rares
         chance: 29 # 2.9%
         count: 14
-      - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
-        # TODO: Put the numbers in the queries section
+      - rawquery: "{fic_borderless_sagas}" # FIC borderless sagas (rares)
         chance: 29 # 2.9%
         count: 7
-      - rawquery: "e:fic (number:201-208 or number:1-8)" # FIC borderless character
+      - rawquery: "{fic_base_commanders} or {fic_borderless_character}"
         chance: 33 # 3.3%
         count: 16 # 
-      - rawquery: "e:fic number:101-193 r:r" # FIC extended-art rares, combining legendary and non-legendary
+      - rawquery: "{fic_extended_art} r:r" # FIC extended-art rares, combining legendary and non-legendary
         chance: 352 # 35.2% = 11.6% + 23.6%
         count: 85
-      - rawquery: "({fic_extended_art} or {fic_base_commanders}) r:m" # FIC extended-art mythic rares
+      - rawquery: "{fic_extended_art} r:m" # FIC extended-art mythic rares
         chance: 16 # 1.6%
-        count: 16
+        count: 8
 
-  foil_boosterfun_rare_mythic:
+  fic_foil_boosterfun_rare_mythic:
     foil: true
     any:
-      - rawquery: "e:fic number:194-200" # FIC borderless sagas (rares)
-        # TODO: Put the numbers in the queries section
+      - rawquery: "{fic_borderless_sagas}" # FIC borderless sagas (rares)
         chance: 14 # 1.4%
         count: 7
-      - rawquery: "e:fic number:101-128" # FIC exteded-art rares non legendary creatures
+      - rawquery: "{fic_extended_art_rares_non_legendary_creatures}" # FIC exteded-art rares non legendary creatures
         chance: 58 # 5.8%
         count: 28
-      - rawquery: "e:fic number:201-208" # FIC borderless character # TODO: I think this is wrong, it's the extended art non legendary ones
+      - rawquery: "{fic_borderless_character}" # FIC borderless character
         chance: 8 # 0.8%
         count: 8
-      - rawquery: "e:fic number:209-216" # FIC surge foil borderless character
+      - rawquery: "{fic_surge_foil_borderless_character}" # FIC surge foil borderless character
         chance: 10 # 1%
         count: 8
 
@@ -168,8 +160,8 @@ sheets:
     use: non_foil_through_the_ages
 
 
-  foil_boosterfun_rare_mythic_2:
-    foil: true # TODO: Does this work if we have surge foils in this sheet?
+  foil_boosterfun_rare_mythic:
+    foil: true
     any:
       - rawquery: "{artist} r:r" # Artist rare
         chance: 19 # 1.9%
@@ -198,3 +190,13 @@ sheets:
       - rawquery: "{colored_chocobo}" # Technically the black chocobo should be rarer than the rest
         chance: 3 # 0.3%
         count: 5
+
+
+# (*) Calculation for boosterfun_rare_mythic_slot
+# The rate for a foil is 9% but there can only be one foil maximum. So we have 2 scenarios:
+# 1. 3 non foil cards
+# 2. 2 non foil cards and one foil
+
+# The chances of scenario 1 are 91% * 91% * 91% = 75.3571%
+# The cnaces of scenario 2 are then 100% - 75.3571% = 24.6429%
+

--- a/data/boosters/fin-play.yaml
+++ b/data/boosters/fin-play.yaml
@@ -24,8 +24,7 @@ queries:
   character: "e:{set} number:374-405"
   uncommon_without_cid: "r:u -cid"
   regular_cid: "e:{set} cid -frame:extendedart"
-  boosterfun: "e:{set} number:310-518,577" # TODO: This query wouldn't be necessary if is:boosterfun works correctly
-  # TODO: I think boosterfun is not correct, extended art should not be included, they never appear in play boosters
+  boosterfun: "e:{set} number:310-420,577" # Doesn't include extended art, they never appear in play boosters
 
 sheets:
   common:
@@ -78,7 +77,6 @@ sheets:
     - query: "r:m"  # Regular mythic
       chance: 100 # 10%
       count: 20
-    # - rawquery: "e:{set} r:r is:borderless (number<519 or number:577)" # TODO: should work if all surge foils are correctly classified
     - rawquery: "e:{set} r:r is:borderless (number<519 or number:577)" # Borderless rare
       chance: 80 # 8%
     - rawquery: "e:{set} r:m is:borderless (number<519 or number:577)" # Borderless mythic
@@ -106,7 +104,7 @@ sheets:
       - rawquery: "{boosterfun} r:c" # Common boosterfun
         chance: 10
         count: 3
-      - rawquery: "{boosterfun} r:u" # Uncommon boosterfun TODO: Should we exclude cid?
+      - rawquery: "{boosterfun} r:u" # Uncommon boosterfun
         chance: 50
       - rawquery: "{boosterfun} r:r"
         chance: 100

--- a/data/boosters/fin-play.yaml
+++ b/data/boosters/fin-play.yaml
@@ -25,6 +25,7 @@ queries:
   uncommon_without_cid: "r:u -cid"
   regular_cid: "e:{set} cid -frame:extendedart"
   boosterfun: "e:{set} number:310-518,577" # TODO: This query wouldn't be necessary if is:boosterfun works correctly
+  # TODO: I think boosterfun is not correct, extended art should not be included, they never appear in play boosters
 
 sheets:
   common:


### PR DESCRIPTION
Based on https://magic.wizards.com/en/news/feature/collecting-final-fantasy

FIN
1-293: normal cards (293)
294-309: basic lands (16)
310-314: Borderless Adventure Lands (5)
315-323: borderless FINAL FANTASY artist cards (9)
324-373: borderless woodblock (50)
374-405: borderless character (32)
406: borderless Traveling Chocobo (1)
407-420: Cid, Timeless Artificer (14) -> version 15 is in the base set
421:518: extended-art legends
519-550: borderless character surge foil (32)
551-551f: Traveling Chocobo
552-563: Starter Kit (12)
564-571: Empty
572:576: surge foil lands (5)
577: The missing artist card
578-585: more surge foils (8)

FIC
1-8: face commanders (8)
9-100: new cards (92)
101-193: Extended art (28 rares, 57 legendary rares, 8 legendary mythics) (93)
194-200: borderless sagas (7)
201-208: borderless character / borderless commanders (8)
209-216: surge foil borderless character / borderless commanders (8)
217-219: Secret Rendezvous (the ones that appear in Collector Booster) (3)
220-227: surge foil face commanders (8)
228: Buy a Box promo
229-441: Reprints (213)
441-483: Empty
484-486: Command tower variants (3)
253: The 4th Secret Rendezvous


Also fixed an issue with fin-play: extended-art legends do not appear in Play Boosters.