### PR TITLE
FDN: fix Play Booster land composition (25/50/25 character/dual/basic)

### DIFF
--- a/data/boosters/fdn-play.yaml
+++ b/data/boosters/fdn-play.yaml
@@ -19,13 +19,18 @@ queries:
   borderless: "e:{set} number:292-361"
 sheets:
   land:
+    # Article: 1 of 10 character lands (25%, the full-art basics), 1 of 10
+    # common dual lands (50%), or 1 of 10 regular-frame basic lands (25%).
     any:
-    - query: "r:c t:land -uncharted -evolving"
+    - query: "t:basic is:fullart"
       chance: 1
       count: 10
-    - query: "t:basic"
+    - query: "r:c t:land -uncharted -evolving"
+      chance: 2
+      count: 10
+    - query: "t:basic -is:fullart"
       chance: 1
-      count: 20
+      count: 10
   common:
     query: "r:c -(e:{set} t:land -uncharted -evolving)"
     count: 80


### PR DESCRIPTION
[Collecting Foundations](https://magic.wizards.com/en/news/feature/collecting-foundations) states the Play Booster land slot is **1 of 10 character lands (25%)**, **1 of 10 common dual lands (50%)**, or **1 of 10 regular-frame basic lands (25%)**.

The `land` sheet weighted `dual : all-basics = 1:1`, and its `t:basic` query lumped the 10 **full-art character** basics (#282–291) in with the 10 **regular-frame** basics (#272–281) — so basics were 50% overall and character vs regular weren't distinguished.

Split into three groups with weights 1 : 2 : 1:
- `t:basic is:fullart` — 10 character lands → **25%**
- `r:c t:land -uncharted -evolving` — 10 dual lands → **50%**
- `t:basic -is:fullart` — 10 regular basics → **25%**

Verified against the index: **25.0 / 50.0 / 25.0%**. (The `foil_land` slot reuses this sheet, so foil lands share the composition, per the article.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)