### PR TITLE
ONE: Collector foil basic lands at equal rate (was 3:1)

### DIFF
--- a/data/boosters/one-collector.yaml
+++ b/data/boosters/one-collector.yaml
@@ -18,8 +18,10 @@ sheets:
   foil_basic:
     foil: true
     any:
+    # Panorama (262-266) and Phyrexianized (267-271) basics appear at an
+    # equal rate to one another per the collecting article.
     - query: "t:basic number:262-266"
-      rate: 3
+      rate: 1
       count: 5
     - query: "t:basic number:267-271"
       rate: 1


### PR DESCRIPTION
[Collecting Phyrexia: All Will Be One](https://magic.wizards.com/en/news/feature/collecting-phyrexia-all-will-be-one) states the 5 panorama and 5 Phyrexianized foil basic lands appear **"at an equal rate to one another."** The Collector `foil_basic` sheet weighted the panorama group (262–266) at rate 3 vs the Phyrexianized group (267–271) at rate 1 → 75%/25%. Set both to rate 1 for an even split.

(The Draft booster uses the same 3:1 split, but the article states no odds for the Draft basic, so that's left unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)