### PR TITLE
Map foil NEO Commander cards in set/collector foil rare-mythic slots

### DIFF
--- a/data/boosters/neo-collector.yaml
+++ b/data/boosters/neo-collector.yaml
@@ -55,6 +55,9 @@ sheets:
     use: ninja_common_uncommon
   foil_rare_mythic:
     foil: true
+    # also carries the new-to-Magic Commander cards that only appear in Set and
+    # Collector Boosters (nec #31-38); without them their foils are productless
+    filter: "(e:neo is:baseset) or (e:nec number:31-38)"
     use: rare_mythic
   extended_commander:
     filter: "e:nec frame:extendedart"

--- a/data/boosters/neo-set.yaml
+++ b/data/boosters/neo-set.yaml
@@ -101,6 +101,10 @@ sheets:
         rate: 12
       - use: rare_has_no_showcase
         rate: 16
+      # foil version of the new-to-Magic Commander cards that only appear in Set
+      # and Collector Boosters (nec #31-38); mirrors the nonfoil wildcard slot
+      - rawquery: "e:nec number:31-38 r:r"
+        rate: 16
       - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
@@ -108,5 +112,7 @@ sheets:
       - use: mythic_has_showcase
         rate: 6
       - use: mythic_has_no_showcase
+        rate: 8
+      - rawquery: "e:nec number:31-38 r:m"
         rate: 8
       chance: 3


### PR DESCRIPTION
Next set in the `is:productless` sweep (after LCI #446, WOE #447).

`s:NEC is:productless -t:token` surfaces **8 foil NEC cards with no product** — the new-to-Magic Commander cards #31–38: the Myojin cycle (Blooming Dawn #31, Cryptic Dreams #33, Grim Betrayal #34, Roaring Blades #36, Towering Might #38), Yoshimaru (#32), Ruthless Technomancer (#35), and Go-Shintai of Life's Origin (#37).

## Why this one is different from LCI/WOE

NEO has **no foil commander slot to widen** — the collector's commander slot is nonfoil-only (the extended-art commanders #39–76 are literally `foiling: nonfoil`), and the decks only carry the face commanders (#1, #2) in foil.

Per the [mtg.wiki Commander decks page](https://mtg.wiki/page/Kamigawa:_Neon_Dynasty/Commander_decks): *"Eight additional cards can only be found in the Set and Collector Boosters and aren't found in the … Commander decks, with five of these forming the New Myojin cycle."* So #31–38 are **Set/Collector Booster rares/mythics** that carry the `nec` set code — not deck cards.

Their **nonfoil** is already mapped (`neo-set` wildcard has explicit `e:nec number<=38 r:r/r:m` buckets). Only the **foil** side was missing: the set booster's `foil_with_showcase` and the collector's `foil_rare_mythic` both queried `e:neo` only.

## Fix

- **neo-set** `foil_with_showcase`: add `e:nec number:31-38 r:r` (rate 16) and `r:m` (rate 8), mirroring the slot's own nonfoil wildcard entries.
- **neo-collector** `foil_rare_mythic`: widen its filter to `(e:neo is:baseset) or (e:nec number:31-38)`.

## Verification

Deck- and booster-inclusive productless check (reproduces mtgban exactly):
- NEC foil rares/mythics productless: **8 → 0**
- both foil sheets pick up nec #31–38 with **no phantom foils** (the `is:foil` restriction drops the nonfoil-only reprints #5–30)
- both packs still build to their prior sizes (set 12.25, collector 15.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)