### PR TITLE
ALA: tournament-pack rare slots can be mythic rares

### DIFF
--- a/data/boosters/ala-tournament.yaml
+++ b/data/boosters/ala-tournament.yaml
@@ -1,10 +1,14 @@
 # Data from https://www.cardkingdom.com/mtg/shards-of-alara/shards-of-alara-tournament-pack
+# Shards of Alara introduced the mythic rare, and per mtg.wiki each rare slot
+# -- in boosters AND tournament packs -- could be a rare or a mythic rare
+# (https://mtg.wiki/page/Tournament_pack). Use the shared rare_mythic sheet so
+# the three rare slots can yield mythics, matching the draft booster.
 name: "{set_name} Tournament Deck"
 pack:
   basic: 29
   common: 33
   uncommon: 10
-  rare: 3
+  rare_mythic: 3
 sheets:
   uncommon:
     duplicates: true


### PR DESCRIPTION
Shards of Alara introduced the mythic rare. Per mtg.wiki's [Tournament pack](https://mtg.wiki/page/Tournament_pack) page: *"In Shards of Alara packs, each rare slot could contain either a rare or mythic rare."* This applied to tournament packs, not just boosters.

`ala-tournament.yaml` pulled its three rare slots from `r:r` only, so a mythic could never appear. Switch the slot to the shared `rare_mythic` sheet (`r:r` rate 2, `r:m` rate 1), matching the draft booster.

Verified against the rebuilt index: 53 rares + 15 mythics on the sheet, **~12.4% mythic per slot**, **~32.8%** chance of at least one mythic across the three rare slots. Pack stays 75 cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)