### PR TITLE
VOW: Set wildcard admits only the 8 new-to-Commander cards (VOC #31-38)

### DIFF
--- a/data/boosters/vow-set.yaml
+++ b/data/boosters/vow-set.yaml
@@ -53,10 +53,15 @@ sheets:
         - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
           rate: 3
         chance: 20
-      - rawquery: "e:voc number<=38 r:r"
-        chance: 32*2
-      - rawquery: "e:voc number<=38 r:m"
-        chance: 6
+      # Only the 8 new-to-Commander cards designed for Set Boosters appear
+      # here (VOC #31-38: 6 rares + 2 mythics -- the Soulbonders cycle,
+      # Hollowhenge Overlord, Wedding Ring, Umbris). The rest of VOC (the
+      # Commander-deck cards) are NOT in Set Boosters. Per-card weight kept
+      # at rare 2 : mythic 1, matching the main-set R/M tier.
+      - rawquery: "e:voc number:31-38 r:r"
+        chance: 6*2
+      - rawquery: "e:voc number:31-38 r:m"
+        chance: 2
       chance: 125
   the_list:
     any:


### PR DESCRIPTION
[Collecting Innistrad: Crimson Vow](https://magic.wizards.com/en/news/feature/collecting-innistrad-crimson-vow-2021-10-28) states **eight new cards (six rares + two mythics)** designed for Commander appear in the Set Booster wildcard — the Soulbonders cycle, Hollowhenge Overlord, Wedding Ring, and Umbris, Fear Manifest. These are **VOC #31–38**; the rest of the Crimson Vow Commander set (the deck cards) does **not** appear in Set Boosters.

The wildcard admitted all of `e:voc number<=38` — **32 rares + 6 mythics**. Restricted to `number:31-38` (verified: 6 rares + 2 mythics = exactly #31–38) and rescaled the per-card weights to the R/M tier's rare 2 : mythic 1 (`6*2` rares, `2` mythics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)