### PR TITLE
MB2: Fix white border sheet, add counts

### DIFF
--- a/data/boosters/mb2-draft.yaml
+++ b/data/boosters/mb2-draft.yaml
@@ -55,11 +55,11 @@ sheets:
     foil: true
   white_border:
     any:
-    - filter: "e:{set} border:white"
-      use: rare_mythic
+    - query: "border:white (r:r OR r:m)"
       chance: 4
-    - filter: "e:{set} border:white"
-      use: common_uncommon
+      count: 51
+    - query: "border:white (r:c OR r:u OR r:l)"
       chance: 6
+      count: 70
   playtest:
     rawquery: "e:{set} is:playtest"


### PR DESCRIPTION
i think the base sheet had something off, as the white border cards weren't picked up by the product mapper, so I rewrote them, hopefully more verbose