### PR TITLE
Map foil ONE commander/jumpstart cards in set booster foil slot

### DIFF
--- a/data/boosters/one-set.yaml
+++ b/data/boosters/one-set.yaml
@@ -147,9 +147,22 @@ sheets:
       chance: 5
     - any:
       - any:
-        - use: rare_with_showcase
+        # foil versions of the commander (onc) and jumpstart (#404-408) cards that
+        # the nonfoil wildcard slot carries but this foil slot was missing, mirroring
+        # the wildcard's rare/mythic structure
+        - any: # Rare with commander and jumpstart options
+          - use: rare_with_showcase
+            chance: 60
+          - rawquery: "e:onc r:r is:baseset"
+            chance: 22
+          - rawquery: "e:{set} r:r number:404-408"
+            chance: 5
           chance: 6
-        - use: mythic_with_showcase
+        - any: # Mythic with commander options
+          - use: mythic_with_showcase
+            chance: 10
+          - rawquery: "e:onc r:m is:baseset"
+            chance: 3
           chance: 1
         chance: 59
       - use: prototype_praetor


### PR DESCRIPTION
Next in the `is:productless` sweep (after LCI #446, WOE #447, NEO #448).

`s:ONE,ONC is:productless -is:promopack` surfaces foil cards with no product across two groups, both from the **set booster's foil slot** being out of sync with its own nonfoil wildcard:

- **ONC #3–4** (Otharri, Vishgraz — the secondary commanders; #1–2 face commanders are deck-covered) and **ONC #21–28** (the new-to-Magic commander cards)
- **ONE #404–408** (Mite Overseer, Serum Sovereign, Kinzu, Rhuk, Goliath Hatchery — the Jumpstart cards)

## Root cause

In `one-set.yaml` the **wildcard** slot carries these in nonfoil — `e:onc r:r/r:m is:baseset` and `e:one r:r number:404-408` (lines 64–89) — but the **foil** slot's rare/mythic group only had `rare_with_showcase`/`mythic_with_showcase` (e:one main set), so the foil versions were productless.

## Fix

Mirror the wildcard's rare/mythic structure into the foil slot so it carries the same `onc` commander cards and `#404-408` Jumpstart cards in foil.

## Verification

Deck- and booster-inclusive productless check:
- ONC foil rares/mythics: **10 → 0**
- ONE Jumpstart foils (#404–408): now covered
- foil sheet picks up onc #1–4/#21–28 and one #404–408, **no phantom foils** (nonfoil-only reprints onc #5–20 correctly excluded), probabilities sum to 1

## Out of scope (separate products)

Not touched, since they aren't set-booster cards: **ONE #282–283** (Bundle promos) and **#284** (Buy-a-Box promo) — foilonly promos that belong to those products. #282–283 already resolve in mtgban (Bundle modeled); #284 (Buy-a-Box) would need that product modeled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)