### PR TITLE
MIR: fix starter deck common/uncommon split (25/10 -> 26/9)

### DIFF
--- a/data/boosters/mir-starter.yaml
+++ b/data/boosters/mir-starter.yaml
@@ -1,9 +1,11 @@
-# Data from https://mtg.wiki/wiki/Tournament_pack
+# Data from https://lethe.xyz/mtg/collation/mir.html
+# Mirage starter decks: 26 commons, 9 uncommons, 3 rares, 22 basic lands
+# (not the generic 25/10 tournament-pack split)
 name: "{set_name} Starter Deck"
 pack:
   basics: 22
-  common_with_duplicates: 25
-  uncommon_with_duplicates: 10
+  common_with_duplicates: 26
+  uncommon_with_duplicates: 9
   rare: 3
 sheets:
   basics:


### PR DESCRIPTION
Mirage starter decks contained **26 commons / 9 uncommons / 3 rares / 22 basic lands**, per the [lethe.xyz Mirage collation](https://lethe.xyz/mtg/collation/mir.html). The file was reusing the generic tournament-pack 25/10 split, over-representing uncommons by one and under-representing commons by one. Total stays 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)