### PR TITLE
Map foil LTR jumpstart cards and nonfoil LTC legends in set booster

### DIFF
--- a/data/boosters/ltr-set.yaml
+++ b/data/boosters/ltr-set.yaml
@@ -67,6 +67,15 @@ sheets:
       chance: 120
     - use: mythic_with_showcase
       chance: 20
+    # Cards that appear in the Set Booster but aren't is:baseset, so the sheets
+    # above miss them: the 5 Jumpstart rares (#282-286, also nonfoil from
+    # Jumpstart) and the 8 mythic Commander legends (#1-8, also foil from the
+    # decks). This sheet feeds both the wildcard (nonfoil) and the foil slot, so
+    # it covers both finishes at once.
+    - rawquery: "e:ltr number:282-286"
+      chance: 10
+    - rawquery: "e:ltc number:1-8"
+      chance: 8
   wildcard:
     any:
     - use: common_with_showcase


### PR DESCRIPTION
Final set in the `is:productless` sweep (after #446–#453).

`s:LTR,LTC is:productless -t:token -is:buyabox,tourney,playpromo,Storechampionship` surfaces 13 cards:
- **LTR #282–286** — the 5 Jumpstart rares (Saradoc, Elvish Mariner, Ringwraiths, Assault on Osgiliath, Elanor Gardner), missing in **FOIL** (their nonfoil comes from Jumpstart)
- **LTC #1–8** — the 8 mythic Commander legends (Éowyn, Frodo, Galadriel, Sauron, …), missing in **NONFOIL** (their foil comes from the decks)

## Root cause

Both groups appear in the Set Booster but are **not `is:baseset`**, so the generic `rare_with_showcase` / `mythic_with_showcase` sheets (which filter on baseset) never reach them.

## Fix

Add the two number ranges to `rare_mythic_with_showcase`. That sheet feeds **both** the wildcard (nonfoil) and the foil slot, so a single addition covers both finishes — the Jumpstart foils and the legend nonfoils — in one place.

The queries are number-specific (`e:ltr number:282-286`, `e:ltc number:1-8`), so they match only the Set Booster printings, **not the holiday-release variants** (which live at other numbers).

## Verification

Deck- and booster-inclusive productless check:
- LTR #282–286 and LTC #1–8: now covered in both finishes; wildcard and foil slot each pick them up with **no phantom cards**
- remaining flagged entries are the #166 Dusk//Dawn split `a/b` faces and the two digital-only Alchemy (rebalanced) cards — neither is flagged by mtgban

🤖 Generated with [Claude Code](https://claude.com/claude-code)