### PR TITLE
Fix and complete collecting-article links for ELD-forward sets

### DIFF
--- a/data/boosters/akr-arena.yaml
+++ b/data/boosters/akr-arena.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/amonkhet-remastered
 # no basic
 pack:
   common: 10

--- a/data/boosters/klr-arena.yaml
+++ b/data/boosters/klr-arena.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/kaladesh-remastered
 # no basic
 pack:
   common: 10

--- a/data/boosters/pio-arena-1.yaml
+++ b/data/boosters/pio-arena-1.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/mtg-arena/collecting-pioneer-masters
 name: "Pioneer Masters Arena Draft Booster: Planeswalkers"
 pack:
   common: 8

--- a/data/boosters/pio-arena-2.yaml
+++ b/data/boosters/pio-arena-2.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/mtg-arena/collecting-pioneer-masters
 name: "Pioneer Masters Arena Draft Booster: Spells"
 pack:
   common: 8

--- a/data/boosters/pio-arena-3.yaml
+++ b/data/boosters/pio-arena-3.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/mtg-arena/collecting-pioneer-masters
 name: "Pioneer Masters Arena Draft Booster: Devotion"
 pack:
   common: 8

--- a/data/boosters/sir-arena-1.yaml
+++ b/data/boosters/sir-arena-1.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/shadows-over-innistrad-remastered-card-image-gallery
 name: "{set_name} Arena Booster: Creature Type Terror"
 pack:
 - bonus: 1

--- a/data/boosters/sir-arena-2.yaml
+++ b/data/boosters/sir-arena-2.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/shadows-over-innistrad-remastered-card-image-gallery
 name: "{set_name} Arena Booster: Fatal Flashback"
 pack:
 - bonus: 1

--- a/data/boosters/sir-arena-3.yaml
+++ b/data/boosters/sir-arena-3.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/shadows-over-innistrad-remastered-card-image-gallery
 name: "{set_name} Arena Booster: Morbid And Macabre"
 pack:
 - bonus: 1

--- a/data/boosters/sir-arena-4.yaml
+++ b/data/boosters/sir-arena-4.yaml
@@ -1,3 +1,4 @@
+# Arena-only set. Data from https://magic.wizards.com/en/news/card-image-gallery/shadows-over-innistrad-remastered-card-image-gallery
 name: "{set_name} Arena Booster: Abominable All Stars"
 pack:
 - bonus: 1

--- a/data/boosters/thb-collector.yaml
+++ b/data/boosters/thb-collector.yaml
@@ -1,4 +1,5 @@
 # data from https://www.lethe.xyz/mtg/collation/thb.html
+# Collecting article: https://magic.wizards.com/en/news/feature/theros-beyond-death-collector-booster-contents-2019-12-13
 # Assumptions:
 # No data for distribution of commons/uncommons
 # - assumed to follow distribution of Set boosters in https://mtg.wiki/wiki/Set_Booster

--- a/data/boosters/thb-draft.yaml
+++ b/data/boosters/thb-draft.yaml
@@ -1,4 +1,5 @@
 # Data from https://www.lethe.xyz/mtg/collation/thb.html
+# Collecting article: https://magic.wizards.com/en/news/feature/theros-beyond-death-collector-booster-contents-2019-12-13
 pack:
 - basic: 1
   common_or_foil:

--- a/data/boosters/tla-collector.yaml
+++ b/data/boosters/tla-collector.yaml
@@ -2,7 +2,7 @@
 # Collector Booster
 # Sources:
 # - https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
-# - https://magic.wizards.com/en/products/marvel/spider-man/card-image-gallery
+# - https://magic.wizards.com/en/products/avatar-the-last-airbender/card-image-gallery
 # - https://scryfall.com/sets/tla
 # - https://scryfall.com/sets/tle
 

--- a/data/boosters/tla-play.yaml
+++ b/data/boosters/tla-play.yaml
@@ -2,7 +2,7 @@
 # Play Booster
 # Sources:
 # - https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
-# - https://magic.wizards.com/en/products/marvel/spider-man/card-image-gallery
+# - https://magic.wizards.com/en/products/avatar-the-last-airbender/card-image-gallery
 # - https://scryfall.com/sets/tla
 # - https://scryfall.com/sets/tle
 


### PR DESCRIPTION
Audited the source-article links on every Throne-of-Eldraine-onward set that has boosters (67 sets). All existing collecting links resolve; this fixes the defects and fills the gaps.

**Fixes**
- **TLA (Avatar: The Last Airbender)** — the card-image-gallery source in `tla-play` / `tla-collector` was copy-pasted from Spider-Man (`.../marvel/spider-man/card-image-gallery`). Repointed to the actual [Avatar gallery](https://magic.wizards.com/en/products/avatar-the-last-airbender/card-image-gallery).
- **THB (Theros Beyond Death)** — only had the lethe.xyz collation source; added the WotC [Collector Booster Contents](https://magic.wizards.com/en/news/feature/theros-beyond-death-collector-booster-contents-2019-12-13) article.

**Arena-only remasters** (previously had no source link → now point to the official MTG Arena article, per the request):
- **AKR** — [Amonkhet Remastered gallery](https://magic.wizards.com/en/news/card-image-gallery/amonkhet-remastered)
- **KLR** — [Kaladesh Remastered gallery](https://magic.wizards.com/en/news/card-image-gallery/kaladesh-remastered)
- **SIR** — [Shadows over Innistrad Remastered gallery](https://magic.wizards.com/en/news/card-image-gallery/shadows-over-innistrad-remastered-card-image-gallery) (all 4 arena boosters)
- **PIO** — [Collecting Pioneer Masters](https://magic.wizards.com/en/news/mtg-arena/collecting-pioneer-masters) (all 3 arena boosters)

**Verified, left as-is**
- *Collecting Innistrad: Midnight Hunt* 404s on the live site but is already pinned to a working Wayback Machine capture in `mid-collector` / `mid-set`.
- Older links under `/articles/archive/…` and `/news/card-preview/…` (STX, IKO, M21, KHM, VOW, etc.) still resolve (some 301-redirect to canonical `/news/feature/…` paths).

Comment-only changes; all 13 files parse.

**Out of scope:** supplemental products with no WotC "Collecting" article (Secret Lair, Signature Spellbook, Zendikar Rising Expeditions, 30th Anniversary, Mystery Booster, Jumpstart, Double Feature, Clue Edition, Fallout) were left untouched. Happy to add product-overview links for any of these if wanted.