### PR TITLE
SNC: fix Set Booster gilded rate (6.7% -> 4%, split 3%/1%)

### DIFF
--- a/data/boosters/snc-set.yaml
+++ b/data/boosters/snc-set.yaml
@@ -19,8 +19,10 @@ pack:
     the_list: 1
     chance: 1
   foil_slot:
+  # Article: a gilded card appears in ~4% of Set Boosters (3% common/
+  # uncommon + 1% rare/mythic), i.e. 1 in 25.
   - foil_with_showcase: 1
-    chance: 14
+    chance: 24
   - gilded_foil: 1
     chance: 1
 sheets:
@@ -108,9 +110,15 @@ sheets:
         rate: 6
       chance: 3
   gilded_foil:
+    # Article: gilded common/uncommon 3% : gilded rare/mythic 1% (3:1),
+    # i.e. 75% C/U, 25% R/M of the 4% gilded slot.
     foil: true
     filter: "e:snc promo:gilded"
-    use: base_1248_by_rarity
+    any:
+    - query: "r:c or r:u"
+      chance: 3
+    - query: "r:r or r:m"
+      chance: 1
   the_list:
     any:
     - set: plst


### PR DESCRIPTION
[Collecting Streets of New Capenna](https://magic.wizards.com/en/news/feature/collecting-streets-of-new-capenna-2022-04-07) states a gilded card appears in **~4%** of Set Boosters — **3% common/uncommon** and **1% rare/mythic**.

The Set Booster gilded slot used a `1/15` (6.7%) guess (the YAML comment admits it) with `base_1248_by_rarity` (≈69/31 internal split), giving ~4.6% / 2.1%. Two changes:
- Slot rate `14:1` → `24:1` (gilded = 1/25 = **4%**).
- Internal split → **3:1** common-uncommon : rare/mythic (75/25).

Result: gilded C/U **3%**, gilded R/M **1%**. (Complements the earlier Collector gilded fix, #465.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)