### PR TITLE
Map foil MOM Jumpstart cards and nonfoil MOC Talents in set booster

### DIFF
--- a/data/boosters/mom-set.yaml
+++ b/data/boosters/mom-set.yaml
@@ -15,7 +15,7 @@ pack:
     the_list: 1
     chance: 1
   finale_2:
-  - foil_with_showcase: 1
+  - mom_foil_with_showcase: 1
     chance: 24
   - foil_etched: 1
     chance: 1
@@ -58,18 +58,21 @@ sheets:
       - rawquery: "e:mom r:r number:323-337 is:paper"
         chance: 2 * 5
         count: 5
-      - rawquery: "e:moc r:r number:1-46 is:paper"
-        chance: 2 * 36
-        count: 36
+      # #72-79 (Planeswalker's Talents cycle etc.) only appear in Set and
+      # Collector Boosters, not the Commander decks, so their nonfoil is added
+      # to this commander bucket alongside #1-46
+      - rawquery: "e:moc r:r number:1-46,72-79 is:paper"
+        chance: 2 * 42
+        count: 42
       - rawquery: "e:mul r:r -is:foilonly is:paper"
         chance: 2 * 30
         count: 30
       - use: mythic_with_showcase
         count: 33
         chance: 20
-      - rawquery: "e:moc r:m number:1-46 is:paper"
-        chance: 10
-        count: 10
+      - rawquery: "e:moc r:m number:1-46,72-79 is:paper"
+        chance: 12
+        count: 12
       - rawquery: "e:mul r:m -is:foilonly is:paper"
         chance: 15
         count: 15
@@ -84,3 +87,10 @@ sheets:
     filter: "e:mul is:etched"
     use: base_1248_by_rarity
     count: 65
+  mom_foil_with_showcase:
+    # the shared base-set foil slot, but with its filter widened to also include
+    # the Jumpstart cards (#323-337): per the collecting article they appear in
+    # Set Boosters in traditional foil, but they are not is:baseset so the
+    # default e:mom is:baseset filter misses them
+    filter: "(e:mom is:baseset) or (e:mom number:323-337)"
+    use: foil_with_showcase


### PR DESCRIPTION
Next in the `is:productless` sweep (after LCI #446, WOE #447, NEO #448, ONE #449, DMU #450, BRO #451). This one is a bit more involved — it has a **nonfoil** gap too.

`s:MOM,MOC is:productless -is:promopack` (24 results on mtgban) breaks down into two real gaps:

### 1. MOM #323–337 — Jumpstart cards, missing in FOIL (15 cards)

The Jumpstart cycle (commons/uncommons/rares — Phyrexian Pegasus, Seedpod Caretaker, Surrak and Goreclaw, …). Their nonfoil comes from Jumpstart; the [collecting article](https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine) says they *"can be found in non-foil and traditional foil in **Set Boosters**"*. The set booster's foil slot (the shared `foil_with_showcase`) filters on `e:mom is:baseset`, which excludes them.

**Fix:** add `mom_foil_with_showcase`, which reuses that slot with the filter widened to `(e:mom is:baseset) or (e:mom number:323-337)`. The cards flow into the existing `has_no_showcase` buckets.

### 2. MOC #72–79 — Talents cycle, missing in NONFOIL (8 cards)

Planeswalker's Talents + Infernal Sovereign + Begin the Invasion. Their **foil** is covered (collector `foil_rare_mythic` lists `e:moc number:72-79`), but the **nonfoil** had no source: per [mtg.wiki](https://mtg.wiki/page/March_of_the_Machine/Commander_decks) they *"can only be found in Set and Collector's Boosters"* and are **not** in the Commander decks (verified).

**Fix:** extend the set booster wildcard's commander bucket from `e:moc number:1-46` to `number:1-46,72-79`.

## Verification

Deck- and booster-inclusive productless check:
- MOM #323–337 foils (all three rarities): now covered — the foil sheet has all 15 with **no phantoms**
- MOC #72–79 nonfoils: now covered — the wildcard has all 8 with **no phantoms**

## Notes

- The remaining MOC entries my local checker flags (`Heaven`/`Earth`, `Wear`/`Tear`, `Swift End`, …) are **split/adventure `a/b` faces** — a data-model artifact of this repo splitting them into separate printings. mtgban's 24 results do **not** include them.
- Out of scope (separate products): MOM **#386** (Bundle) and **#387** (Buy-a-Box) — foilonly promos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)