### PR TITLE
MOM: fix Multiverse Legends rare/mythic rate (~48% -> ~one third)

### DIFF
--- a/data/boosters/mom-draft.yaml
+++ b/data/boosters/mom-draft.yaml
@@ -79,9 +79,16 @@ sheets:
     use: rare_mythic
     count: 16
   multiverse_legend:
+    # Article: ~one third of non-foil Multiverse Legends are rare/mythic.
+    # base_1248_by_rarity over the 20u/30r/15m pool gave ~48%; use a 2:1
+    # uncommon : rare/mythic split instead.
     filter: "e:mul -is:foilonly is:paper"
-    use: base_1248_by_rarity
     count: 65
+    any:
+    - query: "r:u"
+      chance: 2
+    - query: "r:r or r:m"
+      chance: 1
   foil_with_showcase_and_mul:
     foil: true
     any:

--- a/data/boosters/mom-set.yaml
+++ b/data/boosters/mom-set.yaml
@@ -35,9 +35,16 @@ sheets:
     query: "r:u t:battle"
     count: 20
   multiverse_legend:
+    # Article: ~one third of non-foil Multiverse Legends are rare/mythic.
+    # base_1248_by_rarity over the 20u/30r/15m pool gave ~48%; use a 2:1
+    # uncommon : rare/mythic split instead.
     filter: "e:mul -is:foilonly is:paper"
-    use: base_1248_by_rarity
     count: 65
+    any:
+    - query: "r:u"
+      chance: 2
+    - query: "r:r or r:m"
+      chance: 1
   wildcard:
     any:
     - use: common
@@ -84,9 +91,14 @@ sheets:
   foil_etched:
     foil: true
     etched: true
+    # Article: ~one third of foil-etched Multiverse Legends are rare/mythic.
     filter: "e:mul is:etched"
-    use: base_1248_by_rarity
     count: 65
+    any:
+    - query: "r:u"
+      chance: 2
+    - query: "r:r or r:m"
+      chance: 1
   mom_foil_with_showcase:
     # the shared base-set foil slot, but with its filter widened to also include
     # the Jumpstart cards (#323-337): per the collecting article they appear in


### PR DESCRIPTION
[Collecting March of the Machine](https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine) states *"roughly one third of the time you receive a non-foil Multiverse Legends card, it will be a rare or mythic rare"* (the pool is 65 cards: 20 uncommons, 30 rares, 15 mythics).

The MUL slots used `base_1248_by_rarity`, which — over a pool with **no commons** — weights uncommon:rare:mythic 4:2:1 → `(60+15)/155 = ~48%` rare/mythic. Replaced with an explicit **2:1 uncommon : rare/mythic** split in all three MUL slots:
- `mom-set.yaml` — nonfoil `multiverse_legend` and `foil_etched`
- `mom-draft.yaml` — nonfoil `multiverse_legend`

Verified each builds to exactly **33.3%** rare/mythic against the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)