### PR TITLE
USG: correct misleading tournament-pack comment

### DIFF
--- a/data/boosters/usg-tournament.yaml
+++ b/data/boosters/usg-tournament.yaml
@@ -1,4 +1,5 @@
-# Pre-mythic, with new style foils, only foil basics in packs
+# Urza's Saga Tournament Deck: 30 basics / 32 commons / 10 uncommons / 3 rares.
+# Pre-foil era (foils began in Urza's Legacy), so no foils in these packs.
 name: "{set_name} Tournament Deck"
 pack:
   basic_with_duplicates: 30


### PR DESCRIPTION
Cosmetic. The `usg-tournament.yaml` header read "with new style foils, only foil basics in packs", but Urza's Saga predates foils (they began in Urza's Legacy) and the pack correctly models none. Replaced with an accurate description of the 30/32/10/3 composition.

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)