### PR TITLE
Remove stale copy-pasted prerelease header comments (AKH/M19/WAR)

### DIFF
--- a/data/boosters/akh-prerelease.yaml
+++ b/data/boosters/akh-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://magic.wizards.com/en/news/feature/adventures-forgotten-realms-prerelease-primer-2021-07-12
 pack:
   prerelease_promo: 1
 sheets:

--- a/data/boosters/m19-prerelease.yaml
+++ b/data/boosters/m19-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://magic.wizards.com/en/news/feature/adventures-forgotten-realms-prerelease-primer-2021-07-12
 pack:
   prerelease_promo: 1
 sheets:

--- a/data/boosters/war-prerelease.yaml
+++ b/data/boosters/war-prerelease.yaml
@@ -1,4 +1,3 @@
-# Data from https://magic.wizards.com/en/news/feature/zendikar-rising-prerelease-primer-2020-09-15
 pack:
   prerelease_promo: 1
   prerelease_pw: 1


### PR DESCRIPTION
Follow-up to #479. Three more prerelease files carry a `# Data from …` source line copied from an unrelated set:

- `akh-prerelease.yaml` and `m19-prerelease.yaml` cite the **2021 Adventures in the Forgotten Realms** prerelease primer
- `war-prerelease.yaml` cites the **2020 Zendikar Rising** prerelease primer

None of these URLs describe the set they're in, and there's no accurate source line to substitute, so drop them — matching the other prerelease files, which carry none. Comment-only; no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)