### PR TITLE
Fix e:snc->e:ncc typo so NCC commander cards appear in SNC set booster

### DIFF
--- a/data/boosters/snc-set.yaml
+++ b/data/boosters/snc-set.yaml
@@ -52,7 +52,11 @@ sheets:
         rate: 8
       - use: rare_has_no_showcase
         rate: 12
-      - rawquery: "e:snc number<=93 r:r"
+      # New Capenna Commander cards that appear in Set Boosters: the 10 mythic
+      # legends (#1-10) and the 6 rare / 2 mythic new cards (#86-93). This was
+      # "e:snc number<=93" - a typo that pointed at the main set (redundant with
+      # the showcase entries) instead of the commander set.
+      - rawquery: "e:ncc number:1-10,86-93 r:r"
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
         rate: 1
@@ -62,7 +66,7 @@ sheets:
         rate: 4
       - use: mythic_has_no_showcase
         rate: 6
-      - rawquery: "e:snc number<=93 r:m"
+      - rawquery: "e:ncc number:1-10,86-93 r:m"
         rate: 6
       chance: 125
   foil_with_showcase:
@@ -89,6 +93,9 @@ sheets:
         rate: 8
       - use: rare_has_no_showcase
         rate: 12
+      # foil New Capenna Commander cards (mirrors the wildcard's nonfoil entry)
+      - rawquery: "e:ncc number:1-10,86-93 r:r"
+        rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
@@ -96,6 +103,8 @@ sheets:
       - use: mythic_has_showcase
         rate: 4
       - use: mythic_has_no_showcase
+        rate: 6
+      - rawquery: "e:ncc number:1-10,86-93 r:m"
         rate: 6
       chance: 3
   gilded_foil:


### PR DESCRIPTION
Next in the `is:productless` sweep (after LCI #446, WOE #447, NEO #448, ONE #449, DMU #450, BRO #451, MOM #452). Mixed foil/nonfoil, and it turned out to be a one-character bug.

`s:NCC is:productless -is:promopack` surfaces:
- **#1–10** (the 10 mythic legends — Anhelo, Tivit, …) as **nonfoil**-productless (their foil is deck-covered, their extended-art is collector-covered)
- **#86–93** (the new commander cards — Bennie Bracks, Boxing Ring, …) as **both foil and nonfoil**

## Root cause: a typo

Every other set's set booster wildcard has an `e:<commander>` bucket. SNC's said **`e:snc number<=93`** — pointing at the *main* set. Those 14 rares are all `is:baseset`, already covered by the `rare_has_showcase` / `rare_has_no_showcase` entries — so it was a no-op double-count, and **no NCC card ever reached the set booster**, even though the legends and #86–93 are found there.

## Fix

Point it at `e:ncc number:1-10,86-93` (the 10 legends + the 6 rare / 2 mythic new cards), and add the matching foil entry to `foil_with_showcase`.

## Verification

Deck- and booster-inclusive productless check:
- NCC #1–10 nonfoil and #86–93 (both finishes): now covered, in both the wildcard (nonfoil) and foil slot, with **no phantom cards**
- remaining flagged entries are split-card `a/b` faces (Indulge//Excess, Dusk//Dawn, Commit//Memory) — a data-model artifact mtgban doesn't flag

## Scope note

I scoped the range to `1-10,86-93` (the cards the article/decks place in Set Boosters) rather than the literal `number<=93`, which would also pull in the ~76 other Commander-set new cards (#11–85). Those are deck-covered (not productless), so I left them out — easy to broaden if you'd rather the slot mirror the full commander set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)