### PR TITLE
Fix foil slot in FIN Collector

### DIFF
--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -94,6 +94,7 @@ sheets:
     count: 16
 
   foil_rare_mythic:
+    foil: true
     any:
       - query: "r:r" # Regular rare
         chance: 8775 # 87.75%


### PR DESCRIPTION
I was missing a foil tag for the foil_rare_mythic slot.