### PR TITLE
LCI: exclude Buy-a-Box promo from Collector extended-art slot

### DIFF
--- a/data/boosters/lci-collector.yaml
+++ b/data/boosters/lci-collector.yaml
@@ -32,7 +32,10 @@ sheets:
     foil: true
     use: rare_mythic
   extended_main_rare_mythic:
-    filter: "e:lci frame:extendedart"
+    # The Buy-a-Box promo (Jadelight Spelunker, lci #403) shares the extended-art
+    # frame but is a WPN store promo, not a Collector Booster card - exclude it,
+    # as every other set does (cf. dmu/khm/mom/mat collector sheets).
+    filter: "e:lci frame:extendedart -promo:buyabox"
     use: rare_mythic
   extended_commander_rare_mythic:
     filter: "e:lcc frame:extendedart"


### PR DESCRIPTION
The Jadelight Spelunker Buy-a-Box promo (`lci` #403) carries the extended-art frame, so the Collector Booster's `extended_main_rare_mythic` sheet (`filter: "e:lci frame:extendedart"`) was pulling it in. It's a WPN-store Buy-a-Box promo, not a Collector Booster card.

Add `-promo:buyabox`, matching how every other set guards this slot (see the `dmu` / `khm` / `mom` / `mat` collector sheets, which all append `-promo:buyabox` to the extended-art filter). The legitimate Booster Fun extended-art printing (`lci` #382) is retained.

Addresses the "Buy-a-Box promo not modeled" finding from the [Collecting Lost Caverns of Ixalan](https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan) audit — the card was in fact *mis*-modeled (leaking into the Collector slot) rather than absent.