### PR TITLE
CLB: fix foil-etched legend rare/mythic rate (~22% -> one third)

### DIFF
--- a/data/boosters/clb-set.yaml
+++ b/data/boosters/clb-set.yaml
@@ -82,10 +82,18 @@ sheets:
         rate: 6
       chance: 125
   foil_etched_legend:
+    # Article: one third of the foil-etched legends are rare or mythic.
+    # base_1248_by_rarity over the etched pool (mostly common/uncommon
+    # legends) gave ~22%; use an explicit 2:1 common-uncommon : rare/mythic
+    # split for 33.3%.
     foil: true
     etched: true
     filter: "e:clb is:etched number<=552"
-    use: base_1248_by_rarity
+    any:
+    - query: "r:c or r:u"
+      chance: 2
+    - query: "r:r or r:m"
+      chance: 1
   foil_with_showcase:
     foil: true
     any:


### PR DESCRIPTION
[Collecting Commander Legends: Battle for Baldur's Gate](https://magic.wizards.com/en/news/feature/collecting-commander-legends-battle-for-baldurs-gate) states one third of the Set Booster's foil-etched legends are rare or mythic. The `foil_etched_legend` slot used `base_1248_by_rarity` over the etched pool (mostly common/uncommon legends → 8:4:2:1 weighting), giving **~22%**. Replaced with an explicit **2:1 common-uncommon : rare/mythic** split — verified **33.3%** over the 82-card etched pool.

(Separate, not in this PR: several count-assertion discrepancies the audit noted — `etched_rare_mythic` 36 vs 32, `extended_commander` 27 vs 39, foil-etched total 86 vs 82 — are pre-existing pool-count warnings, left for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)