### PR TITLE
Map foil WOE Commander cards in collector foil extended-art slot

### DIFF
--- a/data/boosters/woe-collector.yaml
+++ b/data/boosters/woe-collector.yaml
@@ -31,7 +31,12 @@ sheets:
     use: rare_mythic
   foil_extended_art:
     foil: true
-    use: extended_art
+    # The traditional-foil version of this slot also carries the new-to-Magic
+    # Commander cards (woc #21-28) in regular frame, not just extended-art: the
+    # article says it includes "the new Commander content found in Set Boosters".
+    # Without number:21-28 their foils are productless.
+    filter: "((e:woe or e:woc) frame:extendedart -number:381) or (e:woc number:21-28)"
+    use: rare_mythic
   enchanting_tales_rare_mythic:
     any:
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"


### PR DESCRIPTION
Next set in the `is:productless` sweep (follow-up to the LCI fix in #446).

`s:WOC is:productless` on mtgban surfaces **8 foil WOC cards with no product** — the new-to-Magic Commander cards #21–28:

- 5 Courts (rare): Court of Ardenvale (#21), Vantress (#22), Locthwain (#23), Embereth (#24), Garenbrig (#25)
- Korvold, Gleeful Glutton (#26, mythic), Brenard, Ginger Sculptor (#27, mythic)
- Throne of Eldraine (#28, rare)

## Root cause (same as #446)

No booster reached the **foil** versions of the regular-frame commander cards:
- the Set Booster covers `e:woc number:1-28` **non-foil** only (wildcard slot),
- the Commander **decks** carry only the #1–4 face commanders in foil (and #5–20 are nonfoil-only reprints, so no foil issue), and
- the Collector's `foil_extended_art` slot filtered on `frame:extendedart` only — so the #21–28 regular foils fell through.

## Fix

The WOTC [collecting article](https://magic.wizards.com/en/news/feature/collecting-wilds-of-eldraine) says this slot's traditional-foil version *"includes new Commander cards in extended art, **including the new Commander content found in Set Boosters**"* ("6 rares and 6 mythic rares" in foil). Give `foil_extended_art` its own filter unioning the regular #21–28 commander cards:

```yaml
filter: "((e:woe or e:woc) frame:extendedart -number:381) or (e:woc number:21-28)"
```

The shared non-foil `extended_art` sheet is left untouched.

## Verification

Deck- and booster-inclusive productless check (reproduces mtgban's result exactly):
- WOC foil rares/mythics productless: **8 → 0**
- no extended-art foil orphaned (union, not replace)
- foil sheet stays all-foil with **no phantom foils**
- collector pack still builds to **16 cards/pack**

🤖 Generated with [Claude Code](https://claude.com/claude-code)