### PR TITLE
Map foil LCI Commander cards in collector foil extended-commander slot

### DIFF
--- a/data/boosters/lci-collector.yaml
+++ b/data/boosters/lci-collector.yaml
@@ -51,7 +51,11 @@ sheets:
       rate: 3
   foil_extended_commander_rare_mythic:
     foil: true
-    filter: "e:lcc frame:extendedart"
+    # The traditional-foil version of this slot is not just the extended-art
+    # commanders: the article says it also includes "the new Commander content
+    # found in Set Boosters" - i.e. the regular #1-16 and showcase #17-20
+    # commander cards - in foil. Without number:1-20 their foils are productless.
+    filter: "e:lcc (number:1-20 or frame:extendedart)"
     use: rare_mythic
   showcase_rare_mythic:
     any:


### PR DESCRIPTION
Using the `is:productless` filter on mtgban (`s:LCC is:productless`) surfaced **12 foil LCC cards with no product assignment** — all from the Commander set, #9–20:

- 6 regular-frame rares: Illustrious Wanderglyph (#9), Altar of the Wretched (#10), Ore-Rich Stalactite (#11), Contest of Claws (#12), Tetzin, Gnome Champion (#13), Xavier Sal (#14)
- 2 regular-frame mythics: Eye of Ojer Taq (#15), Paleontologist's Pick-Axe (#16)
- 4 showcase mythics: Admiral Brass (#17), Clavileño (#18), Hakbal (#19), Pantlaza (#20)

## Root cause

No booster sheet reached the **foil** versions of the regular/showcase commander cards:
- the Set Booster only covers them **non-foil** (wildcard slot),
- the Commander **decks** only carry the #1–8 face/secondary commanders in foil (which is why #1–8 aren't productless), and
- the Collector Booster's `foil_extended_commander_rare_mythic` sheet filtered on `frame:extendedart` only — so the #1–20 base/showcase foils fell through.

## Fix

The WOTC [collecting article](https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan) says the traditional-foil version of this slot *"includes new Commander cards in extended art, **including the new Commander content found in Set Boosters**"* — and its stated "6 rares and 14 mythic rares" is exactly the 20 `e:lcc number:1-20` commander cards (14 mythics is impossible for the 12 extended-art mythics, confirming it's the base cards). So the foil slot is the **union** of the extended-art commanders and the #1–20 set-booster commanders:

```yaml
filter: "e:lcc (number:1-20 or frame:extendedart)"
```

## Verification

With a **deck- and booster-inclusive** productless check (mirrors mtgban's `is:productless`):
- LCC foil rares/mythics productless: **12 → 0**
- no extended-art foil is orphaned (replacing instead of unioning would have made #21–36 productless)
- the foil sheet stays all-foil with **no phantom foils** (the `is:foil` restriction excludes nonfoil-only extended cards)
- the collector pack still builds to **15 cards/pack**

🤖 Generated with [Claude Code](https://claude.com/claude-code)