### PR TITLE
THB: add missing Collector foil showcase slot (14 -> 15 cards)

### DIFF
--- a/data/boosters/thb-collector.yaml
+++ b/data/boosters/thb-collector.yaml
@@ -31,6 +31,7 @@ pack:
     foil_uncommon: 7
     chance: 20
   showcase: 1
+  foil_showcase: 1
   ancillary: 1
   rm_extended: 1
   foil_rare_mythic: 1
@@ -48,6 +49,12 @@ sheets:
       rate: 1
     - query: "r:m t:saga"
       rate: 1
+  foil_showcase:
+    # 15th Collector slot: a traditional-foil constellation/showcase card
+    # (article: foil showcase demigods/rares/borderless PWs). Same pool as
+    # the non-foil showcase slot, foil.
+    foil: true
+    use: showcase
   ancillary:
     # C/U/R/M rates guessed to be at 8x/4x/2x/1x multiples
     filter: "e:thb -promo:boosterfun number:269-297"


### PR DESCRIPTION
The [Theros Beyond Death Collector Booster Contents](https://magic.wizards.com/en/news/feature/theros-beyond-death-collector-booster-contents-2019-12-13) article specifies **15 cards**, including *both* a non-foil and a **traditional-foil constellation/showcase** card. `thb-collector.yaml` modeled only the non-foil `showcase` slot — 14 card slots total, with the foil showcase entirely absent.

Adds a `foil_showcase` slot drawing the same showcase pool as foil (verified: resolves to 24 foil cards, mirroring the 24 non-foil showcase cards). Pack is now 15 cards.

(The foil token — the 16th item — remains unmodeled, consistent with the engine not representing tokens.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)