### PR TITLE
WOE: fix Collector pack size (foil uncommons 4 -> 3, 16 -> 15)

### DIFF
--- a/data/boosters/woe-collector.yaml
+++ b/data/boosters/woe-collector.yaml
@@ -2,7 +2,7 @@
 pack:
   foil_full_art_land: 1
   foil_common: 4
-  foil_uncommon: 4
+  foil_uncommon: 3
   enchanting_tales_uncommon: 1
   foil_enchanting_tales_uncommon: 1
   foil_rare_mythic: 1


### PR DESCRIPTION
The [Collecting Wilds of Eldraine](https://magic.wizards.com/en/news/feature/collecting-wilds-of-eldraine) article lists the Collector Booster with **4 traditional foil commons** and **3 traditional foil uncommons** (15 cards + token). `woe-collector.yaml` had `foil_uncommon: 4`, inflating the pack to 16. Corrected to 3.

(Separate, not in this PR: the **confetti foil** slot — the article states a 2.8% chance of 1 of 20 confetti anime-borderless Enchanting Tales cards (1.1% rare / 1.7% mythic) — is not modeled at all; that needs a dedicated variant and is left for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)