### PR TITLE
Map foil DMU commander/set-exclusive cards in set booster foil slot

### DIFF
--- a/data/boosters/dmu-set.yaml
+++ b/data/boosters/dmu-set.yaml
@@ -76,14 +76,23 @@ sheets:
         rate: 16
       - use: rare_has_no_showcase
         rate: 24
+      # foil versions of the set-booster-exclusive rares (#282-286) and the
+      # commander cards (dmc #1-28) that the nonfoil wildcard slot carries but
+      # this foil slot was missing
+      - rawquery: "e:dmu number:282-286"
+        rate: 24
+      - rawquery: "e:dmc number:1-28 r:r"
+        rate: 24
       - rawquery: "e:dmu Ajani, Sleeper Agent -is:foilonly -frame:extendedart is:paper promo:boosterfun"
         rate: 1
       - rawquery: "e:dmu Sheoldred, the Apocalypse -is:foilonly -frame:extendedart is:paper promo:boosterfun number<=427"
         rate: 2
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Ajani, Sleeper Agent or Sheoldred, the Apocalypse)'
-        rate: 4 
+        rate: 4
       - use: mythic_has_showcase
         rate: 8
       - use: mythic_has_no_showcase
+        rate: 12
+      - rawquery: "e:dmc number:1-28 r:m"
         rate: 12
       chance: 3


### PR DESCRIPTION
Next in the `is:productless` sweep (after LCI #446, WOE #447, NEO #448, ONE #449). DMU/DMC is the same set-booster foil gap as ONE.

`s:DMU,DMC is:productless -t:token,emblem -is:promopack` surfaces:

- **DMU #282–286** (Serra Redeemer, Cosmic Epiphany, Tyrannical Pitlord, Ragefire Hellkite, Briar Hydra) — set-booster-exclusive rares
- **DMC #3–4** (secondary commanders) and **#21–28** (new commander cards)

## Root cause

In `dmu-set.yaml` the **wildcard** slot carries these in nonfoil — `e:dmu number:282-286`, `e:dmc number:1-28 r:r`, and `e:dmc number:1-28 r:m` (lines 36–50) — but the **foil** slot (`foil_with_showcase`) had none of them, so the foil versions were productless.

## Fix

Mirror those three entries into the foil slot's rare/mythic group at the same rates the wildcard uses (24/24/12).

## Verification

Deck- and booster-inclusive productless check:
- DMC foil rares/mythics: **10 → 0**
- DMU #282–286 foils: covered
- foil sheet picks up dmc #1–4/#21–28 and dmu #282–286, **no phantom foils**, probabilities sum to 1

## Out of scope (separate products)

Not touched, since they aren't set-booster cards: **DMU #428** (Buy-a-Box) and **#429** (Bundle) — foilonly promos. #429 already resolves in mtgban (Bundle modeled); #428 (Buy-a-Box) would need that product modeled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)