### PR TITLE
Remove stale copy-pasted prerelease header comments (KLD/BFZ/XLN)

### DIFF
--- a/data/boosters/bfz-prerelease.yaml
+++ b/data/boosters/bfz-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://magic.wizards.com/en/news/feature/adventures-forgotten-realms-prerelease-primer-2021-07-12
 pack:
   prerelease_promo: 1
 sheets:

--- a/data/boosters/kld-prerelease.yaml
+++ b/data/boosters/kld-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://wpn.wizards.com/en/products/the-brothers-war
 pack:
   prerelease_promo: 1
 sheets:

--- a/data/boosters/xln-prerelease.yaml
+++ b/data/boosters/xln-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://magic.wizards.com/en/news/feature/zendikar-rising-prerelease-primer-2020-09-15
 pack:
   prerelease_promo: 1
 sheets:


### PR DESCRIPTION
`kld-prerelease.yaml`, `bfz-prerelease.yaml`, and `xln-prerelease.yaml` only model the seeded foil stamped promo, but each carried a `# Data from …` header copy-pasted from an unrelated set:
- KLD → cited *The Brothers' War*
- BFZ → cited an *Adventures in the Forgotten Realms* primer
- XLN → cited a *Zendikar Rising* primer

Removed the misleading comments (other prerelease files carry no source line). Comment-only; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)