### PR TITLE
DTK: fix fat-pack basics to use e:dtk (was Mirrodin e:mrd)

### DIFF
--- a/data/boosters/dtk-fat-pack.yaml
+++ b/data/boosters/dtk-fat-pack.yaml
@@ -6,4 +6,4 @@ pack:
 sheets:
   foil_basic:
     foil: true
-    rawquery: "e:mrd t:basic"
+    rawquery: "e:dtk t:basic"


### PR DESCRIPTION
`dtk-fat-pack.yaml` is a byte-identical copy of `5dn-fat-pack.yaml`, including its `rawquery: "e:mrd t:basic"`. Fifth Dawn (5dn) correctly pulls **Mirrodin** basics because it has none of its own, but **Dragons of Tarkir has its own basic lands** — so the DTK fat pack was incorrectly attributing Mirrodin basics to a DTK product. Changed the foil-basic query to `e:dtk`.

Note (not changed here): the wider `*-fat-pack.yaml` "Promotional Cards" model (1 foil basic + 1 foil common) doesn't perfectly match the real 2015 fat pack (80 non-foil basics, no promo foils) — but that's the repo's existing convention shared with 5dn, so this PR only corrects the set code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)