### PR TITLE
DTK: include in-color non-watermarked promos in Kolaghan prerelease pack

### DIFF
--- a/data/boosters/dtk-prerelease-kolaghan.yaml
+++ b/data/boosters/dtk-prerelease-kolaghan.yaml
@@ -11,7 +11,7 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:pdtk r:m (w:kolaghan) promo:prerelease"
+    - rawquery: "e:pdtk r:m (w:kolaghan or (id<=br and -w:*)) promo:prerelease"
       rate: 1
-    - rawquery: "e:pdtk r:r (w:kolaghan) promo:prerelease"
+    - rawquery: "e:pdtk r:r (w:kolaghan or (id<=br and -w:*)) promo:prerelease"
       rate: 2


### PR DESCRIPTION
Four of the five DTK seeded-prerelease boosters filter their promo slot as `(w:CLAN or (id<=colors and -w:*))` — the clan's watermarked promos **plus** in-color prerelease promos that carry no clan watermark. **Kolaghan** alone used `(w:kolaghan)` only.

That omission excluded two BR-eligible non-watermarked prerelease rares from the Kolaghan promo pool: **Damnable Pact** and **Volcanic Vision** (the latter already appears in the Atarka pool via the same clause). Add the matching `or (id<=br and -w:*)` clause so the pool goes from 8 → 10 promos.

Verified against the rebuilt index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)