### PR TITLE
Map foil BRO commander/set-exclusive cards in set booster foil slot

### DIFF
--- a/data/boosters/bro-set.yaml
+++ b/data/boosters/bro-set.yaml
@@ -38,11 +38,21 @@ sheets:
         rate: 4
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
         rate: 6
+      # foil versions of the commander (brc #1-28) and set-booster-exclusive
+      # (#288-292) cards that the nonfoil wildcard carries but this foil slot was
+      # missing (the slot filter is e:bro is:baseset, which excludes them);
+      # rates are half the wildcard's, matching the rest of this foil slot
+      - rawquery: "e:brc r:r number<=28"
+        rate: 6
+      - rawquery: "e:{set} number:288-292"
+        rate: 6
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper"
         rate: 1
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
         rate: 2
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        rate: 3
+      - rawquery: "e:brc r:m number<=28"
         rate: 3
       chance: 3
   basic:


### PR DESCRIPTION
Next in the `is:productless` sweep (after LCI #446, WOE #447, NEO #448, ONE #449, DMU #450). Same set-booster foil gap.

`s:BRO,BRC is:productless -is:promopack` surfaces:

- **BRO #288–292** (Rescue Retriever, Geology Enthusiast, Terror Ballista, Artificer's Dragon, Woodcaller Automaton) — set-booster-exclusive rares
- **BRC #21–28** (the new commander cards)

## Root cause

In `bro-set.yaml` the **wildcard** slot carries these in nonfoil — `e:brc r:r/r:m number<=28` and `e:bro number:288-292` (they're `is:baseset` = false, hence the explicit entries) — but the **foil** slot (`foil_with_showcase`) is filtered on `(e:bro is:baseset -number:268-277) or (e:brr ...)`, which excludes both. So their foils were productless.

## Fix

Add the three entries to the foil slot's rare/mythic group at half the wildcard's rates (matching the rest of that foil slot).

## Verification

Deck- and booster-inclusive productless check:
- BRC foil rares/mythics: **8 → 0**
- BRO #288–292 foils: covered
- foil sheet picks up brc #1–4/#21–28 and bro #288–292, **no phantom foils**, probabilities sum to 1

## Out of scope (separate products)

**BRO #378** (Buy-a-Box) and **#379** (Bundle) — foilonly promos, not booster cards. #379 already resolves in mtgban (Bundle modeled); #378 (Buy-a-Box) is intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)