### PR TITLE
DSK: fix Play Booster land composition (manor 16.7% / basic 33.3% / dual 50%)

### DIFF
--- a/data/boosters/dsk-play.yaml
+++ b/data/boosters/dsk-play.yaml
@@ -42,11 +42,17 @@ sheets:
     - rawquery: "r:u ({lurking_evil} or {showcase})"
       rate: 1
   land:
+    # Article: full-art manor lands 16.7% (the 5 full-art basics), regular
+    # basic lands 33.3%, common dual lands 50% (1:2:3). The old sheet
+    # weighted dual : all-basics 1:1 and lumped the full-art manor basics in
+    # with the regular basics.
     any:
+    - query: "t:basic is:fullart"
+      chance: 1
+    - query: "t:basic -is:fullart"
+      chance: 2
     - query: "r:c t:land -terramorphic"
-      chance: 1
-    - query: "t:basic"
-      chance: 1
+      chance: 3
   foil_land:
     foil: true
     use: land


### PR DESCRIPTION
[Collecting Duskmourn](https://magic.wizards.com/en/news/feature/collecting-duskmourn) states the Play Booster land slot is a **full-art manor land (16.7%)**, a **regular basic land (33.3%)**, or a **common dual land (50%)**. The manor lands are the 5 full-art basics.

The `land` sheet weighted `dual : all-basics = 1:1`, and its `t:basic` query lumped the 5 full-art manor basics (#272–276) in with the 10 regular basics (#277–286) — so basics were ~50% and manor wasn't separated. Split into weights 1 : 2 : 3:
- `t:basic is:fullart` — 5 manor lands → **16.7%**
- `t:basic -is:fullart` — 10 regular basics → **33.3%**
- `r:c t:land -terramorphic` — 10 dual lands → **50%**

Verified: **16.7 / 33.3 / 50.0%**. (The `foil_land` slot reuses this sheet, matching the article's foil composition.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)