### PR TITLE
FDN: Collector foil common/uncommon uniform (borderless at full rate)

### DIFF
--- a/data/boosters/fdn-collector.yaml
+++ b/data/boosters/fdn-collector.yaml
@@ -14,25 +14,17 @@ queries:
   extended: "e:{set} number:442-487"
 sheets:
   foil_common:
-    # Showcase treatments 1/8 for relevant cards
+    # FDN's borderless commons appear at full (uniform) rate, not a reduced
+    # showcase rate: 2 borderless + 90 base-set commons -> borderless
+    # 2/92 = 2.2%, dual lands 10/92 = 10.9%, other commons 80/92 = 87%,
+    # matching the article. (The old 8/7/1 reduction gave borderless ~0.28%.)
     foil: true
-    any:
-    - query: "r:c -alt:{borderless}"
-      rate: 8
-    - query: "r:c alt:{borderless}"
-      rate: 7
-    - rawquery: "r:c {borderless}"
-      rate: 1
+    rawquery: "e:{set} r:c (is:baseset or number:292-361)"
+    count: 92
   foil_uncommon:
-    # Showcase treatments 1/8 for relevant cards
+    # Same as foil_common: FDN borderless uncommons appear at full rate.
     foil: true
-    any:
-    - query: "r:u -alt:{borderless}"
-      rate: 8
-    - query: "r:u alt:{borderless}"
-      rate: 7
-    - rawquery: "r:u {borderless}"
-      rate: 1
+    rawquery: "e:{set} r:u (is:baseset or number:292-361)"
   foil_basic:
     foil: true
     query: "t:basic is:fullart"


### PR DESCRIPTION
[Collecting Foundations](https://magic.wizards.com/en/news/feature/collecting-foundations) gives the Collector foil common composition as **main 87% / dual land 10.9% / borderless 2.1%**. That is precisely the **uniform per-printing** rate over the 92 foil commons:
- 80 non-land commons → 80/92 = **87%**
- 10 dual lands → 10/92 = **10.9%**
- 2 borderless commons → 2/92 = **2.2%** (article 2.1%)

The `foil_common`/`foil_uncommon` sheets used the standard `8/7/1` showcase-reduction, treating FDN's borderless as a rare showcase and crushing borderless commons to **~0.28%**. Replaced both with a uniform sheet over base-set + borderless (`#292-361`).

Verified against the index: foil_common borderless **2.17%** (dual lands 10.9%); foil_uncommon borderless 7.3% (uniform over 8 of 109 — same design; the article details only the common split, but the uncommon slot shares the identical structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)