### PR TITLE
NEO: fix Set Booster land-slot foil rate (15% -> 20%)

### DIFF
--- a/data/boosters/neo-set.yaml
+++ b/data/boosters/neo-set.yaml
@@ -2,9 +2,9 @@
 pack:
   land_slot:
   - foil_basic: 1
-    chance: 3
+    chance: 4 # traditional foil land in 20% of Set Boosters
   - basic_or_gainland: 1
-    chance: 17
+    chance: 16
   sfc_common: 3
   sfc_uncommon: 2
   dfc_common_uncommon: 1


### PR DESCRIPTION
[Collecting Kamigawa: Neon Dynasty](https://magic.wizards.com/en/news/feature/collecting-kamigawa-neon-dynasty-2022-01-27) states the Set Booster's land slot is a traditional foil in **20%** of packs. The `land_slot` weighted `foil_basic: 3` vs `basic_or_gainland: 17` = **15%**. Corrected to 4 : 16 = 20%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)