### PR TITLE
BRO: Fix query for transformers and add count

### DIFF
--- a/data/boosters/bro-collector.yaml
+++ b/data/boosters/bro-collector.yaml
@@ -57,10 +57,12 @@ sheets:
       chance: 1
   transformers:
     any:
-    - rawquery: "e:bot number<=15"
+    - rawquery: "e:bot number<16"
       rate: 7
+      count: 15
     - rawquery: "e:bot number>=16"
       rate: 1
+      count: 14
   foil_transformers:
     foil: true
     use: transformers


### PR DESCRIPTION
<= 15 skips a card from the non-shattered glass series, is it possible the <= check is broken due to the card nubmers having a and b suffixes?