### PR TITLE
SLD: Add booster config for July25 Chaos Vault promo cards

### DIFF
--- a/data/boosters/sld-deceptive-districts.yaml
+++ b/data/boosters/sld-deceptive-districts.yaml
@@ -1,0 +1,8 @@
+name: "SLD Deceptive Districts"
+pack:
+  deceptive_districts: 1
+sheets:
+  deceptive_districts:
+    query: "number>=888 number<=892"
+    foil: true
+    count: 5


### PR DESCRIPTION
i picked the name off the sld drop with the same style

note: the lands are not loaded in mtgjson/scryfall yet