### PR TITLE
SNC: fix Collector gilded common/uncommon rate (41.7% -> 25%)

### DIFF
--- a/data/boosters/snc-collector.yaml
+++ b/data/boosters/snc-collector.yaml
@@ -11,8 +11,9 @@ pack:
   extended_commander: 1
   rare_mythic_showcase: 1
   foil_showcase_cu_slot:
+  # Article: gilded common/uncommon in 25% of Collector Boosters (75:25).
   - foil_common_uncommon_showcase: 1
-    chance: 35
+    chance: 75
   - gilded_common_uncommon_showcase: 1
     chance: 25
   foil_showcase_rm_slot:


### PR DESCRIPTION
[Collecting Streets of New Capenna](https://magic.wizards.com/en/news/feature/collecting-streets-of-new-capenna-2022-04-07) states **25%** of Collector Boosters contain a gilded common/uncommon (and 13% a gilded rare/mythic). The `foil_showcase_cu_slot` weighted `foil: 35` vs `gilded: 25` → gilded = 25/60 = **41.7%**. Changed foil to 75 so gilded = 25/(75+25) = 25%.

The gilded rare/mythic slot (`45 / (280+13+45)` = 13.3%) already matches the article's 13%, so it's unchanged.

(Separate, not in this PR: the Set Booster's gilded slot rate is a `1/15` guess (~6.7%) vs the article's ~4% total — flagged for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)