### PR TITLE
Document known DOM legendary-slot & RNA theme-booster rate gaps

### DIFF
--- a/data/boosters/dom-draft.yaml
+++ b/data/boosters/dom-draft.yaml
@@ -11,6 +11,13 @@
 # I suspect there's a chance to get 2 or 3 legend uncommons in a pack
 # (9/64 and 1/64 if DOM was a regular set), so we could add more cases
 # and adjus numbers accordingly
+#
+# Audit note (left as-is): this print-run model yields P(legendary at the
+# rare/mythic slot) ~29.8% vs the documented 25%, and legendary_rare_mythic's
+# t:"legendary creature" query catches 14 rares / 8 mythics vs the lethe.xyz
+# collation's 12 / 6. Reaching exactly 25% would require reworking the
+# print-run weights below, and the specific rares/mythics the collation
+# excludes from the legendary slot are not documented.
 pack:
 - basic: 1
   common: 9

--- a/data/boosters/rna-theme-azorius.yaml
+++ b/data/boosters/rna-theme-azorius.yaml
@@ -15,6 +15,8 @@ pack:
     chance: 1
   - uncommon: 3
     chance: 1
+  # Source (unboxings): a theme booster may contain one OR two rares/mythics;
+  # the rate of a second is undocumented, so exactly 1 is modeled here.
   rare_mythic: 1
 sheets:
   common:

--- a/data/boosters/rna-theme-gruul.yaml
+++ b/data/boosters/rna-theme-gruul.yaml
@@ -15,6 +15,8 @@ pack:
     chance: 1
   - uncommon: 3
     chance: 1
+  # Source (unboxings): a theme booster may contain one OR two rares/mythics;
+  # the rate of a second is undocumented, so exactly 1 is modeled here.
   rare_mythic: 1
 sheets:
   common:

--- a/data/boosters/rna-theme-orzhov.yaml
+++ b/data/boosters/rna-theme-orzhov.yaml
@@ -15,6 +15,8 @@ pack:
     chance: 1
   - uncommon: 3
     chance: 1
+  # Source (unboxings): a theme booster may contain one OR two rares/mythics;
+  # the rate of a second is undocumented, so exactly 1 is modeled here.
   rare_mythic: 1
 sheets:
   common:

--- a/data/boosters/rna-theme-rakdos.yaml
+++ b/data/boosters/rna-theme-rakdos.yaml
@@ -15,6 +15,8 @@ pack:
     chance: 1
   - uncommon: 3
     chance: 1
+  # Source (unboxings): a theme booster may contain one OR two rares/mythics;
+  # the rate of a second is undocumented, so exactly 1 is modeled here.
   rare_mythic: 1
 sheets:
   common:

--- a/data/boosters/rna-theme-simic.yaml
+++ b/data/boosters/rna-theme-simic.yaml
@@ -15,6 +15,8 @@ pack:
     chance: 1
   - uncommon: 3
     chance: 1
+  # Source (unboxings): a theme booster may contain one OR two rares/mythics;
+  # the rate of a second is undocumented, so exactly 1 is modeled here.
   rare_mythic: 1
 sheets:
   common:


### PR DESCRIPTION
Comment-only. The M15→WAR booster audit surfaced two rate discrepancies best **left as-is** — one needs reworking a deliberate print-run model, the other a rate that isn't publicly documented. These comments record them as *known* rather than overlooked:

- **`dom-draft.yaml`** — the legendary-slot print-run model yields `P(legendary at the rare/mythic slot) ≈ 29.8%` vs the documented **25%**, and `legendary_rare_mythic`'s `t:"legendary creature"` query catches **14R/8M** vs the lethe.xyz collation's **12R/6M**. Reaching 25% would require reworking the pack-variant weights, and the specific cards the collation excludes from the slot aren't documented.
- **`rna-theme-*.yaml` (×5)** — sources (unboxings) indicate a theme booster may contain **one or two** rares/mythics; the rate of a second is undocumented, so exactly 1 is modeled.

(For reference: ORI's flip-planeswalkers were confirmed to have **no** dedicated DFC slot — they mix into the rare/mythic slot at an undocumented rate — so the existing ORI model is already correct and unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)