### PR TITLE
AFR: raise Set Booster wildcard R/M rate to hit stated 30% >=2 rare/mythic

### DIFF
--- a/data/boosters/afr-set.yaml
+++ b/data/boosters/afr-set.yaml
@@ -46,7 +46,10 @@ sheets:
         chance: 60*2
       - use: mythic_with_showcase
         chance: 20
-      chance: 125
+      # Article: 30% of Set Boosters have >=2 rare/mythic (27% exactly two,
+      # 3% three). With 1 guaranteed R/M + 2 wildcards, that needs each
+      # wildcard R/M ~16.35% (was 12.5% = 125), reproducing both figures.
+      chance: 171
   the_list:
     set: plst
     code: "AFR"


### PR DESCRIPTION
[Collecting Adventures in the Forgotten Realms](https://magic.wizards.com/en/news/feature/collecting-adventures-forgotten-realms-2021-06-29) states **30%** of Set Boosters contain **≥2 rare/mythic** (27% exactly two, 3% exactly three).

The Set Booster has 1 guaranteed R/M + 2 wildcards. With the wildcard R/M block at `chance: 125` (12.5%), P(≥2) = 1−(1−0.125)² = **23.4%** — ~7 points low. Raising the block to **171** (≈16.35%) gives:
- P(≥2) = **30.0%**
- P(exactly 2) = 27.3%  ·  P(exactly 3) = 2.7%

which matches all three stated figures. The wildcard's common/uncommon weights (700 / 175) are unchanged; the article doesn't state a wildcard common/uncommon mix, so only the R/M block was adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)