### PR TITLE
OTJ: fix Play Booster Breaking News / wildcard / Big Score+SPG rates

### DIFF
--- a/data/boosters/otj-play.yaml
+++ b/data/boosters/otj-play.yaml
@@ -45,11 +45,11 @@ sheets:
       chance: 1
   wildcard:
     any:
-    - chance: 700
+    - chance: 880
       use: common
-    - chance: 175
+    - chance: 220
       use: uncommon
-    - chance: 125
+    - chance: 100 # wildcard is a rare/mythic in 1 of 12 Play Boosters
       use: rare_mythic_with_showcase
   foil:
     foil: true
@@ -61,14 +61,25 @@ sheets:
     - chance: 3
       use: rare_mythic_with_showcase
   the_list:
+    # The List slot is 1/5 of packs and holds 30 Big Score + 10 Special
+    # Guests cards, but a non-foil Special Guests appears in only 1/64 packs
+    # (1.5625% overall = 7.8125% of this slot). Weight Big Score : SPG =
+    # 118 : 10 (not per-card equal) -> Big Score ~18.4%, SPG 1/64.
     any:
     - rawquery: "e:big number<=30"
-      rate: 1
+      chance: 118
     - set: spg
       code: "OTJ"
-      rate: 1
+      chance: 10
   common:
     query: "r:c -(number:251-264 -(Mirage Mesa) -(Conduit Pylons))"
   breaking_news:
+    # Article: in 1 of 3 Play Boosters the Breaking News card is a rare or
+    # mythic. base_1248_by_rarity over this commonless pool gave ~48%; use an
+    # explicit 2:1 uncommon : rare/mythic split.
     filter: "e:otp number<=65"
-    use: base_1248_by_rarity
+    any:
+    - query: "r:u"
+      chance: 2
+    - query: "r:r or r:m"
+      chance: 1


### PR DESCRIPTION
Three Play Booster rate fixes verified against [Collecting Outlaws of Thunder Junction](https://magic.wizards.com/en/news/feature/collecting-outlaws-of-thunder-junction):

| Slot | Article | Was | Now |
|---|---|---|---|
| Breaking News rare/mythic | 1 in 3 (33.3%) | ~48.4% (`base_1248` over commonless pool) | **33.3%** |
| Wildcard rare/mythic | 1 in 12 (8.33%) | 12.5% (generic 1/8) | **8.33%** |
| Big Score | ~18.4% | 15% | **18.4%** |
| Special Guests | 1 in 64 (1.5625%) | ~5% | **1.5625%** |

- **Breaking News** used `base_1248_by_rarity`, which over-weights rares/mythics on a pool with no commons; replaced with an explicit 2:1 uncommon:rare/mythic split.
- **Wildcard** used the generic 1/8 mix; reweighted `880/220/100` (keeps common:uncommon 4:1).
- **The List slot** weighted Big Score and Special Guests equally per card, but SPG is ~4× rarer per card; reweighted the group to 118:10.

Rates confirmed by building the sheets against the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)