### PR TITLE
MB1 misprints from the 2021 version

### DIFF
--- a/data/boosters/mb1-convention-2021.yaml
+++ b/data/boosters/mb1-convention-2021.yaml
@@ -47,8 +47,8 @@ sheets:
     set: plst
     code: "GREENB"
   multicolor:
-    set: plst
-    code: "MULTICOLOR"
+    rawquery: "set:PLST sheet:MULTICOLOR -number:/^GK1-119$/"
+    count: 120
   colorless:
     set: plst
     code: "COLORLESS"

--- a/data/boosters/mb1-convention-2021.yaml
+++ b/data/boosters/mb1-convention-2021.yaml
@@ -53,8 +53,8 @@ sheets:
     set: plst
     code: "COLORLESS"
   old_frame:
-    set: plst
-    code: "OLDFRAME"
+    rawquery: "set:PLST sheet:OLDFRAME -number:/^JUD-127$/"
+    count: 120
   rare:
     set: plst
     code: "RARE"

--- a/data/boosters/mb1-convention.yaml
+++ b/data/boosters/mb1-convention.yaml
@@ -53,8 +53,8 @@ sheets:
     set: plst
     code: "COLORLESS"
   old_frame:
-    set: plst
-    code: "OLDFRAME"
+    rawquery: "set:PLST sheet:OLDFRAME -number:/^JUD-127†$/"
+    count: 120
   rare:
     set: plst
     code: "RARE"

--- a/data/boosters/mb1-convention.yaml
+++ b/data/boosters/mb1-convention.yaml
@@ -47,8 +47,8 @@ sheets:
     set: plst
     code: "GREENB"
   multicolor:
-    set: plst
-    code: "MULTICOLOR"
+    rawquery: "set:PLST sheet:MULTICOLOR -number:/^EMA-203$/"
+    count: 120
   colorless:
     set: plst
     code: "COLORLESS"

--- a/data/boosters/mb1-draft.yaml
+++ b/data/boosters/mb1-draft.yaml
@@ -53,8 +53,8 @@ sheets:
     set: plst
     code: "COLORLESS"
   old_frame:
-    set: plst
-    code: "OLDFRAME"
+    rawquery: "set:PLST sheet:OLDFRAME -number:/^JUD-127†$/"
+    count: 120
   rare:
     set: plst
     code: "RARE"

--- a/data/boosters/mb1-draft.yaml
+++ b/data/boosters/mb1-draft.yaml
@@ -47,8 +47,8 @@ sheets:
     set: plst
     code: "GREENB"
   multicolor:
-    set: plst
-    code: "MULTICOLOR"
+    rawquery: "set:PLST sheet:MULTICOLOR -number:/^EMA-203$/"
+    count: 120
   colorless:
     set: plst
     code: "COLORLESS"

--- a/data/print_sheets_new/plst.txt
+++ b/data/print_sheets_new/plst.txt
@@ -2187,6 +2187,7 @@ Swelter  JUD-101  MBTWRED
 Worldgorger Dragon  JUD-103  CLB DMU BRO
 Grizzly Fate  JUD-119  ZNR KHM STX MHTWO AFR MBTWGREEN
 Harvester Druid  JUD-120  MBTWGREEN
+Phantom Centaur  JUD-127  OLDFRAME
 Phantom Centaur  JUD-127†  OLDFRAME
 Phantom Tiger  JUD-129  MBTWGREEN
 Serene Sunset  JUD-131  MID VOW NEO CLB

--- a/data/print_sheets_new/plst.txt
+++ b/data/print_sheets_new/plst.txt
@@ -1829,6 +1829,7 @@ Trostani, Selesnya's Voice  GK1-102  MBTWRM
 Scatter the Seeds  GK1-106  GREENB
 Pollenbright Wings  GK1-115  MULTICOLOR
 Selesnya Guildmage  GK1-119  MULTICOLOR
+Goblin Trenches  EMA-203  MULTICOLOR
 Azorius Herald  GK2-2  MBTWWHITE
 Belfry Spirit  GK2-29  ZNR KHM STX MHTWO AFR MID MBTWWHITE
 Ultimate Price  GK2-36  MBTWBLACK


### PR DESCRIPTION
i'm 99% this is wrong because `filter` is not supported in the set/code combo, but it'd be really nice if it did

alternatively I'm open for suggestions on how to map these two cards