### PR TITLE
BRO: fix swapped Collector foil commons/uncommons (4C + 2U)

### DIFF
--- a/data/boosters/bro-collector.yaml
+++ b/data/boosters/bro-collector.yaml
@@ -2,8 +2,8 @@
 # Serialized card rate assumed to be 0.5%
 pack:
   foil_fullart_basic: 1
-  foil_common: 2
-  foil_uncommon: 4
+  foil_common: 4
+  foil_uncommon: 2
   foil_rare_mythic: 1
   extended_rare_mythic: 1
   extended_commander_jumpstart: 1


### PR DESCRIPTION
The [Brothers' War booster article](https://magic.wizards.com/en/news/feature/whats-inside-the-brothers-war-boosters) lists the Collector Booster with **4 traditional foil commons** and **2 traditional foil uncommons**. `bro-collector.yaml` had them reversed (`foil_common: 2`, `foil_uncommon: 4`). Swapped to match.

(Separate, not in this PR: the Set Booster's Transformers rate — the article says ~10% but the impl routes Transformers only through the wildcard rare tier, ~2–3%. That needs a dedicated slot and is left for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)