### PR TITLE
Fix MH3 collector sample booster: drop fetches, ripple foils, retro rare/mythic foils

### DIFF
--- a/data/boosters/mh3-collector-sample.yaml
+++ b/data/boosters/mh3-collector-sample.yaml
@@ -1,4 +1,6 @@
 # data from https://magic.wizards.com/en/news/feature/collecting-modern-horizons-3
+# community review (https://github.com/taw/magic-search-engine/issues/442):
+# no fetchlands, no ripple foils, no rare/mythic retro foils
 pack:
 - foil_retro: 1
   rm:
@@ -14,18 +16,10 @@ sheets:
       rate: 4
     - rawquery: "e:mh3 r:c number:384-441"
       rate: 8
-    - rawquery: "e:mh3 r:r number:384-441"
-      rate: 2
-    - rawquery: "e:mh3 r:m number:384-441"
-      rate: 1
     - rawquery: "e:h2r r:u"
       rate: 4
     - rawquery: "e:h2r r:c"
       rate: 8
-    - rawquery: "e:h2r r:r"
-      rate: 2
-    - rawquery: "e:h2r r:m"
-      rate: 1
   showcase_rm:
     any:
     - # two versions mythic
@@ -34,11 +28,9 @@ sheets:
     - # one version mythic
       rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
       rate: 6
-    - # three versions rare
-      rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
-      rate: 4
     - # two versions rare
-      rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+      # (the only three-version rares are the fetchlands, which don't appear in this product)
+      rawquery: "e:mh3 number:320-467 r:r -is:fetchland alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
       rate: 6
     - # one version rare
       rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
@@ -59,5 +51,27 @@ sheets:
       rate: 12
       count: 52
   foil_showcase_rm:
+    # same as showcase_rm, but without the retro frame cards (e:mh3 number:384-441
+    # and e:h2r, whose foils would be retro foils) and without the m3c rares
+    # (whose foils are ripple foils), so version counts differ
     foil: true
-    use: showcase_rm
+    any:
+    - # two versions mythic
+      rawquery: "e:mh3 number:320-383,442-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467))) -is:foilonly"
+      rate: 3
+    - # one version mythic
+      rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:447-467))) -is:foilonly"
+      rate: 6
+    - # one version rare
+      # (without the retro versions no rare has two versions left, except the
+      # fetchlands, which don't appear in this product)
+      rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:447-467))) -is:foilonly"
+      rate: 12
+    - rawquery: "e:m3c number:9-16"
+      rate: 6
+      count: 8
+      # foil borderless mythic
+    - rawquery: "e:m3c number:25-31"
+      rate: 6
+      count: 7
+      # foil extended mythic

--- a/data/boosters/mh3-collector-sample.yaml
+++ b/data/boosters/mh3-collector-sample.yaml
@@ -8,6 +8,26 @@ pack:
     chance: 2
   - foil_showcase_rm: 1
     chance: 1
+queries:
+  # the four showcase treatments a rare/mythic can appear in
+  borderless: "e:{set} number:320-361,381-383,442-446a"
+  profile:    "e:{set} number:362-380"
+  retro:      "e:{set} number:384-441"
+  textured:   "e:{set} number:447-467"
+  # a card shows up once per treatment it was printed in; these buckets pick
+  # cards by how many of the four treatments exist, so each is weighted right.
+  # exactly one treatment:
+  one_version: "({borderless} -alt:{profile} -alt:{retro} -alt:{textured}) or (-alt:{borderless} {profile} -alt:{retro} -alt:{textured}) or (-alt:{borderless} -alt:{profile} {retro} -alt:{textured}) or (-alt:{borderless} -alt:{profile} -alt:{retro} {textured})"
+  # two or more treatments (mythics top out at two):
+  two_plus_versions: "(alt:{borderless} alt:{profile}) or (alt:{borderless} alt:{retro}) or (alt:{profile} alt:{retro}) or (alt:{textured} alt:{borderless}) or (alt:{textured} alt:{profile}) or (alt:{textured} alt:{retro})"
+  # exactly two treatments (rares can have three, so this is spelled out):
+  two_versions: "(alt:{borderless} alt:{profile} -alt:{retro} -alt:{textured}) or (alt:{borderless} -alt:{profile} alt:{retro} -alt:{textured}) or (-alt:{borderless} alt:{profile} alt:{retro} -alt:{textured}) or (alt:{borderless} -alt:{profile} -alt:{retro} alt:{textured}) or (-alt:{borderless} alt:{profile} -alt:{retro} alt:{textured}) or (-alt:{borderless} -alt:{profile} alt:{retro} alt:{textured})"
+  # foil showcases drop the retro treatment (its foils would be retro foils),
+  # so the foil sheet only counts borderless/profile/textured.
+  # exactly one non-retro treatment:
+  one_version_nonretro: "({borderless} -alt:{profile} -alt:{textured}) or (-alt:{borderless} {profile} -alt:{textured}) or (-alt:{borderless} -alt:{profile} {textured})"
+  # two or more non-retro treatments (mythics top out at two):
+  two_plus_versions_nonretro: "(alt:{borderless} alt:{profile}) or (alt:{borderless} alt:{textured}) or (alt:{profile} alt:{textured})"
 sheets:
   foil_retro:
     foil: true
@@ -22,18 +42,18 @@ sheets:
       rate: 8
   showcase_rm:
     any:
-    - # two versions mythic
-      rawquery: "e:mh3 number:320-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:320-361,381-383,442-446a)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:384-441))) -is:foilonly"
+    - # mythic in two showcase treatments
+      rawquery: "e:{set} number:320-467 r:m alt:{two_plus_versions} -is:foilonly"
       rate: 3
-    - # one version mythic
-      rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+    - # mythic in one showcase treatment
+      rawquery: "e:{set} r:m {one_version} -is:foilonly"
       rate: 6
-    - # two versions rare
-      # (the only three-version rares are the fetchlands, which don't appear in this product)
-      rawquery: "e:mh3 number:320-467 r:r -is:fetchland alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+    - # rare in two showcase treatments
+      # (the only three-version rares are the fetchlands, which aren't in this product)
+      rawquery: "e:{set} number:320-467 r:r -is:fetchland alt:{two_versions} -is:foilonly"
       rate: 6
-    - # one version rare
-      rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+    - # rare in one showcase treatment
+      rawquery: "e:{set} r:r {one_version} -is:foilonly"
       rate: 12
     - rawquery: "e:h2r r:m"
       rate: 6
@@ -51,21 +71,21 @@ sheets:
       rate: 12
       count: 52
   foil_showcase_rm:
-    # same as showcase_rm, but without the retro frame cards (e:mh3 number:384-441
-    # and e:h2r, whose foils would be retro foils) and without the m3c rares
-    # (whose foils are ripple foils), so version counts differ
+    # like showcase_rm, but without the retro-frame cards (e:mh3 number:384-441 and
+    # e:h2r, whose foils would be retro foils) and without the m3c rares (whose foils
+    # are ripple foils), so the version counts differ
     foil: true
     any:
-    - # two versions mythic
-      rawquery: "e:mh3 number:320-383,442-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467))) -is:foilonly"
+    - # mythic in two non-retro showcase treatments
+      rawquery: "e:{set} number:320-383,442-467 r:m alt:{two_plus_versions_nonretro} -is:foilonly"
       rate: 3
-    - # one version mythic
-      rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:447-467))) -is:foilonly"
+    - # mythic in one non-retro showcase treatment
+      rawquery: "e:{set} r:m {one_version_nonretro} -is:foilonly"
       rate: 6
-    - # one version rare
-      # (without the retro versions no rare has two versions left, except the
-      # fetchlands, which don't appear in this product)
-      rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:447-467))) -is:foilonly"
+    - # rare in one non-retro showcase treatment
+      # (without the retro version no rare has two versions left, except the
+      # fetchlands, which aren't in this product)
+      rawquery: "e:{set} r:r {one_version_nonretro} -is:foilonly"
       rate: 12
     - rawquery: "e:m3c number:9-16"
       rate: 6


### PR DESCRIPTION
Fixes the errors flagged by community review in the MH3 Collector Sample booster (https://mtg.wtf/pack/mh3-collector-sample).

Per #442, the sample booster should contain **no fetchlands, no ripple foils, and no rare/mythic retro foils**. The old definition let all three slip in:

- **Fetchlands** — the five allied fetches are the only rares in MH3 with three showcase versions (borderless #352–361, retro #435–441, extended #463–467), so the "three versions rare" query in `showcase_rm` matched nothing *but* fetchlands. They also reached `foil_retro` via its rare line.
- **Ripple foils** — `m3c` #32–83 are the new commander rares; their nonfoil versions are fine, but their foil finish is ripple foil, so they were wrong in the foil showcase sheet.
- **Rare/mythic retro foils** — came from the `r:r`/`r:m` lines in `foil_retro`, plus the retro range (mh3 #384–441) and `h2r` being reachable through `foil_showcase_rm`.

## Changes

- `foil_retro`: dropped the four rare/mythic lines — now foil retro commons/uncommons only (also removes the retro fetches).
- `showcase_rm`: removed the all-fetchland "three versions rare" query and added a defensive `-is:fetchland` to the rare line.
- `foil_showcase_rm`: no longer `use: showcase_rm`. It now has its own queries with the retro range and `h2r` removed and the version-count math redone; with retro gone no rare has two versions left (except fetches), so the rare part collapses to a single one-version-rare query. The m3c rare line is dropped (foil = ripple), while the m3c borderless/extended commanders stay.
- Regenerated `index/booster_index.json`.

## Verification

Auditing the generated sheets shows zero fetchlands, zero ripple foils, and zero foil retro rares/mythics; the foil showcase sheet equals the nonfoil one minus the 30 retro printings. 20 opened sample packs all had the correct shape (foil retro c/u + nonfoil-or-foil showcase r/m).

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)