### PR TITLE
APC: at most one foil per Apocalypse draft booster

### DIFF
--- a/data/boosters/apc-draft.yaml
+++ b/data/boosters/apc-draft.yaml
@@ -1,22 +1,30 @@
+# Foil rate 1:100 cards (~15% of packs). At most one foil per pack, per
+# lethe.xyz/mtg/collation/apc.html: "not possible to get more than one foil
+# in a pack." A foil replaces a card of its own rarity, so the per-rarity
+# foil rates are unchanged from independent slots (common 11%, uncommon 3%,
+# rare 1%); this single mutually-exclusive slot only removes the ~0.5% of
+# packs that would otherwise carry two or more foils.
 # (APC should probably be balanced, just by c: not ci:)
 pack:
-  rare_maybe_foil:
-  - rare: 1
-    chance: 100 - 1
-  - foil_rare: 1
-    chance: 1
-  uncommon_maybe_foil:
-  - uncommon: 3
-    chance: 100 - 3
-  - uncommon: 2
-    foil_uncommon: 1
-    chance: 3
-  common_maybe_foil:
+  cards:
   - common: 11
-    chance: 100 - 11
+    uncommon: 3
+    rare: 1
+    chance: 100 - 15
   - common: 10
     foil_common: 1
+    uncommon: 3
+    rare: 1
     chance: 11
+  - common: 11
+    uncommon: 2
+    foil_uncommon: 1
+    rare: 1
+    chance: 3
+  - common: 11
+    uncommon: 3
+    foil_rare: 1
+    chance: 1
 sheets:
   common:
     balanced: false


### PR DESCRIPTION
The [lethe.xyz Apocalypse collation](https://lethe.xyz/mtg/collation/apc.html) states it is *"not possible to get more than one foil in a pack"*, but the three independent maybe-foil slots (common/uncommon/rare) could produce **2–3 foils in ~0.46% of packs**. This folds them into a single mutually-exclusive slot.

Verified against the regenerated booster index — per-rarity foil rates are **identical**:

| | before | after |
|---|---|---|
| P(foil common) | 11.000% | 11.000% |
| P(foil uncommon) | 3.000% | 3.000% |
| P(foil rare) | 1.000% | 1.000% |
| max foils/pack | 3 | **1** |
| multi-foil packs | 0.463% | 0% |
| pack size | 15 | 15 |

The 0.46% multi-foil mass is redistributed to the no-foil case (85.467% → 85%). A foil still displaces a card of its own rarity. No card's individual pull rate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)