### PR TITLE
2XM: Box Topper Pack has 2 cards, not 1

### DIFF
--- a/data/boosters/2xm-box-topper.yaml
+++ b/data/boosters/2xm-box-topper.yaml
@@ -1,6 +1,6 @@
 name: "{set_name} Box Topper Pack"
 pack:
-  boxtopper: 1
+  boxtopper: 2
 sheets:
   boxtopper:
     filter: "e:2xm promo:boxtopper"


### PR DESCRIPTION
Each Double Masters booster box includes **two** foil box-topper cards, so the Box Topper Pack slot should be `boxtopper: 2` (was `1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)