### PR TITLE
MH2: correct etched_rare_mythic count assertion (78 -> 77)

### DIFF
--- a/data/boosters/mh2-collector.yaml
+++ b/data/boosters/mh2-collector.yaml
@@ -43,4 +43,4 @@ sheets:
     etched: true
     filter: "(e:mh2 or e:h1r) is:etched"
     use: rare_mythic
-    count: 78 # incl. the MH1/h1r retro etched rares & mythics
+    count: 77 # incl. the MH1/h1r retro etched; Fire // Ice (#290) is one card


### PR DESCRIPTION
Follow-up to #459. That PR set `etched_rare_mythic`'s `count: 78`, derived from a raw `(e:mh2 or e:h1r) is:etched (r:r or r:m)` search — but that counts the **split card Fire // Ice** (#290) as two cards (`#290a Fire` + `#290b Ice`). The built sheet correctly treats it as **one** printing, so the true pool is **77** (which also matches the article's "~77").

This corrects the assertion to 77, silencing the build warning:
```
mh2/etched_rare_mythic: Expected sheet to have 78 cards, got 77
```

Verified by building the sheet against the index (77 cards; the only raw-vs-sheet difference is the Fire // Ice split-card halves). No query change — the query and output were already correct; only the assertion was off by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)