### PR TITLE
10E: drop the basic-land slot (booster is 1R/3U/11C, no basic)

### DIFF
--- a/data/boosters/10e-draft.yaml
+++ b/data/boosters/10e-draft.yaml
@@ -1,11 +1,9 @@
-# I couldn't find information about foils in core sets, so I'm somewhat guessing here
-# Treating all of these as independent, totals look hilariously high
+# Tenth Edition boosters held 15 game cards (1 rare, 3 uncommon, 11 common)
+# plus a marketing card; there was NO basic land in the pack.
+# Source: https://mtg.wiki/page/Tenth_Edition
+# Premium (foil) versions of any card were randomly inserted; the per-slot
+# rolls below are an approximation (independent, so totals run a little high).
 pack:
-  basic_maybe_foil:
-  - basic: 1
-    chance: 70 - 1
-  - foil_basic: 1
-    chance: 1
   rare_maybe_foil:
   - rare: 1
     chance: 70 - 1
@@ -18,8 +16,8 @@ pack:
     foil_uncommon: 1
     chance: 3
   common_maybe_foil:
+  - common: 11
+    chance: 70 - 11
   - common: 10
-    chance: 70 - 10
-  - common: 9
     foil_common: 1
-    chance: 10
+    chance: 11


### PR DESCRIPTION
Tenth Edition boosters held **15 game cards — 1 rare, 3 uncommon, 11 common** — plus a marketing card, with **no basic land** in the pack. `10e-draft.yaml` instead modeled a guaranteed basic-land slot and only 10 commons.

Fix: remove the `basic_maybe_foil` slot and restore the 11th common. All eight pack variants now build to exactly 15 cards (1R/3U/11C with foil substitutions) and contain zero basics.

Source: https://mtg.wiki/page/Tenth_Edition — *"Each Tenth Edition booster pack contained fifteen game cards (1 rare, 3 uncommon, 11 common) and a marketing card."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)