### PR TITLE
TMT: fix Play Booster land dual:rooftop rate (80% -> 60% dual)

### DIFF
--- a/data/boosters/tmt-play.yaml
+++ b/data/boosters/tmt-play.yaml
@@ -247,12 +247,15 @@ sheets:
         chance: 1000 - 619 - 283
 
   non_foil_land:
+    # Article: dual land 48% non-foil / 12% foil; rooftop basic 32% non-foil
+    # / 8% foil -> dual : rooftop = 60 : 40 (3:2), not 4:1. Both pools are 5
+    # cards, so rate 3:2 gives the 60/40 split.
     any:
       - rawquery: "{dual_land}"
-        rate: 4
+        rate: 3
         count: 5
       - rawquery: "{rooftop_basic}"
-        rate: 1
+        rate: 2
         count: 5
 
   foil_land:


### PR DESCRIPTION
[Collecting Teenage Mutant Ninja Turtles](https://magic.wizards.com/en/news/feature/collecting-teenage-mutant-ninja-turtles) states the Play Booster land slot is a **common dual land (48% non-foil / 12% foil)** or a **rooftop basic land (32% non-foil / 8% foil)** → dual : rooftop = **60 : 40**.

The `non_foil_land` sheet weighted `dual : rooftop = 4 : 1` over equal 5-card pools, making duals **80%** of the slot (non-foil dual 64% / foil 16%). Changed to `rate 3 : 2` → 60/40, which with the 80/20 non-foil/foil slot split reproduces the article exactly: dual 48%/12%, rooftop 32%/8%. (`foil_land` reuses this sheet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)