### PR TITLE
Add Marvel Superheroes Play and Collector Boosters

### DIFF
--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -1,0 +1,233 @@
+# Marvel Super Heroes
+# Collector Booster
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-marvel-super-heroes
+# - https://magic.wizards.com/en/products/marvel/marvel-super-heroes/card-image-gallery
+# - https://scryfall.com/sets/msh
+# - https://scryfall.com/sets/msc
+# - https://scryfall.com/sets/mar
+
+
+pack:
+  foil_common: 3
+  foil_uncommon: 2
+  foil_common_commander: 2
+  foil_uncommon_commander: 1
+  foil_c_u_scene: 1
+  foil_land: 1
+  foil_rare_mythic: 1
+  boosterfun_commander: 1
+  boosterfun: 1
+  source_material:
+    - non_foil_source_material: 1
+      chance: 75
+    - foil_source_material: 1
+      chance: 25
+  foil_boosterfun: 1
+
+queries:
+  # dual_land: "e:{set} number:257-259,262,265,268,270-273"
+  city_calm_chaos: "e:{set} number:277-286"
+  panel: "e:{set} number:297-313"
+  scene: "e:{set} number:314-351"
+  logo: "e:{set} number:352-379"
+  borderless_land: "e:{set} number:380-384"
+  gauntlet_mind_stone: "e:{set} number:385"
+  cosmic_mind_stone: "e:{set} number:386"
+  classic_comic: "e:{set} number:387-401"
+  msh_extended_art: "e:{set} number:402-429"
+
+  source_material: "e:MAR number:41-100"
+
+  msc_face_commander: "e:MSC number:1-7"
+  msc_extended_art: "e:MSC number:291-500"
+  msc_scene_box: "e:MSC number:501-512"
+  jumpstart_new: "e:MSC number:583-767"
+  jumpstart_reprint: "e:MSC number:583-767,874"
+  welcome_deck: "e:MSC number:829-833"
+
+sheets:
+  foil_common:
+    foil: true
+    query: "r:c"
+    count: 81 + 10 # commons + duals
+
+  foil_uncommon:
+    foil: true
+    query: "r:u"
+    count: 100
+
+
+  foil_common_commander:
+    foil: true
+    any:
+      - rawquery: "{jumpstart_reprint} r:c"
+        rate: 1
+        count: 37
+      - rawquery: "{jumpstart_new} r:c"
+        rate: 1
+        count: 37
+
+  foil_uncommon_commander:
+    foil: true
+    any:
+      - rawquery: "{jumpstart_reprint} r:u"
+        rate: 1
+        count: 21
+      - rawquery: "{jumpstart_new} r:u"
+        rate: 1
+        count: 92
+
+  foil_c_u_scene:
+    foil: true
+    any:
+      - rawquery: "{scene} r:c"
+        rate: 1
+        count: 3
+      - rawquery: "{scene} r:u"
+        rate: 1
+        count: 12
+
+  foil_land:
+    foil: true
+    rawquery: "{city_calm_chaos}"
+    count: 10
+
+  foil_rare_mythic_no_dfc:
+    foil: true
+    any:
+    - use: rare
+      rate: 2
+      count: 60
+    - use: mythic
+      rate: 1
+      count: 25
+      # TODO: Maybe just rare_mythic here?
+    - rawquery: "{jumpstart_new} r:r"
+      rate: 2
+      count: 45
+    - rawquery: "{jumpstart_new} r:m"
+      rate: 1
+      count: 11
+    - rawquery: "{jumpstart_reprint} r:r"
+      rate: 2
+      count: 4
+    - rawquery: "{welcome_deck} r:m"
+      rate: 1
+      count: 5
+
+  foil_rare_mythic:
+    # Everything in this sheet is 2:1 R:M ratio except the double faced cards
+    foil: true
+    any:
+    - use: foil_rare_mythic_no_dfc
+      chance: 972 # 100% - 1.4% - 1.4% = 97.2%
+    - rawquery: "{scene} is:dfc"
+      chance: 14 # 1.4%
+      count: 5
+    - rawquery: "{logo} is:dfc"
+      chance: 14 # 1.4%
+      count: 5
+
+  boosterfun_commander:
+    any:
+    - rawquery: "{msc_extended_art} r:r"
+      rate: 1
+      count: 203
+    - rawquery: "{msc_extended_art} r:m"
+      rate: 1 # It's weird that they have the same rate as the rares but that's what Wizard's numbers say
+      count: 7
+    - rawquery: "{msc_face_commander} r:r"
+      rate: 1
+      count: 7
+
+  msh_extended_art:
+    any:
+    - rawquery: "{msh_extended_art} r:r"
+      rate: 2
+      count: 24
+    - rawquery: "{msh_extended_art} r:m"
+      rate: 1
+      count: 4
+
+  non_foil_source_material:
+    rawquery: "{source_material}"
+    count: 60
+
+  foil_source_material:
+    foil: true
+    use: non_foil_source_material
+
+  boosterfun:
+  # I tried to use rates but I couldn't get many clear rates from Wizard's numbers
+    any:
+    - use: msh_extended_art
+      chance: 278 + 23 # 27.8% + 2.3%
+      count: 28
+    - rawquery: "{scene} r:r"
+      chance: 64 # 6.4%
+      count: 8
+    - rawquery: "{scene} r:m"
+      chance: 49 # 4.9%
+      count: 15
+    - rawquery: "{logo} r:r"
+      chance: 151 # 15.1%
+      count: 15
+    - rawquery: "{logo} r:m"
+      chance: 46 # 4.6%
+      count: 13
+    - rawquery: "{panel} r:r"
+      chance: 121 # 12.1%
+      count: 11
+    - rawquery: "{panel} r:m"
+      chance: 26 # 2.6%
+      count: 6
+    - rawquery: "{msc_scene_box}"
+      chance: 139 # 13.9%
+      count: 12
+    - rawquery: "{borderless_land}"
+      chance: 58 # 5.8%
+      count: 5
+    - use: non_foil_source_material
+      chance: 45 # 4.5%
+
+  foil_boosterfun:
+    foil: true
+  # I tried to use rates but I couldn't get many clear rates from Wizard's numbers
+    any:
+    - use: msh_extended_art
+      chance: 318 + 27 # 31.8% + 2.7%
+      count: 28
+    - rawquery: "{scene} r:r"
+      chance: 73 # 7.3%
+      count: 8
+    - rawquery: "{scene} r:m -is:dfc"
+      chance: 40 # 4%
+      count: 10
+    - rawquery: "{logo} r:r"
+      chance: 172 # 17.2%
+      count: 15
+    - rawquery: "{logo} r:m -is:dfc"
+      chance: 36 # 3.6%
+      count: 8
+    - rawquery: "{panel} r:r"
+      chance: 139 # 13.9%
+      count: 11
+    - rawquery: "{panel} r:m"
+      chance: 30 # 3%
+      count: 6
+    - rawquery: "{borderless_land}"
+      chance: 66 # 6.6%
+      count: 5
+    - rawquery: "{classic_comic}"
+      chance: 99 # 9.9%
+      count: 15
+    
+      chance: 1 # TODO: Update
+      count: 1
+
+  
+
+
+
+# TODO: Double check all foil tags!

--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -26,7 +26,6 @@ pack:
   foil_boosterfun: 1
 
 queries:
-  # dual_land: "e:{set} number:257-259,262,265,268,270-273"
   city_calm_chaos: "e:{set} number:277-286"
   panel: "e:{set} number:297-313"
   scene: "e:{set} number:314-351"
@@ -43,7 +42,7 @@ queries:
   msc_extended_art: "e:MSC number:291-500"
   msc_scene_box: "e:MSC number:501-512"
   jumpstart_new: "e:MSC number:583-767"
-  jumpstart_reprint: "e:MSC number:583-767,874"
+  jumpstart_reprint: "e:MSC number:768-828,874"
   welcome_deck: "e:MSC number:829-833"
 
 sheets:
@@ -56,7 +55,6 @@ sheets:
     foil: true
     query: "r:u"
     count: 100
-
 
   foil_common_commander:
     foil: true
@@ -137,7 +135,7 @@ sheets:
     - rawquery: "{msc_extended_art} r:m"
       rate: 1 # It's weird that they have the same rate as the rares but that's what Wizard's numbers say
       count: 7
-    - rawquery: "{msc_face_commander} r:r"
+    - rawquery: "{msc_face_commander}"
       rate: 1
       count: 7
 

--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -7,7 +7,6 @@
 # - https://scryfall.com/sets/msc
 # - https://scryfall.com/sets/mar
 
-
 pack:
   foil_common: 3
   foil_uncommon: 2
@@ -100,7 +99,6 @@ sheets:
     - use: mythic
       rate: 1
       count: 25
-      # TODO: Maybe just rare_mythic here?
     - rawquery: "{jumpstart_new} r:r"
       rate: 2
       count: 45
@@ -189,8 +187,7 @@ sheets:
     - use: non_foil_source_material
       chance: 45 # 4.5%
 
-  foil_boosterfun:
-    foil: true
+  foil_boosterfun_no_chase_cards:
   # I tried to use rates but I couldn't get many clear rates from Wizard's numbers
     any:
     - use: msh_extended_art
@@ -220,12 +217,24 @@ sheets:
     - rawquery: "{classic_comic}"
       chance: 99 # 9.9%
       count: 15
+   
+
+  foil_boosterfun:
+  # Created a separate sheet to make it easier to play around with the chase rare chances without having to adjust everything else
+    foil: true
+    any:
+    - use: foil_boosterfun_no_chase_cards
+      chance: 10000 - 10 - 1 # 100% - 0.1% - 0.01%
     - rawquery: "{gauntlet_mind_stone}"
-      chance: 1 # TODO: Update
+      chance: 10 # 0.1%
       count: 1
     - rawquery: "{cosmic_mind_stone}"
-      chance: 1 # TODO: Update
+      chance: 1 # 0.01%
       count: 1
 
+########## foil_boosterfun sheet:
+# The numbers for the Gauntlet Mind Stone and cosmic foil Mind Store are a mistery.
+# I'm using the same numbers we used for the Soul Stone in SPM:
 
-# TODO: Double check all foil tags!
+# 1 Gauntlet Mind Stone on 0.1% of boosters
+# 1 Cosmic Mind Stone on 0.01% of boosters

--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -30,8 +30,8 @@ queries:
   scene: "e:{set} number:314-351"
   logo: "e:{set} number:352-379"
   borderless_land: "e:{set} number:380-384"
-  gauntlet_mind_stone: "e:{set} number:385"
-  cosmic_mind_stone: "e:{set} number:386"
+  cosmic_mind_stone: "e:{set} number:385
+  gauntlet_mind_stone: "e:{set} number:386"
   classic_comic: "e:{set} number:387-401"
   msh_extended_art: "e:{set} number:402-429"
 

--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -30,7 +30,7 @@ queries:
   scene: "e:{set} number:314-351"
   logo: "e:{set} number:352-379"
   borderless_land: "e:{set} number:380-384"
-  cosmic_mind_stone: "e:{set} number:385
+  cosmic_mind_stone: "e:{set} number:385"
   gauntlet_mind_stone: "e:{set} number:386"
   classic_comic: "e:{set} number:387-401"
   msh_extended_art: "e:{set} number:402-429"

--- a/data/boosters/msh-collector.yaml
+++ b/data/boosters/msh-collector.yaml
@@ -220,12 +220,12 @@ sheets:
     - rawquery: "{classic_comic}"
       chance: 99 # 9.9%
       count: 15
-    
+    - rawquery: "{gauntlet_mind_stone}"
       chance: 1 # TODO: Update
       count: 1
-
-  
-
+    - rawquery: "{cosmic_mind_stone}"
+      chance: 1 # TODO: Update
+      count: 1
 
 
 # TODO: Double check all foil tags!

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -32,6 +32,9 @@ queries:
   borderless_land: "e:{set} number:380-384"
   source_material: "e:MAR number:41-100"
 
+  rare_with_two_boosterfun: "e:{set} number:25,97,213,220,244"
+  mythic_with_two_boosterfun: "e:{set} number:6,9,11,18,23,49,80,89,95,146,156,219,245"
+
 sheets:
   common:
     # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene commons.
@@ -64,10 +67,10 @@ sheets:
       - rawquery: "{boosterfun_no_land} r:r" # Rare boosterfun
         rate: 1
         count: 34
-      - query: "r:r alt:({boosterfun_no_land})" # Rare with one boosterfun version # TODO: Define properly
+      - query: "r:r alt:({boosterfun_no_land}) -{rare_with_two_boosterfun}" # Rare with one boosterfun version # TODO: Define properly
         rate: 6
         count: 24
-      - query: "r:r alt:({boosterfun_no_land})" # Rare with two boosterfun versions # TODO: Define properly
+      - query: "{rare_with_two_boosterfun})" # Rare with two boosterfun versions
         rate: 7
         count: 5
       - query: "r:r -alt:({boosterfun_no_land})" # Rare without boosterfun version
@@ -76,16 +79,16 @@ sheets:
 
   mythic:
     any:
-      - rawquery: "{boosterboosterfun_no_landfun} r:m" # Mythic boosterfun
+      - rawquery: "{boosterfun_no_land} r:m" # Mythic boosterfun
         rate: 1
         count: 34
-      - query: "r:m alt:({boosterfun})" # Mythic with one boosterfun version # TODO: Define properly
+      - query: "r:m alt:({boosterfun_no_land}) -{mythic_with_two_boosterfun}" # Mythic with one boosterfun version # TODO: Define properly
         rate: 12
-        count: 13
-      - query: "r:m alt:({boosterfun})" # Mythic with two boosterfun version # TODO: Define properly
-        rate: 13
         count: 8
-      - query: "r:m -alt:({boosterfun})" # Mythic without boosterfun version
+      - query: "{mythic_with_two_boosterfun}" # Mythic with two boosterfun version
+        rate: 13
+        count: 13
+      - query: "r:m -alt:({boosterfun_no_land})" # Mythic without boosterfun version
         rate: 14
         count: 25 - 13 - 5
 
@@ -116,16 +119,12 @@ sheets:
     any:
       - use: common
         chance: 608
-        count: 81
       - use: uncommon
         chance: 308
-        count: 100
       - use: rare_mythic
         chance: 75
-        count: 85
       - rawquery: "{borderless_land}"
         chance: 9
-        count: 5
 
   non_foil_land:
     any:
@@ -145,7 +144,7 @@ sheets:
 
   source_material:
     rawquery: "{source_material}"
-    count: 40
+    count: 60
 
 
   

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -1,0 +1,151 @@
+# Marvel Super Heroes
+# Play Booster
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-marvel-super-heroes
+# - https://magic.wizards.com/en/products/marvel/marvel-super-heroes/card-image-gallery
+# - https://scryfall.com/sets/msh
+# - https://scryfall.com/sets/msc
+# - https://scryfall.com/sets/mar
+
+pack:
+  common_source:
+    - common: 7
+      chance: 23
+    - common: 6
+      source_material: 1
+      chance: 1
+  uncommon: 3
+  wildcard: 1
+  rare_mythic: 1
+  foil: 1
+  land:
+    - non_foil_land: 1
+      chance: 80
+    - foil_land: 1
+      chance: 20
+
+
+queries:
+  dual_land: "e:{set} number:257-259,262,265,268,270-273"
+  city_calm_chaos: "e:{set} number:277-286"
+  basic_land: "e:{set} number:287-296"
+  boosterfun: "e:{set} number:297-379"
+# 380-384: Borderless Lands (5R) (5)
+  source_material: "e:MAR number:41-100"
+
+ 
+sheets:
+  common:
+    # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene commons.
+    any:
+      - rawquery: "{boosterfun} r:c"
+        rate: 1
+        count: 3
+      # - query: "r:c alt:({boosterfun})"
+      #   rate: 2
+      #   count: 3
+      # - query: "r:c -alt:({boosterfun}) -{dual_land}"
+      #   rate: 3
+      #   count: 81 - 3
+
+  uncommon:
+    # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene uncommons.
+    any:
+      - rawquery: "{boosterfun} r:u"
+        rate: 1
+        count: 12
+      - query: "r:u alt:({boosterfun})"
+        rate: 2
+        count: 12
+      - query: "r:u -alt:({boosterfun})"
+        rate: 3
+        count: 100 - 12
+
+  rare:
+    # TODO: Define correct ratio after all cards are spoiled
+    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
+    any:
+      - rawquery: "{boosterfun} r:r" # TODO: Make sure this boosterfun doesn't include rare borderless land
+        rate: 1
+        count: 34 # TODO: Only if all boosterfun rares are different
+      - query: "r:r alt:({boosterfun})"
+        rate: 6 # TODO: Update
+        count: 34
+      - query: "r:r -alt:({boosterfun})"
+        rate: 7 # TODO: Update
+        count: 60 - 34
+
+  mythic:
+    # TODO: Define correct ratio after all cards are spoiled
+    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
+    any:
+      - rawquery: "{boosterfun} r:m"
+        rate: 1
+        count: 34 # TODO: Only if all boosterfun mythics are different
+      - query: "r:m alt:({boosterfun})"
+        rate: 6 # TODO: Update
+        count: 34
+      - query: "r:m -alt:({boosterfun})"
+        rate: 7 # TODO: Update
+        count: 60 - 34
+
+  rare_mythic:
+    any:
+      - use: rare
+        chance: 6
+      - use: mythic
+        chance: 1
+
+  wildcard:
+    any:
+      - use: common
+        chance: 130
+      - use: uncommon
+        chance: 667
+      - use: rare_mythic
+        chance: 203
+      # TODO: Add rare borderless land
+
+  foil:
+  # C:U seems to be 2:1 and R:M also 2:1 # TODO: Update, review all chances in this slot
+    foil: true
+    any:
+      - any:
+        - use: common
+          rate: 2
+        - use: uncommon
+          rate: 1
+        chance: 544 + 336 # 54.4% + 33.6% = 88% # TODO: Update
+      - any: # TODO: Just use rare_mythic
+        - use: rare
+          chance: 6
+        - use: mythic
+          chance: 1
+        chance: 67 + 11 + 10 # Add the extra 1% for the boosterfun 
+
+  non_foil_land:
+    any:
+      - rawquery: "{basic_land}" # Default frame basic land
+        rate: 1
+        count: 10
+      - rawquery: "{city_calm_chaos}"
+        rate: 1
+        count: 10
+      - rawquery: "{dual_land}"
+        rate: 2
+        count: 10
+
+  foil_land:
+    foil: true
+    use: non_foil_land
+
+  source_material:
+    rawquery: "{source_material}"
+    count: 40
+
+
+  
+
+ 
+
+  

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -67,7 +67,7 @@ sheets:
       - rawquery: "{boosterfun_no_land} r:r" # Rare boosterfun
         rate: 1
         count: 34
-      - query: "r:r alt:({boosterfun_no_land}) -{rare_with_two_boosterfun}" # Rare with one boosterfun version # TODO: Define properly
+      - query: "r:r alt:({boosterfun_no_land}) -{rare_with_two_boosterfun}" # Rare with one boosterfun version
         rate: 6
         count: 24
       - query: "{rare_with_two_boosterfun})" # Rare with two boosterfun versions
@@ -82,7 +82,7 @@ sheets:
       - rawquery: "{boosterfun_no_land} r:m" # Mythic boosterfun
         rate: 1
         count: 34
-      - query: "r:m alt:({boosterfun_no_land}) -{mythic_with_two_boosterfun}" # Mythic with one boosterfun version # TODO: Define properly
+      - query: "r:m alt:({boosterfun_no_land}) -{mythic_with_two_boosterfun}" # Mythic with one boosterfun version
         rate: 12
         count: 8
       - query: "{mythic_with_two_boosterfun}" # Mythic with two boosterfun version
@@ -90,7 +90,7 @@ sheets:
         count: 13
       - query: "r:m -alt:({boosterfun_no_land})" # Mythic without boosterfun version
         rate: 14
-        count: 25 - 13 - 5
+        count: 25 - 13 - 8
 
   rare_mythic:
     any:
@@ -145,7 +145,6 @@ sheets:
   source_material:
     rawquery: "{source_material}"
     count: 60
-
 
   
 ####### Rare and Mythic slots:

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -41,12 +41,12 @@ sheets:
       - rawquery: "{boosterfun} r:c"
         rate: 1
         count: 3
-      # - query: "r:c alt:({boosterfun})"
-      #   rate: 2
-      #   count: 3
-      # - query: "r:c -alt:({boosterfun}) -{dual_land}"
-      #   rate: 3
-      #   count: 81 - 3
+      - query: "r:c alt:({boosterfun})"
+        rate: 2
+        count: 3
+      - query: "r:c -alt:({boosterfun}) -{dual_land}"
+        rate: 3
+        count: 81 - 3
 
   uncommon:
     # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene uncommons.

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -24,77 +24,77 @@ pack:
     - foil_land: 1
       chance: 20
 
-
 queries:
   dual_land: "e:{set} number:257-259,262,265,268,270-273"
   city_calm_chaos: "e:{set} number:277-286"
   basic_land: "e:{set} number:287-296"
-  boosterfun: "e:{set} number:297-379"
-# 380-384: Borderless Lands (5R) (5)
+  boosterfun_no_land: "e:{set} number:297-379"
+  borderless_land: "e:{set} number:380-384"
   source_material: "e:MAR number:41-100"
 
- 
 sheets:
   common:
     # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene commons.
     any:
-      - rawquery: "{boosterfun} r:c"
+      - rawquery: "{boosterfun_no_land} r:c"
         rate: 1
         count: 3
-      - query: "r:c alt:({boosterfun})"
+      - query: "r:c alt:({boosterfun_no_land})"
         rate: 2
         count: 3
-      - query: "r:c -alt:({boosterfun}) -{dual_land}"
+      - query: "r:c -alt:({boosterfun_no_land}) -{dual_land}"
         rate: 3
         count: 81 - 3
 
   uncommon:
     # By doing the math on the percentages given by Wizards, we come to the 3:1 rate between normal and scene uncommons.
     any:
-      - rawquery: "{boosterfun} r:u"
+      - rawquery: "{boosterfun_no_land} r:u"
         rate: 1
         count: 12
-      - query: "r:u alt:({boosterfun})"
+      - query: "r:u alt:({boosterfun_no_land})"
         rate: 2
         count: 12
-      - query: "r:u -alt:({boosterfun})"
+      - query: "r:u -alt:({boosterfun_no_land})"
         rate: 3
         count: 100 - 12
 
   rare:
-    # TODO: Define correct ratio after all cards are spoiled
-    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
     any:
-      - rawquery: "{boosterfun} r:r" # TODO: Make sure this boosterfun doesn't include rare borderless land
+      - rawquery: "{boosterfun_no_land} r:r" # Rare boosterfun
         rate: 1
-        count: 34 # TODO: Only if all boosterfun rares are different
-      - query: "r:r alt:({boosterfun})"
-        rate: 6 # TODO: Update
         count: 34
-      - query: "r:r -alt:({boosterfun})"
-        rate: 7 # TODO: Update
-        count: 60 - 34
+      - query: "r:r alt:({boosterfun_no_land})" # Rare with one boosterfun version # TODO: Define properly
+        rate: 6
+        count: 24
+      - query: "r:r alt:({boosterfun_no_land})" # Rare with two boosterfun versions # TODO: Define properly
+        rate: 7
+        count: 5
+      - query: "r:r -alt:({boosterfun_no_land})" # Rare without boosterfun version
+        rate: 8
+        count: 60 - 24 - 5
 
   mythic:
-    # TODO: Define correct ratio after all cards are spoiled
-    # By doing the math on the percentages given by Wizards, we come to the 7:1 rate between normal and boosterfun rares and mythics.
     any:
-      - rawquery: "{boosterfun} r:m"
+      - rawquery: "{boosterboosterfun_no_landfun} r:m" # Mythic boosterfun
         rate: 1
-        count: 34 # TODO: Only if all boosterfun mythics are different
-      - query: "r:m alt:({boosterfun})"
-        rate: 6 # TODO: Update
         count: 34
-      - query: "r:m -alt:({boosterfun})"
-        rate: 7 # TODO: Update
-        count: 60 - 34
+      - query: "r:m alt:({boosterfun})" # Mythic with one boosterfun version # TODO: Define properly
+        rate: 12
+        count: 13
+      - query: "r:m alt:({boosterfun})" # Mythic with two boosterfun version # TODO: Define properly
+        rate: 13
+        count: 8
+      - query: "r:m -alt:({boosterfun})" # Mythic without boosterfun version
+        rate: 14
+        count: 25 - 13 - 5
 
   rare_mythic:
     any:
       - use: rare
-        chance: 6
+        chance: 2 * 60 # Equivalent to 2:1 rate
       - use: mythic
-        chance: 1
+        chance: 1 * 25
 
   wildcard:
     any:
@@ -102,26 +102,30 @@ sheets:
         chance: 130
       - use: uncommon
         chance: 667
-      - use: rare_mythic
-        chance: 203
-      # TODO: Add rare borderless land
-
+      - use: rare
+        # R:M don't seem to be 2:1 in this slot
+        chance: 172
+      - use: mythic
+        chance: 21
+      - rawquery: "{borderless_land}"
+        chance: 10
+        count: 5
+      
   foil:
-  # C:U seems to be 2:1 and R:M also 2:1 # TODO: Update, review all chances in this slot
     foil: true
     any:
-      - any:
-        - use: common
-          rate: 2
-        - use: uncommon
-          rate: 1
-        chance: 544 + 336 # 54.4% + 33.6% = 88% # TODO: Update
-      - any: # TODO: Just use rare_mythic
-        - use: rare
-          chance: 6
-        - use: mythic
-          chance: 1
-        chance: 67 + 11 + 10 # Add the extra 1% for the boosterfun 
+      - use: common
+        chance: 608
+        count: 81
+      - use: uncommon
+        chance: 308
+        count: 100
+      - use: rare_mythic
+        chance: 75
+        count: 85
+      - rawquery: "{borderless_land}"
+        chance: 9
+        count: 5
 
   non_foil_land:
     any:
@@ -145,7 +149,6 @@ sheets:
 
 
   
-
- 
-
-  
+####### Rare and Mythic slots:
+# These slots are getting quite complicated. Rares and mythics can have 0,1 or 2 boosterfun alternatives.
+# I did what I could to work with Wizards numbers and to keep all rares/mythics equally likely independently of the number of boosterfun versions.

--- a/indexer/lib/patches/patch_base_size.rb
+++ b/indexer/lib/patches/patch_base_size.rb
@@ -4,6 +4,7 @@ class PatchBaseSize < Patch
   def call
     sizes = {
       "ecl" => 273, # up to the last normal basic
+      "msh" => 295, # up to and including all basic lands (fullart and normal ones)
       "tmt" => 195, # up to first set of basics (but they are fancy ones, boring ones are have much higher numbers)
       "sos" => 281, # up to and including all basic lands (fullart and normal ones)
     }


### PR DESCRIPTION
MSH

1-276: normal cards (81C, 100U, 60R, 25M, 10 dual lands) (276)
277-286: Full-Art City Calm and City Chaos Basic Lands (10)
287-296: normal basic lands(10)
297-313: Showcase Panel Cards (11R, 6M) (17)
314-351: Borderless Scene Cards (3C, 12U, 8R, 15M) (38)
352-379: Borderless Logo Cards (15R, 13M) (28)
380-384: Borderless Lands (5R) (5)
385: Textless cosmic foil version of The Mind Stone
386: A traditional foil borderless Gauntlet version of The Mind Stone
387-401: Borderless Classic Comic Cards (15M) (15)
402-429: Extended-art (24R, 4M) (28)
431-432: Gift Bundle
433-442: Surge Foil City Calm and City Chaos Basic Lands
443-453: Surge Foil Cards

MSC

1-7: Borderless Face Commanders (7)
8-120: Commander Deck New Cards (113)
121:275: Commander Deck New Art Reprints (155)
276:290: Commander Deck Reflavored Reprints (15)
291-500: Commander Deck Extended Art (210) 
501-506: Scene: Heroes United (6R) (6)
507-512: Scene: Villains Unleashed (6R) (6)
517-582 : Beginner Box
583-767: Jumpstart Booster new to magic (37C, 92U, 45R, 11M) (185)
768-828, 874: Jumpstart Booster reprint (37C, 21U, 4R, 0M) (62)
829-833: Welcome Deck Legends (5) (appear in Collector Booster)
834-857: Jumpstart Beginner Box (24) (doesn't appear in Collector Booster)
858-873: Basic lands Beginner Box(16) (doesn't appear in Collector Booster)
24+16=40 -> 2x20 jumpstart decks / Tutorial decks
875-881: Surge foil Borderless Face Commanders (7)
882-883: More surge foil (2)

MAR
41-100: Source Material (60)

