### PR TITLE
MAT: split Collector Halo foil slots so each is an independent 1 in 6

### DIFF
--- a/data/boosters/mat-collector.yaml
+++ b/data/boosters/mat-collector.yaml
@@ -1,14 +1,18 @@
 # Data from https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine-the-aftermath
 pack:
-  halo_slot:
+  # Article: the foil showcase uncommon slot and the foil showcase
+  # rare/mythic slot are EACH a Halo foil ~1 in 6, independently. The old
+  # single halo_slot made the two Halo upgrades mutually exclusive, so each
+  # appeared only 1 in 12. Split into two independent 5:1 slots.
+  halo_uncommon_slot:
   - foil_showcase_uncommon: 1
-    foil_showcase_rare_mythic: 1
-    chance: 10
-  - foil_showcase_uncommon: 1
-    halo_showcase_rare_mythic: 1
-    chance: 1
+    chance: 5
   - halo_showcase_uncommon: 1
-    foil_showcase_rare_mythic: 1
+    chance: 1
+  halo_rare_mythic_slot:
+  - foil_showcase_rare_mythic: 1
+    chance: 5
+  - halo_showcase_rare_mythic: 1
     chance: 1
   etched_uncommon: 1
   foil_rare_mythic: 1


### PR DESCRIPTION
[Collecting MOM: The Aftermath](https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine-the-aftermath) states the Collector Booster's foil showcase **uncommon** slot and foil showcase **rare/mythic** slot are *each* a Halo foil about **1 in 6**, independently.

`mat-collector.yaml` combined them into one `halo_slot` where the two Halo upgrades were mutually exclusive (weights 10 : 1 : 1), so each Halo appeared only **1 in 12**. Split into two independent 5:1 slots — `halo_uncommon_slot` and `halo_rare_mythic_slot` — each yielding a Halo 1 in 6. (Same total card count; both can now independently be Halo.)

Note: the audit's "Epilogue Booster Booster-Fun" finding pointed at `mat-arena.yaml`, but that file is actually the **MOM** arena booster (`filter: "e:mom is:baseset"`, MOM article), not the MAT Epilogue Booster — so it's intentionally left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)