### PR TITLE
ECL: fix non-foil Booster Fun borderless-rare weight typo (130 -> 1300)

### DIFF
--- a/data/boosters/ecl-collector.yaml
+++ b/data/boosters/ecl-collector.yaml
@@ -85,7 +85,7 @@ sheets:
         chance: 910 # 9.1%
         count: 14
       - rawquery: "{borderless} r:r"
-        chance: 130 # 13%
+        chance: 1300 # 13%
         count: 5
       - rawquery: "{borderless} r:m"
         chance: 450 # 4.5%


### PR DESCRIPTION
In `ecl-collector.yaml`, the non-foil Booster Fun slot's borderless-rare option had `chance: 130` (=1.3%) while its own comment says `# 13%`. With 130 the per-10000 weights summed to **8830**, so every option's normalized probability was skewed high.

Correcting to **1300** makes the weights sum to exactly 10000 and match the [Collecting Lorwyn Eclipsed](https://magic.wizards.com/en/news/feature/collecting-lorwyn-eclipsed) article precisely:

| | Article | Was | Now |
|---|---|---|---|
| extended-art | 37.7% | 42.7% | 37.7% |
| fable | 42.8% | 48.5% | 42.8% |
| borderless | 17.5% | 6.6% | 17.5% |
| shock land | 2% | 2.3% | 2% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)