### PR TITLE
MH2: include MH1 (h1r) retro cards in Collector foil-etched pools

### DIFF
--- a/data/boosters/mh2-collector.yaml
+++ b/data/boosters/mh2-collector.yaml
@@ -35,12 +35,12 @@ sheets:
   etched_common_uncommon:
     foil: true
     etched: true
-    filter: "e:mh2 is:etched"
+    filter: "(e:mh2 or e:h1r) is:etched"
     use: common_uncommon
-    count: 13+30
+    count: 66 # 13 commons + 53 uncommons (incl. the MH1/h1r retro etched)
   etched_rare_mythic:
     foil: true
     etched: true
-    filter: "e:mh2 is:etched"
+    filter: "(e:mh2 or e:h1r) is:etched"
     use: rare_mythic
-    count: 50+10
+    count: 78 # incl. the MH1/h1r retro etched rares & mythics


### PR DESCRIPTION
The [Collecting Modern Horizons 2](https://magic.wizards.com/en/news/feature/collecting-modern-horizons-2-2021-05-21) article's foil-etched pools include the original Modern Horizons retro etched cards: the **common/uncommon pool is 66** (13 commons + 53 uncommons, incl. 23 from MH1) and the **rare/mythic pool ~77** (incl. 12R + 5M from MH1).

But `etched_common_uncommon` and `etched_rare_mythic` filtered `e:mh2 is:etched` only → pools of just 43 and 61, dropping the MH1 (`h1r`) etched cards. The sibling `sketch_common_uncommon` and `foil_boosterfun_*` sheets in the same file already correctly use `(e:mh2 or e:h1r)`.

Both etched filters changed to `(e:mh2 or e:h1r) is:etched`, with count assertions corrected to the verified pool sizes (**66** and **78** — 78 matches the article's "~77"). `etched_basic` is unchanged (h1r has no etched basics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)