### PR TITLE
BRO: Set Booster Transformers appear in ~10% of packs via the wildcard

### DIFF
--- a/data/boosters/bro-set.yaml
+++ b/data/boosters/bro-set.yaml
@@ -103,9 +103,13 @@ sheets:
         rate: 1
       - rawquery: "e:brc r:m number<=28"
         rate: 6
-      - rawquery: "e:bot number<=15"
-        rate: 6
       chance: 125
+    # A Transformers card appears in ~10% of Set Boosters via the wildcard
+    # slots (non-foil, no shattered glass) -- so it's a top-level wildcard
+    # outcome, not part of the rare/mythic tier. With 2 wildcard slots,
+    # chance 54 (~5.12% per wildcard) gives ~10% per pack.
+    - rawquery: "e:bot number<=15"
+      chance: 54
   brr_retro_artifact:
     filter: "e:brr -number:/z/"
     any:


### PR DESCRIPTION
[What's Inside The Brothers' War Boosters](https://magic.wizards.com/en/news/feature/whats-inside-the-brothers-war-boosters): *"You can find a Transformers card in 10% of Set Boosters,"* in the **wildcard slots**, non-foil, no shattered glass.

The impl buried the Transformers cards (`e:bot number<=15`) inside the wildcard's rare/mythic tier at `rate: 6`, giving only **~2–3%**. Pulled them out to a **top-level wildcard outcome** at `chance: 54` (~5.12% per wildcard). With 2 wildcard slots, P(≥1 Transformers) = **10.0%** (verified against the index). Non-foil (the wildcard sheet has no `foil:`), consistent with the article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)