### PR TITLE
Add SOS Play and Collector Boosters

### DIFF
--- a/data/boosters/sos-collector.yaml
+++ b/data/boosters/sos-collector.yaml
@@ -1,0 +1,165 @@
+# Secrets of Strixhaven
+# Collector Booster
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-secrets-of-strixhaven
+# - https://magic.wizards.com/en/products/secrets-of-strixhaven/card-image-gallery
+# - https://scryfall.com/sets/sos
+# - https://scryfall.com/sets/soc
+# - https://scryfall.com/sets/soa
+# - https://mtgscribe.com/2026/04/03/secrets-of-strixhaven-play-booster-fact-sheet/
+
+
+pack:
+  foil_common: 4
+  foil_uncommon: 3
+  uncommon_mystical_archive:
+    - non_foil_u_mystical_archive: 2
+      chance: 6333
+    - foil_u_mystical_archive: 2
+      chance: 3667
+  foil_land: 1
+  foil_rare_mythic: 1
+  commander: 1
+  boosterfun: 1
+  rare_mythic_mystical_archive:
+    - non_foil_u_mystical_archive: 1
+      chance: 2 # 25.6% + 7.7% + 25.6% + 7.7% = 66.6% -> 2/3
+    - foil_u_mystical_archive: 1
+      chance: 1
+  foil_boosterfun: 1
+
+queries:
+  dual_land: "e:{set} number:255,256,258,262,266"
+  spellcraft_land: "e:{set} number:267-271"
+  basic_land: "e:{set} number:272-281"
+  boosterfun: "e:{set} number:282-305"
+  serialized_emeritus: "e:{set} number:306"
+  extended_art: "e:{set} number:307-361" # TODO: Update numbers
+  mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+  japanese_mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+  silver_scroll_japanese_mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+  soc_mythic_borderless: "e:SOC number:1-10"
+  soc_rare_extended: "e:SOC number:61-108"
+
+sheets:
+  foil_common:
+    foil: true
+    query: "r:c"
+    count: 81
+
+  foil_uncommon:
+    foil: true
+    query: "r:u"
+    count: 100
+
+
+  non_foil_u_mystical_archive:
+    any:
+      - rawquery: "{mystical_archive} r:u"
+        rate: 1
+        count: 25
+      - rawquery: "{japanese_mystical_archive} r:u"
+        rate: 1
+        count: 25
+
+  foil_u_mystical_archive:
+    foil: true
+    any:
+      - rawquery: "{mystical_archive} r:u"
+        chance: 317
+        count: 25
+      - rawquery: "{silver_scroll_japanese_mystical_archive} r:u"
+        chance: 50
+        count: 25
+
+  foil_land:
+    foil: true
+    rawquery: "{spellcraft_land}"
+    count: 5
+
+  foil_rare_mythic:
+    foil: true
+    any:
+      - use: rare
+        rate: 2
+        count: 60
+      - use: mythic
+        rate: 1
+        count: 20
+
+  commander:
+    any:
+      - rawquery: "{soc_rare_extended}"
+        rate: 2
+        count: 48
+      - rawquery: "{soc_mythic_borderless}"
+        rate: 1
+        count: 10
+
+  boosterfun_2_1_ratio:
+    any:
+    - rawquery: "{boosterfun} r:r"
+      rate: 2
+      count: 5 + 6
+    - rawquery: "{boosterfun} r:m"
+      rate: 1
+      count: 7 + 6
+
+  boosterfun:
+    any:
+      - rawquery: "{extended_art} r:r" # TODO: Once we get the actual amounts, we can check if we can move to rates and remove the boosterfun_2_1_ratio sheet 
+        chance: 700 # 70%
+        # count: ? TODO: Update
+      - rawquery: "{extended_art} r:m"
+        chance: 50 # 5%
+         # count: ? TODO: Update
+      - use: boosterfun_2_1_ratio
+        chance: 250 # 25% = 100% - 70% - 5% = 25%
+
+
+  non_foil_r_m_mystical_archive:
+    any:
+      - rawquery: "{mystical_archive} r:r"
+        rate: 2
+        count: 25
+      - rawquery: "{mystical_archive} r:m"
+        rate: 1
+        count: 15
+      - rawquery: "{japanese_mystical_archive} r:r"
+        rate: 2
+        count: 25
+      - rawquery: "{japanese_mystical_archive} r:m"
+        rate: 1
+        count: 15
+
+  foil_r_m_mystical_archive:
+    foil: true
+    use: non_foil_r_m_mystical_archive
+
+  foil_boosterfun:
+  # TODO: Review these rates once we know the exact number of rare and mythic extended art
+    foil: true  
+    any:
+    - rawquery: "{extended_art} r:r"
+      rate: 8
+      # count: 
+    - rawquery: "{extended_art} r:r"
+      rate: 4
+      # count: 
+    - rawquery: "{boosterfun} r:r"
+      rate: 8
+      count: 5 + 6
+    - rawquery: "{boosterfun} r:m"
+      rate: 4
+      count: 7 + 6
+    - rawquery: "{silver_scroll_japanese_mystical_archive} r:r"
+      rate: 2
+      count: 25
+    - rawquery: "{silver_scroll_japanese_mystical_archive} r:m"
+      rate: 1
+      count: 15
+    - set: spg
+      code: "SOS"
+      rate: 1
+      count: 10
+    # Add serialized (but then rate doesn't really work here, we probably need to make this foil_boosterfun_ratio

--- a/data/boosters/sos-collector.yaml
+++ b/data/boosters/sos-collector.yaml
@@ -33,10 +33,10 @@ queries:
   spellcraft_land: "e:{set} number:267-271"
   basic_land: "e:{set} number:272-281"
   boosterfun: "e:{set} number:282-305"
-  serialized_emeritus: "e:{set} number:306"
+  serialized_emeritus: "e:{set} number:306a"
   extended_art: "e:{set} number:307-362"
   en_mystical_archive: "e:SOA number:1-65"
-  jp_mystical_archive: "e:SOA number:65-130"
+  jp_mystical_archive: "e:SOA number:66-130"
   silver_scroll_jp_mystical_archive: "e:SOA number:131-195"
   soc_mythic_borderless: "e:SOC number:1-10"
   soc_rare_extended: "e:SOC number:61-108"
@@ -45,7 +45,7 @@ sheets:
   foil_common:
     foil: true
     query: "r:c"
-    count: 81
+    count: 81 + 5 # commons + duals
 
   foil_uncommon:
     foil: true

--- a/data/boosters/sos-collector.yaml
+++ b/data/boosters/sos-collector.yaml
@@ -52,7 +52,6 @@ sheets:
     query: "r:u"
     count: 100
 
-
   non_foil_u_mystical_archive:
     any:
       - rawquery: "{en_mystical_archive} r:u"

--- a/data/boosters/sos-collector.yaml
+++ b/data/boosters/sos-collector.yaml
@@ -22,9 +22,9 @@ pack:
   commander: 1
   boosterfun: 1
   rare_mythic_mystical_archive:
-    - non_foil_u_mystical_archive: 1
+    - non_foil_r_m_mystical_archive: 1
       chance: 2 # 25.6% + 7.7% + 25.6% + 7.7% = 66.6% -> 2/3
-    - foil_u_mystical_archive: 1
+    - foil_r_m_mystical_archive: 1
       chance: 1
   foil_boosterfun: 1
 
@@ -34,10 +34,10 @@ queries:
   basic_land: "e:{set} number:272-281"
   boosterfun: "e:{set} number:282-305"
   serialized_emeritus: "e:{set} number:306"
-  extended_art: "e:{set} number:307-361" # TODO: Update numbers
-  mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
-  japanese_mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
-  silver_scroll_japanese_mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+  extended_art: "e:{set} number:307-362"
+  en_mystical_archive: "e:SOA number:1-65"
+  jp_mystical_archive: "e:SOA number:65-130"
+  silver_scroll_jp_mystical_archive: "e:SOA number:131-195"
   soc_mythic_borderless: "e:SOC number:1-10"
   soc_rare_extended: "e:SOC number:61-108"
 
@@ -55,20 +55,20 @@ sheets:
 
   non_foil_u_mystical_archive:
     any:
-      - rawquery: "{mystical_archive} r:u"
+      - rawquery: "{en_mystical_archive} r:u"
         rate: 1
         count: 25
-      - rawquery: "{japanese_mystical_archive} r:u"
+      - rawquery: "{jp_mystical_archive} r:u"
         rate: 1
         count: 25
 
   foil_u_mystical_archive:
     foil: true
     any:
-      - rawquery: "{mystical_archive} r:u"
+      - rawquery: "{en_mystical_archive} r:u"
         chance: 317
         count: 25
-      - rawquery: "{silver_scroll_japanese_mystical_archive} r:u"
+      - rawquery: "{silver_scroll_jp_mystical_archive} r:u"
         chance: 50
         count: 25
 
@@ -96,39 +96,33 @@ sheets:
         rate: 1
         count: 10
 
-  boosterfun_2_1_ratio:
-    any:
-    - rawquery: "{boosterfun} r:r"
-      rate: 2
-      count: 5 + 6
-    - rawquery: "{boosterfun} r:m"
-      rate: 1
-      count: 7 + 6
-
   boosterfun:
     any:
-      - rawquery: "{extended_art} r:r" # TODO: Once we get the actual amounts, we can check if we can move to rates and remove the boosterfun_2_1_ratio sheet 
-        chance: 700 # 70%
-        # count: ? TODO: Update
+      - rawquery: "{extended_art} r:r"
+        rate: 2
+        count: 49
       - rawquery: "{extended_art} r:m"
-        chance: 50 # 5%
-         # count: ? TODO: Update
-      - use: boosterfun_2_1_ratio
-        chance: 250 # 25% = 100% - 70% - 5% = 25%
-
+        rate: 1
+        count: 7
+      - rawquery: "{boosterfun} r:r"
+        rate: 2
+        count: 5 + 6
+      - rawquery: "{boosterfun} r:m"
+        rate: 1
+        count: 7 + 6
 
   non_foil_r_m_mystical_archive:
     any:
-      - rawquery: "{mystical_archive} r:r"
+      - rawquery: "{en_mystical_archive} r:r"
         rate: 2
         count: 25
-      - rawquery: "{mystical_archive} r:m"
+      - rawquery: "{en_mystical_archive} r:m"
         rate: 1
         count: 15
-      - rawquery: "{japanese_mystical_archive} r:r"
+      - rawquery: "{jp_mystical_archive} r:r"
         rate: 2
         count: 25
-      - rawquery: "{japanese_mystical_archive} r:m"
+      - rawquery: "{jp_mystical_archive} r:m"
         rate: 1
         count: 15
 
@@ -136,30 +130,36 @@ sheets:
     foil: true
     use: non_foil_r_m_mystical_archive
 
-  foil_boosterfun:
-  # TODO: Review these rates once we know the exact number of rare and mythic extended art
-    foil: true  
+  foil_boosterfun_no_serialized:
     any:
     - rawquery: "{extended_art} r:r"
       rate: 8
-      # count: 
-    - rawquery: "{extended_art} r:r"
+      count: 49
+    - rawquery: "{extended_art} r:m"
       rate: 4
-      # count: 
+      count: 
     - rawquery: "{boosterfun} r:r"
       rate: 8
       count: 5 + 6
     - rawquery: "{boosterfun} r:m"
       rate: 4
       count: 7 + 6
-    - rawquery: "{silver_scroll_japanese_mystical_archive} r:r"
+    - rawquery: "{silver_scroll_jp_mystical_archive} r:r"
       rate: 2
       count: 25
-    - rawquery: "{silver_scroll_japanese_mystical_archive} r:m"
+    - rawquery: "{silver_scroll_jp_mystical_archive} r:m"
       rate: 1
       count: 15
     - set: spg
       code: "SOS"
       rate: 1
       count: 10
-    # Add serialized (but then rate doesn't really work here, we probably need to make this foil_boosterfun_ratio
+
+  foil_boosterfun:
+    foil: true
+    any:
+      - use: foil_boosterfun_no_serialized
+        chance: 5999
+      - rawquery: "{serialized_emeritus}"
+        chance: 1 # 1 / 6000
+        count: 1

--- a/data/boosters/sos-collector.yaml
+++ b/data/boosters/sos-collector.yaml
@@ -12,11 +12,12 @@
 pack:
   foil_common: 4
   foil_uncommon: 3
-  uncommon_mystical_archive:
-    - non_foil_u_mystical_archive: 2
-      chance: 6333
-    - foil_u_mystical_archive: 2
-      chance: 3667
+  non_foil_u_mystical_archive: 1 # Full explanation at the end of the file
+  u_mystical_archive:
+    - non_foil_u_mystical_archive: 1
+      chance: 2666
+    - foil_u_mystical_archive: 1
+      chance: 7334
   foil_land: 1
   foil_rare_mythic: 1
   commander: 1
@@ -65,10 +66,10 @@ sheets:
     foil: true
     any:
       - rawquery: "{en_mystical_archive} r:u"
-        chance: 317
+        chance: 3167 * 2 # 2x31.67%
         count: 25
       - rawquery: "{silver_scroll_jp_mystical_archive} r:u"
-        chance: 50
+        chance: 500 * 2 # 2x5%
         count: 25
 
   foil_land:
@@ -162,3 +163,25 @@ sheets:
       - rawquery: "{serialized_emeritus}"
         chance: 1 # 1 / 6000
         count: 1
+
+
+####### Uncommon Mystical Archive Slot:
+# What Wizards says:
+# 2 Uncommon Mystical Archive cards
+# A non-foil (31.7%) or traditional foil (31.7%) Mystical Archive card
+# A non-foil (31.7%) or silver scroll foil (5%) Japanese Mystical Archive card
+
+# I took a look at these 3 box openings:
+# https://www.youtube.com/watch?v=MoaXQHIOxrM
+# https://www.youtube.com/watch?v=oXkQcz3M0Eg
+# https://www.youtube.com/watch?v=dS7LtK0hWfQ
+
+# This is what I noticed:
+# - The first slot is always a non-foil.
+# - The first slot is English 50% of the time, Japanese 50% of the time.
+# - The second slot can be anything.
+# - The overall distribution complies with what Wizard says.
+
+# It seems to me know that this is how the slots work:
+# - First uncommon mystical archive slot: non-foil English cards, non-foil Japanese (50-50 probability)
+# - Second uncommon mystical archive slot: silver scroll foil (10%, to make it 5% globally), foil english (63.4%, to make it 31.7% globally), non-foil English cards, non-foil Japanese (13.3% each).

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -39,7 +39,7 @@ queries:
 
 sheets:
   common:
-    query: "r:c" # Regular common
+    query: "r:c -{dual_land}"
     count: 81
 
   uncommon:

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -1,0 +1,150 @@
+# Secrets of Strixhaven
+# Play Booster (English)
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-secrets-of-strixhaven
+# - https://magic.wizards.com/en/products/secrets-of-strixhaven/card-image-gallery
+# - https://scryfall.com/sets/sos
+# - https://scryfall.com/sets/soc
+# - https://scryfall.com/sets/soa]
+# - https://mtgscribe.com/2026/04/03/secrets-of-strixhaven-play-booster-fact-sheet/
+
+
+
+# TODO: Should I add some language tag to make it explicit that this is for English boosters?
+
+superfilter: "-is:reversibleback" # TODO: Not sure if I need it here
+
+
+pack:
+  common_special_guest: # TODO: Can I call this "common"? 
+    - common: 6
+      chance: 54
+    - common: 5
+      special_guest: 1
+      chance: 1
+  uncommon: 3
+  wildcard: 1
+  rare_mythic: 1
+  mystical_archive: 1
+  foil: 1
+  land:
+    - non_foil_land: 1
+      chance: 80
+    - foil_land: 1
+      chance: 20
+
+queries:
+  dual_land: "e:{set} number:255,256,258,262,266"
+  spellcraft_land: "e:{set} number:267-271"
+  basic_land: "e:{set} number:272-281"
+  boosterfun: "e:{set} number:282-305"
+  mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+
+sheets:
+  common:
+    query: "r:c" # Regular common
+    count: 81
+
+  uncommon:
+    query: "r:u" # Regular uncommon
+    count: 100
+
+  rare:
+    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
+    any:
+      - rawquery: "{boosterfun} r:r"
+        rate: 1
+        # count: ?
+      - query: "r:r alt:({boosterfun})"
+        rate: 6
+        # count: ?
+      - query: "r:r -alt:({boosterfun})"
+        rate: 7
+        # count: ?
+
+  mythic:
+    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
+    any:
+      - rawquery: "{boosterfun} r:m"
+        rate: 1
+        # count: ?
+      - query: "r:m alt:({boosterfun})"
+        rate: 6
+        # count: ?
+      - query: "r:m -alt:({boosterfun})"
+        rate: 7
+        # count: ?
+
+  wildcard:
+    # We don't do 2:1 ratio for R:M because the numbers from Wizards paint a completely different picture
+    any:
+      - use: common
+        chance: 391
+      - use: uncommon
+        chance: 391
+      - use: rare
+        chance: 195 + 3 # There's an extra 0.4% for the boosterfun so we distribute it between rares and mythics
+      - use: mythic
+        chance: 19 + 1
+
+  rare_mythic:
+    any:
+      - use: rare
+        chance: 6
+      - use: mythic
+        chance: 1
+
+  mystical_archive:
+    any:
+    - rawquery: "{mystical_archive} r:u"
+      rate: 18
+      count: 25
+    - rawquery: "{mystical_archive} r:r"
+      rate: 2
+      count: 25
+    - rawquery: "{mystical_archive} r:m"
+      rate: 1
+      count: 15
+
+  foil:
+  # C:U seems to be 2:1 and R:M also 2:1
+  # For the Mystical Archive cards, we assume the same distribution as in the previous slot
+    foil: true
+    any:
+      - any:
+        - use: common
+          rate: 2
+        - use: uncommon
+          rate: 1
+        chance: 544 + 336 # 54.4% + 33.6% = 88%
+      - any:
+        - use: rare
+          chance: 6
+        - use: mythic
+          chance: 1
+        chance: 67 + 11 + 10 # Add the extra 1% for the boosterfun 
+      - use: mystical_archive
+        chance: 32
+
+  non_foil_land:
+    any:
+      - rawquery: "{basic_land}" # Default frame basic land
+        rate: 1
+        count: 10
+      - rawquery: "{spellcraft_land}"
+        rate: 1
+        count: 5
+      - rawquery: "{dual_land}"
+        rate: 3
+        count: 5
+
+  foil_land:
+    foil: true
+    use: non_foil_land
+
+  special_guest:
+    set: spg
+    code: "SOS"
+    count: 10
+
+  

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -5,15 +5,14 @@
 # - https://magic.wizards.com/en/products/secrets-of-strixhaven/card-image-gallery
 # - https://scryfall.com/sets/sos
 # - https://scryfall.com/sets/soc
-# - https://scryfall.com/sets/soa]
+# - https://scryfall.com/sets/soa
 # - https://mtgscribe.com/2026/04/03/secrets-of-strixhaven-play-booster-fact-sheet/
 
 
 
 # TODO: Should I add some language tag to make it explicit that this is for English boosters?
 
-superfilter: "-is:reversibleback" # TODO: Not sure if I need it here
-
+# superfilter: "-is:reversibleback" # TODO: Not sure if I need it here, probably not
 
 pack:
   common_special_guest: # TODO: Can I call this "common"? 

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -143,5 +143,3 @@ sheets:
     set: spg
     code: "SOS"
     count: 10
-
-  

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -12,10 +12,8 @@
 
 # TODO: Should I add some language tag to make it explicit that this is for English boosters?
 
-# superfilter: "-is:reversibleback" # TODO: Not sure if I need it here, probably not
-
 pack:
-  common_special_guest: # TODO: Can I call this "common"? 
+  common_special_guest:
     - common: 6
       chance: 54
     - common: 5
@@ -37,7 +35,7 @@ queries:
   spellcraft_land: "e:{set} number:267-271"
   basic_land: "e:{set} number:272-281"
   boosterfun: "e:{set} number:282-305"
-  mystical_archive: "e:SOA number:1-100" # TODO: Update numbers
+  en_mystical_archive: "e:SOA number:1-65"
 
 sheets:
   common:
@@ -95,13 +93,13 @@ sheets:
 
   mystical_archive:
     any:
-    - rawquery: "{mystical_archive} r:u"
+    - rawquery: "{en_mystical_archive} r:u"
       rate: 18
       count: 25
-    - rawquery: "{mystical_archive} r:r"
+    - rawquery: "{en_mystical_archive} r:r"
       rate: 2
       count: 25
-    - rawquery: "{mystical_archive} r:m"
+    - rawquery: "{en_mystical_archive} r:m"
       rate: 1
       count: 15
 

--- a/data/boosters/sos-play.yaml
+++ b/data/boosters/sos-play.yaml
@@ -51,26 +51,26 @@ sheets:
     any:
       - rawquery: "{boosterfun} r:r"
         rate: 1
-        # count: ?
+        count: 11
       - query: "r:r alt:({boosterfun})"
         rate: 6
-        # count: ?
+        count: 11
       - query: "r:r -alt:({boosterfun})"
         rate: 7
-        # count: ?
+        count: 60 - 11
 
   mythic:
     # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
     any:
       - rawquery: "{boosterfun} r:m"
         rate: 1
-        # count: ?
+        count: 13
       - query: "r:m alt:({boosterfun})"
         rate: 6
-        # count: ?
+        count: 13
       - query: "r:m -alt:({boosterfun})"
         rate: 7
-        # count: ?
+        count: 20 - 13
 
   wildcard:
     # We don't do 2:1 ratio for R:M because the numbers from Wizards paint a completely different picture

--- a/data/print_sheets_new/spg.txt
+++ b/data/print_sheets_new/spg.txt
@@ -136,3 +136,13 @@ Dolmen Gate  145  ECL
 Door of Destinies  146  ECL
 Painter's Servant  147  ECL
 Thousand-Year Elixir  148  ECL
+Archaeomancer  149  SOS
+Archmage Emeritus  150  SOS
+Murmuring Mystic  151  SOS
+Grim Haruspex  152  SOS
+Dualcaster Mage  153  SOS
+Magus of the Library  154  SOS
+Sylvan Library  155  SOS
+Adrix and Nev, Twincasters  156  SOS
+Codie, Vociferous Codex  157  SOS
+Library of Leng  158  SOS

--- a/indexer/lib/patches/patch_base_size.rb
+++ b/indexer/lib/patches/patch_base_size.rb
@@ -5,6 +5,7 @@ class PatchBaseSize < Patch
     sizes = {
       "ecl" => 273, # up to the last normal basic
       "tmt" => 195, # up to first set of basics (but they are fancy ones, boring ones are have much higher numbers)
+      "sos" => 281, # up to and including all basic lands (fullart and normal ones)
     }
 
     sizes.each do |code, size|


### PR DESCRIPTION
SOS

1-266: normal cards (81C, 100U, ?R, ?M, 5 dual lands) (266)
267-271: Full-Art Spellcraft Lands (5)
272-281: normal basics (10)
282-283: Borderless Planeswalkers (2M) (2)
284-288: Borderless  Elder Dragons (5M) (5)
289-300: Borderless Field Notes Cards (6R, 6M) (12)
301-305: Borderless Lands (5R) (5)
306: Headliner Emeritus of Ideation
307-362+: Extended Art (49R, 7M) (56)
363-368: Promos

SOC
1-10: Commanders (10M) (10)
11-60: New cards (50)
61-108: Extended art (48R)  (48)
… More stuff

SOA (Mystical Archives)
1-65: English
66-130: Japanese
131-195: Japanese silver scroll foil
