### PR TITLE
Add count assertions to booster query/rawquery sheets

### DIFF
--- a/data/boosters/2x2-draft.yaml
+++ b/data/boosters/2x2-draft.yaml
@@ -7,6 +7,7 @@ pack:
 sheets:
   cryptic_spires:
     rawquery: "e:2x2 number:332"
+    count: 1
   rare_mythic_with_showcase:
     any:
     - use: rare_with_showcase

--- a/data/boosters/2xm-draft.yaml
+++ b/data/boosters/2xm-draft.yaml
@@ -8,12 +8,16 @@ sheets:
     foil: true
     any:
       - query: "r<=c"
+        count: 91
         chance: 8
       - query: "r:u"
+        count: 80
         chance: 3
       - any:
         - query: "r:r"
+          count: 121
           rate: 2
         - query: "r:m"
+          count: 40
           rate: 1
         chance: 2

--- a/data/boosters/2xm-vip.yaml
+++ b/data/boosters/2xm-vip.yaml
@@ -28,24 +28,35 @@ sheets:
     use: rare_mythic
   plains_1:
     rawquery: "e:2xm number:373"
+    count: 1
   plains_2:
     rawquery: "e:2xm number:374"
+    count: 1
   island_1:
     rawquery: "e:2xm number:375"
+    count: 1
   island_2:
     rawquery: "e:2xm number:376"
+    count: 1
   swamp_1:
     rawquery: "e:2xm number:377"
+    count: 1
   swamp_2:
     rawquery: "e:2xm number:378"
+    count: 1
   mountain_1:
     rawquery: "e:2xm number:379"
+    count: 1
   mountain_2:
     rawquery: "e:2xm number:380"
+    count: 1
   forest_1:
     rawquery: "e:2xm number:381"
+    count: 1
   forest_2:
     rawquery: "e:2xm number:382"
+    count: 1
   foil_basic:
     foil: true
     rawquery: "e:2xm t:basic"
+    count: 10

--- a/data/boosters/4ed-starter.yaml
+++ b/data/boosters/4ed-starter.yaml
@@ -9,9 +9,12 @@ sheets:
   basic:
     duplicates: true
     query: "r:b"
+    count: 15
   common_with_duplicates:
     query: "r:c"
+    count: 121
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 121
     duplicates: true

--- a/data/boosters/5dn-fat-pack.yaml
+++ b/data/boosters/5dn-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:mrd t:basic"
+    count: 20

--- a/data/boosters/5ed-starter.yaml
+++ b/data/boosters/5ed-starter.yaml
@@ -9,9 +9,12 @@ sheets:
   basic:
     duplicates: true
     query: "r:b"
+    count: 20
   common_with_duplicates:
     query: "r:c"
+    count: 165
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 132
     duplicates: true

--- a/data/boosters/6ed-tournament.yaml
+++ b/data/boosters/6ed-tournament.yaml
@@ -9,9 +9,12 @@ sheets:
   basic:
     duplicates: true
     query: "r:b"
+    count: 20
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/acr-collector.yaml
+++ b/data/boosters/acr-collector.yaml
@@ -16,19 +16,24 @@ sheets:
   foil_showcase_uncommon:
     foil: true
     rawquery: "e:{set} frame:showcase r:u"
+    count: 9
   etched_uncommon:
     foil: true
     etched: true
     rawquery: "e:{set} is:etched r:u"
+    count: 49
   foil_basic:
     foil: true
     rawquery: "e:{set} t:basic is:fullart"
+    count: 10
   borderless_scene:
     foil: true
     any:
     - rawquery: "e:{set} number:111-116 r:r"
+      count: 5
       rate: 2
     - rawquery: "e:{set} number:111-116 r:m"
+      count: 1
       rate: 1
   foil_rare_mythic:
     foil: true
@@ -40,8 +45,10 @@ sheets:
   nonfoil_extended:
     any:
     - rawquery: "e:{set} frame:extendedart r:r"
+      count: 16
       rate: 2
     - rawquery: "e:{set} frame:extendedart r:m"
+      count: 1
       rate: 1
   foil_showcase_rare_mythic:
     foil: true

--- a/data/boosters/acr.yaml
+++ b/data/boosters/acr.yaml
@@ -21,11 +21,14 @@ sheets:
   booster_fun:
     any:
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -is:extendedart"
+      count: 9
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -is:extendedart -number:/z/ -number:111-116"
+        count: 16
         rate: 2
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -is:extendedart -number:/z/ -number:111-116"
+        count: 13
         rate: 1
       chance: 1
   booster_fun_foil:
@@ -36,10 +39,13 @@ sheets:
     foil: true
     any:
     - query: "r:u"
+      count: 54
       chance: 5
     - any:
       - query: "r:r"
+        count: 32
         rate: 2
       - query: "r:m"
+        count: 14
         rate: 1
       chance: 1

--- a/data/boosters/aer-draft.yaml
+++ b/data/boosters/aer-draft.yaml
@@ -15,8 +15,10 @@ sheets:
     - use: rare_mythic
       chance: 3*8
     - query: "r:u"
+      count: 60
       chance: 5*8
     - rawquery: "(e:aer r:c) or (e:kld r:b)"
+      count: 85
       chance: 12*8-2
     - rawquery: "e:mps number>=31"
       count: 24
@@ -24,3 +26,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:kld r:b"
+    count: 15

--- a/data/boosters/afr-set.yaml
+++ b/data/boosters/afr-set.yaml
@@ -35,6 +35,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   wildcard:
     any:
     - use: common

--- a/data/boosters/afr-theme-b.yaml
+++ b/data/boosters/afr-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/afr-theme-dungeons.yaml
+++ b/data/boosters/afr-theme-dungeons.yaml
@@ -27,23 +27,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 22
       rate: 1
     - query: "r:c -id:c"
+      count: 16
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 10
       rate: 2
     - query: "r:r -id:c"
+      count: 5
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/afr-theme-g.yaml
+++ b/data/boosters/afr-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/afr-theme-r.yaml
+++ b/data/boosters/afr-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/afr-theme-u.yaml
+++ b/data/boosters/afr-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/afr-theme-w.yaml
+++ b/data/boosters/afr-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/akh-draft.yaml
+++ b/data/boosters/akh-draft.yaml
@@ -15,8 +15,10 @@ sheets:
     - use: rare_mythic
       chance: 3*7
     - query: "r:u"
+      count: 80
       chance: 5*7
     - query: "r<=c"
+      count: 121
       chance: 12*7
     - rawquery: "e:mp2 number<=30"
       count: 30

--- a/data/boosters/ala-draft.yaml
+++ b/data/boosters/ala-draft.yaml
@@ -14,3 +14,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 101

--- a/data/boosters/ala-tournament.yaml
+++ b/data/boosters/ala-tournament.yaml
@@ -13,9 +13,12 @@ sheets:
   uncommon:
     duplicates: true
     query: "r:u"
+    count: 60
   common:
     duplicates: true
     query: "r:c"
+    count: 101
   basic:
     duplicates: true
     query: "r:b"
+    count: 20

--- a/data/boosters/apc-draft.yaml
+++ b/data/boosters/apc-draft.yaml
@@ -29,3 +29,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 55

--- a/data/boosters/apc-fat-pack.yaml
+++ b/data/boosters/apc-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:inv t:basic"
+    count: 20

--- a/data/boosters/arb-draft.yaml
+++ b/data/boosters/arb-draft.yaml
@@ -14,6 +14,8 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 60
   basic:
     # borrowed basics
     rawquery: "e:ala r:b"
+    count: 20

--- a/data/boosters/arb-six.yaml
+++ b/data/boosters/arb-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 60
   basic:
     rawquery: "e:ala t:basic"
+    count: 20

--- a/data/boosters/avr-six.yaml
+++ b/data/boosters/avr-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/bfz-draft.yaml
+++ b/data/boosters/bfz-draft.yaml
@@ -18,8 +18,10 @@ sheets:
     - use: rare_mythic
       chance: 3*8
     - query: "r:u"
+      count: 80
       chance: 5*8
     - query: "r<=c"
+      count: 126
       chance: 12*8-2
     - rawquery: "e:exp number<=25"
       count: 25

--- a/data/boosters/blb-collector.yaml
+++ b/data/boosters/blb-collector.yaml
@@ -16,12 +16,16 @@ sheets:
     foil: true
     any:
     - query: "number:262,266,270,274,278"
+      count: 5
       chance: 4
     - query: "number:263,267,271,275,279"
+      count: 5
       chance: 3
     - query: "number:264,268,272,276,280"
+      count: 5
       chance: 2
     - query: "number:265,269,273,277,281"
+      count: 5
       chance: 1
   foil_rare_mythic:
     foil: true
@@ -41,6 +45,7 @@ sheets:
   foil_commander:
     foil: true
     rawquery: "e:blc number:41-44"
+    count: 4
   showcase_rare_mythic:
     any:
     - rawquery: "e:blc r:r number:73-92"

--- a/data/boosters/blb-play.yaml
+++ b/data/boosters/blb-play.yaml
@@ -18,15 +18,20 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 81
   land:
     any:
     - query: "number:262,266,270,274,278"
+      count: 5
       chance: 4
     - query: "number:263,267,271,275,279"
+      count: 5
       chance: 3
     - query: "number:264,268,272,276,280"
+      count: 5
       chance: 2
     - query: "number:265,269,273,277,281"
+      count: 5
       chance: 1
   foil_land:
     foil: true
@@ -35,8 +40,10 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Lumra)"
+      count: 2
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Lumra)"
+      count: 19
       rate: 2
     - use: mythic_has_showcase
       rate: 4
@@ -46,8 +53,10 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper (Three Tree City)"
+      count: 4
       rate: 1
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Three Tree City)"
+      count: 36
       rate: 4
     - use: rare_has_showcase
       rate: 8

--- a/data/boosters/bng-draft.yaml
+++ b/data/boosters/bng-draft.yaml
@@ -14,3 +14,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:ths r:b"
+    count: 20

--- a/data/boosters/bok-fat-pack.yaml
+++ b/data/boosters/bok-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:chk t:basic"
+    count: 20

--- a/data/boosters/bro-collector-sample.yaml
+++ b/data/boosters/bro-collector-sample.yaml
@@ -18,6 +18,8 @@ sheets:
     foil: true
     any:
     - rawquery: "e:brr number<=63 -number:/z/ r:u"
+      count: 18
       rate: 5
     - rawquery: "e:brr number>63 -number:/z/ r:u"
+      count: 18
       rate: 1

--- a/data/boosters/bro-collector.yaml
+++ b/data/boosters/bro-collector.yaml
@@ -29,6 +29,7 @@ sheets:
   foil_fullart_basic:
     foil: true
     query: "r:b is:fullart"
+    count: 10
   foil_rare_mythic:
     foil: true
     use: rare_mythic
@@ -40,8 +41,10 @@ sheets:
     use: rare_mythic
   brr_retro_artifact_uncommon:
     rawquery: "e:brr number<=63 r:u -number:/z/"
+    count: 18
   brr_schematic_uncommon:
     rawquery: "e:brr number>=64 r:u -number:/z/"
+    count: 18
   brr_retro_artifact_rare_mythic:
     filter: "e:brr number<=63 -number:/z/"
     use: rare_mythic
@@ -70,16 +73,22 @@ sheets:
     foil: true
     any:
     - rawquery: "(e:bro or e:brc) promo:boosterfun r:r"
+      count: 68
       rate: 12
     - rawquery: "e:brr number<=63 r:r -number:/z/"
+      count: 30
       rate: 10
     - rawquery: "e:brr number>=64 r:r -number:/z/"
+      count: 30
       rate: 2
     - rawquery: "(e:bro or e:brc) promo:boosterfun r:m"
+      count: 27
       rate: 6
     - rawquery: "e:brr number<=63 r:m -number:/z/"
+      count: 15
       rate: 5
     - rawquery: "e:brr number>=64 r:m -number:/z/"
+      count: 15
       rate: 1
   double_rainbow_serialized:
     foil: true

--- a/data/boosters/bro-draft.yaml
+++ b/data/boosters/bro-draft.yaml
@@ -34,21 +34,29 @@ sheets:
     foil: true
     any:
     - query: "r<=c"
+      count: 111
       chance: 12
     - query: "r:u"
+      count: 116
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 6
         rate: 2
       - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 6
         rate: 4
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 117
         rate: 6
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 2
         rate: 1
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 2
         rate: 2
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 51
         rate: 3
       chance: 3
   mech_basic:

--- a/data/boosters/bro-set.yaml
+++ b/data/boosters/bro-set.yaml
@@ -22,44 +22,58 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   foil_with_showcase:
     # Copied from base set
     filter: "(e:bro is:baseset -number:268-277) or (e:brr -number:/z/)"
     foil: true
     any:
     - query: "r<=c"
+      count: 111
       chance: 12
     - query: "r:u"
+      count: 116
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 6
         rate: 2
       - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 6
         rate: 4
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 117
         rate: 6
       # foil versions of the commander (brc #1-28) and set-booster-exclusive
       # (#288-292) cards that the nonfoil wildcard carries but this foil slot was
       # missing (the slot filter is e:bro is:baseset, which excludes them);
       # rates are half the wildcard's, matching the rest of this foil slot
       - rawquery: "e:brc r:r number<=28"
+        count: 6
         rate: 6
       - rawquery: "e:{set} number:288-292"
+        count: 5
         rate: 6
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 2
         rate: 1
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 2
         rate: 2
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 51
         rate: 3
       - rawquery: "e:brc r:m number<=28"
+        count: 6
         rate: 3
       chance: 3
   basic:
     any:
     - rawquery: "e:bro number:268-277"
+      count: 10
       rate: 5
     - rawquery: "e:bro number:278-287"
+      count: 10
       rate: 2
   foil_basic:
     foil: true
@@ -70,38 +84,54 @@ sheets:
       chance: 700
     - any:
       - query: "r:u"
+        count: 80
         rate: 6
       - rawquery: "e:brr r:u number<=63"
+        count: 18
         rate: 5
       - rawquery: "e:brr r:u number>=64"
+        count: 18
         rate: 1
       chance: 175
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 6
         rate: 4
       - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 6
         rate: 8
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 57
         rate: 12
       - rawquery: "e:brr r:r number<=63"
+        count: 30
         rate: 10
       - rawquery: "e:brr r:r number>=64"
+        count: 30
         rate: 2
       - rawquery: "e:brc r:r number<=28"
+        count: 22
         rate: 12
       - rawquery: "e:{set} number:288-292"
+        count: 5
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 2
         rate: 2
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 2
         rate: 4
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 21
         rate: 6
       - rawquery: "e:brr r:m number<=63"
+        count: 15
         rate: 5
       - rawquery: "e:brr r:m number>=64"
+        count: 15
         rate: 1
       - rawquery: "e:brc r:m number<=28"
+        count: 6
         rate: 6
       chance: 125
     # A Transformers card appears in ~10% of Set Boosters via the wildcard
@@ -109,6 +139,7 @@ sheets:
     # outcome, not part of the rare/mythic tier. With 2 wildcard slots,
     # chance 54 (~5.12% per wildcard) gives ~10% per pack.
     - rawquery: "e:bot number<=15"
+      count: 14
       chance: 54
   brr_retro_artifact:
     filter: "e:brr -number:/z/"

--- a/data/boosters/chk-tournament.yaml
+++ b/data/boosters/chk-tournament.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   basics:
     query: "r:b"
+    count: 20
     duplicates: true
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 89
     duplicates: true

--- a/data/boosters/clb-draft.yaml
+++ b/data/boosters/clb-draft.yaml
@@ -22,19 +22,25 @@ sheets:
     balanced: true
     any:
     - rawquery: "e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart -t:legendary is:paper"
+      count: 10
       rate: 1
     - query: "r:c alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 10
       rate: 2
     - query: "r:c -alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 126
       rate: 3
   nonlegendary_uncommon_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart -t:legendary is:paper"
+      count: 4
       rate: 1
     - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 4
       rate: 2
     - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 71
       rate: 3
   nonlegendary_rare_with_showcase:
     # Showcase treatments 1/3 for relevant cards
@@ -44,17 +50,22 @@ sheets:
     - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
       rate: 2
     - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) (-t:legendary or Baldur's Gate)"
+      count: 47
       rate: 3
   nonlegendary_mythic_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -t:legendary t:dragon is:paper"
+      count: 10
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -t:legendary -t:dragon is:paper"
+      count: 5
       rate: 2
     - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 10
       rate: 4
     - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:legendary"
+      count: 7
       rate: 6
   nonlegendary_rare_mythic_with_showcase:
     any:
@@ -67,20 +78,26 @@ sheets:
     any:
     # no idea about ratios
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 30
       rate: 4
     - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 30
       rate: 8
     - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
       rate: 12
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 25
       rate: 2
     - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 25
       rate: 4
     - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background -t:land"
       rate: 6
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 5
       rate: 1
     - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 5
       rate: 2
     - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
       rate: 3
@@ -112,8 +129,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart t:dragon is:paper"
+        count: 10
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -t:dragon is:paper"
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4

--- a/data/boosters/clb-set.yaml
+++ b/data/boosters/clb-set.yaml
@@ -38,20 +38,26 @@ sheets:
     any:
     # no idea about ratios
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 30
       rate: 4
     - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 30
       rate: 8
     - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
       rate: 12
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 25
       rate: 2
     - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 25
       rate: 4
     - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background -t:land"
       rate: 6
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart t:legendary -t:background is:paper"
+      count: 5
       rate: 1
     - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
+      count: 5
       rate: 2
     - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) t:legendary -t:background"
       rate: 3
@@ -69,10 +75,13 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:clb number:646-685 r:r"
+        count: 28
         rate: 12
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper t:"elder dragon"'
+        count: 10
         rate: 1
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:"elder dragon"'
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4
@@ -91,8 +100,10 @@ sheets:
     filter: "e:clb is:etched number<=552"
     any:
     - query: "r:c or r:u"
+      count: 50
       chance: 2
     - query: "r:r or r:m"
+      count: 32
       chance: 1
   foil_with_showcase:
     foil: true
@@ -119,8 +130,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart t:dragon is:paper"
+        count: 10
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -t:dragon is:paper"
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4

--- a/data/boosters/clu-box-topper.yaml
+++ b/data/boosters/clu-box-topper.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   shock_land:
     rawquery: "e:{set} is:shockland"
+    count: 10
     foil: true

--- a/data/boosters/cmm-draft.yaml
+++ b/data/boosters/cmm-draft.yaml
@@ -20,46 +20,64 @@ sheets:
   nonlegendary_uncommon:
     any:
     - rawquery: "e:cmm r:u -t:legendary is:baseset -alt:(e:cmm promo:boosterfun)"
+      count: 66
       rate: 3
     - rawquery: "e:cmm r:u -t:legendary is:baseset alt:(e:cmm promo:boosterfun)"
+      count: 14
       rate: 2
     - rawquery: "e:cmm r:u -t:legendary promo:boosterfun"
+      count: 14
       rate: 1
   legendary_uncommon:
     any:
     - rawquery: "e:cmm r:u t:legendary is:baseset -alt:(e:cmm promo:boosterfun)"
+      count: 51
       rate: 3
     - rawquery: "e:cmm r:u t:legendary is:baseset alt:(e:cmm promo:boosterfun)"
+      count: 4
       rate: 2
     - rawquery: "e:cmm r:u t:legendary promo:boosterfun"
+      count: 4
       rate: 1
   nonlegendary_rare_mythic:
     any:
     - rawquery: "e:cmm r:r -t:legendary is:baseset -alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 57
       rate: 6
     - rawquery: "e:cmm r:r -t:legendary is:baseset alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 23
       rate: 4
     - rawquery: "e:cmm r:r -t:legendary promo:boosterfun -is:foilonly alt:is:baseset"
+      count: 27
       rate: 2
     - rawquery: "e:cmm r:m -t:legendary is:baseset -alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 9
       rate: 3
     - rawquery: "e:cmm r:m -t:legendary is:baseset alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 9
       rate: 2
     - rawquery: "e:cmm r:m -t:legendary promo:boosterfun -is:foilonly alt:is:baseset"
+      count: 9
       rate: 1
   legendary_rare_mythic:
     any:
     - rawquery: "e:cmm r:r t:legendary is:baseset -alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 44
       rate: 6
     - rawquery: "e:cmm r:r t:legendary is:baseset alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 11
       rate: 4
     - rawquery: "e:cmm r:r t:legendary promo:boosterfun -is:foilonly alt:is:baseset"
+      count: 11
       rate: 2
     - rawquery: "e:cmm r:m t:legendary is:baseset -alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 8
       rate: 3
     - rawquery: "e:cmm r:m t:legendary is:baseset alt:(e:cmm promo:boosterfun -is:foilonly)"
+      count: 9
       rate: 2
     - rawquery: "e:cmm r:m t:legendary promo:boosterfun -is:foilonly alt:is:baseset"
+      count: 9
       rate: 1
   foil:
     foil: true
@@ -68,6 +86,7 @@ sheets:
       - use: common_with_showcase
         chance: 130
       - query: "r:b"
+        count: 15
         chance: 15
       chance: 12
     - use: uncommon_with_showcase

--- a/data/boosters/cmm-set.yaml
+++ b/data/boosters/cmm-set.yaml
@@ -26,10 +26,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 130
   nonlegendary_uncommon:
     rawquery: "e:cmm r:u -t:legendary is:baseset"
+    count: 80
   legendary_uncommon:
     rawquery: "e:cmm r:u t:legendary is:baseset"
+    count: 55
   nonlegendary_rare_mythic:
     filter: "e:cmm -t:legendary is:baseset"
     use: rare_mythic
@@ -55,6 +58,7 @@ sheets:
       - use: common_with_showcase
         chance: 130
       - query: "r:b"
+        count: 15
         chance: 15
       chance: 12
     - use: uncommon_with_showcase

--- a/data/boosters/cmr-draft.yaml
+++ b/data/boosters/cmr-draft.yaml
@@ -47,6 +47,7 @@ sheets:
     - use: rare_mythic
       chance: 1
     - query: "r:u"
+      count: 120
       chance: 3
     - query: "r:c or r:s"
       count: 141 + 1
@@ -59,5 +60,6 @@ sheets:
     - use: base_1248_by_rarity
       chance: 245
     - rawquery: "e:cmr number:546"
+      count: 1
       chance: 1
     count: 103

--- a/data/boosters/cn2-draft.yaml
+++ b/data/boosters/cn2-draft.yaml
@@ -50,8 +50,10 @@ sheets:
     foil: true
     any:
     - query: "-t:conspiracy r<=c"
+      count: 85
       chance: 12
     - query: "-t:conspiracy r:u"
+      count: 65
       chance: 5
     - use: nonconspiracy_rare_mythic
       chance: 3

--- a/data/boosters/cns-draft.yaml
+++ b/data/boosters/cns-draft.yaml
@@ -55,8 +55,10 @@ sheets:
     foil: true
     any:
     - query: "-is:draft r:c"
+      count: 80
       chance: 12
     - query: "-is:draft r:u"
+      count: 60
       chance: 5
     - use: nondraft_rare_mythic
       chance: 3

--- a/data/boosters/con-draft.yaml
+++ b/data/boosters/con-draft.yaml
@@ -14,3 +14,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:ala r:b"
+    count: 20

--- a/data/boosters/con-six.yaml
+++ b/data/boosters/con-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 60
   basic:
     rawquery: "e:ala t:basic"
+    count: 20

--- a/data/boosters/csp-draft.yaml
+++ b/data/boosters/csp-draft.yaml
@@ -13,3 +13,4 @@ sheets:
   common_or_basic:
     balanced: true
     query: "r<=c"
+    count: 60

--- a/data/boosters/dft-collector.yaml
+++ b/data/boosters/dft-collector.yaml
@@ -28,11 +28,14 @@ sheets:
   foil_driver_seat_land:
     foil: true
     query: "{driver_basic}"
+    count: 5
   revved_up_cu:
     any:
     - rawquery: "{revved_up} r:c"
+      count: 9
       chance: 15
     - rawquery: "{revved_up} r:u"
+      count: 17
       chance: 17
   foil_revved_up_cu:
     foil: true
@@ -43,33 +46,43 @@ sheets:
   showcase_commander:
     any:
     - rawquery: "e:drc number<=4"
+      count: 4
       rate: 1
     - rawquery: "e:drc frame:extendedart"
+      count: 16
       rate: 2
   foil_showcase_commander:
     foil: true
     rawquery: "e:drc number<=4"
+    count: 4
   booster_fun:
     any:
     - rawquery: "{boosterfun} r:r"
+      count: 60
       rate: 2
     - rawquery: "{boosterfun} r:m"
+      count: 18
       rate: 1
   foil_booster_fun:
     foil: true
     any:
     - rawquery: "{boosterfun} r:r"
+      count: 60
       chance: 7460
     - rawquery: "{boosterfun} r:m"
+      count: 18
       chance: 1120
     - rawquery: "{jp_showcase}"
+      count: 10
       chance: 900
     - rawquery: "{fracture_foil}"
+      count: 10
       chance: 100
     - set: spg
       code: "DFT"
       chance: 420
     - rawquery: "{serialized_aetherspark}"
+      count: 1
       chance: 2
 
 ########## foil_booster_fun sheet:

--- a/data/boosters/dft-play.yaml
+++ b/data/boosters/dft-play.yaml
@@ -27,6 +27,7 @@ queries:
 sheets:
   common:
     query: "r:c -{dual_land} -t:basic"
+    count: 81
   common_with_showcase:
     any:
     - rawquery: "{revved_up} r:c"
@@ -41,18 +42,24 @@ sheets:
   uncommon_with_showcase:
     any:
     - rawquery: "{revved_up} r:u"
+      count: 17
       rate: 1
     - query: "r:u alt:({revved_up})"
+      count: 17
       rate: 3
     - query: "r:u -alt:({revved_up})"
+      count: 83
       rate: 4
   non_foil_land:
     any:
       - query: "{dual_land}"
+        count: 10
         chance: 4
       - query: "{normal_basic}"
+        count: 15
         chance: 3
       - query: "{driver_basic}"
+        count: 5
         chance: 1
   foil_land:
     foil: true
@@ -62,18 +69,24 @@ sheets:
     any:
     - any:
       - rawquery: "{boosterfun} r:r"
+        count: 45
         rate: 1
       - query: "r:r alt:({boosterfun})"
+        count: 45
         rate: 3
       - query: "r:r -alt:({boosterfun})"
+        count: 15
         rate: 4
       chance: 6
     - any:
       - rawquery: "{boosterfun} r:m"
+        count: 13
         rate: 1
       - query: "r:m alt:({boosterfun})"
+        count: 13
         rate: 3
       - query: "r:m -alt:({boosterfun})"
+        count: 7
         rate: 4
       chance: 1
   wildcard:

--- a/data/boosters/dgm-six.yaml
+++ b/data/boosters/dgm-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 70
   basic:
     rawquery: "e:rtr t:basic"
+    count: 25

--- a/data/boosters/dis-draft.yaml
+++ b/data/boosters/dis-draft.yaml
@@ -20,3 +20,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 60

--- a/data/boosters/dka-draft.yaml
+++ b/data/boosters/dka-draft.yaml
@@ -36,3 +36,4 @@ sheets:
   basic:
     # borrowed basic
     rawquery: "e:isd r:b"
+    count: 15

--- a/data/boosters/dka-six.yaml
+++ b/data/boosters/dka-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 64
   basic:
     rawquery: "e:isd t:basic"
+    count: 15

--- a/data/boosters/dmr-collector.yaml
+++ b/data/boosters/dmr-collector.yaml
@@ -13,6 +13,7 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:{set} r:b"
+    count: 10
   foil_rare_mythic:
     foil: true
     use: rare_mythic

--- a/data/boosters/dmr-draft.yaml
+++ b/data/boosters/dmr-draft.yaml
@@ -39,16 +39,22 @@ sheets:
   rare_mythic_with_showcase:
     any:
     - rawquery: "e:{set} r:r is:borderless"
+      count: 23
       rate: 2
     - query: "r:r alt:(e:{set} r:r is:borderless)"
+      count: 23
       rate: 4
     - query: "r:r -alt:(e:{set} r:r is:borderless)"
+      count: 37
       rate: 6
     - rawquery: "e:{set} r:m is:borderless"
+      count: 17
       rate: 1
     - query: "r:m alt:(e:{set} r:m is:borderless)"
+      count: 17
       rate: 2
     - query: "r:m -alt:(e:{set} r:m is:borderless)"
+      count: 3
       rate: 3
   rare_mythic_retro:
     filter: "e:{set} frame:old"

--- a/data/boosters/dmu-collector-sample.yaml
+++ b/data/boosters/dmu-collector-sample.yaml
@@ -16,4 +16,5 @@ sheets:
     use: nonfoil_rare_mythic
   foil_uncommon_showcase:
     rawquery: "e:dmu frame:showcase r:u"
+    count: 40
     foil: true

--- a/data/boosters/dmu-draft.yaml
+++ b/data/boosters/dmu-draft.yaml
@@ -26,6 +26,7 @@ sheets:
   legendary_uncommon:
     any:
     - query: 't:"legendary creature" r:u'
+      count: 20
       rate: 2
     - use: uncommon_showcase
       rate: 1
@@ -36,30 +37,42 @@ sheets:
   legendary_rare_mythic:
     any:
     - query: 't:"legendary creature" r:r'
+      count: 14
       rate: 8
     - rawquery: 'e:{set} r:r t:"legendary creature" promo:boosterfun -is:foilonly -frame:extendedart is:paper'
+      count: 14
       rate: 4
     - query: 't:"legendary creature" r:m'
+      count: 7
       rate: 4
     - rawquery: 'e:{set} r:m t:"legendary creature" promo:boosterfun -is:foilonly -frame:extendedart is:paper -Sheoldred'
+      count: 6
       rate: 2
     - rawquery: 'e:{set} Sheoldred, the Apocalypse promo:boosterfun number<=427'
+      count: 2
       rate: 1
   nonlegendary_rare_mythic:
     any:
     - rawquery: 'e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:"legendary creature"'
+      count: 6
       rate: 8
     - query: 'r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) -t:"legendary creature"'
+      count: 6
       rate: 16
     - query: 'r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) -t:"legendary creature"'
+      count: 40
       rate: 24
     - rawquery: "e:dmu Ajani, Sleeper Agent -is:foilonly -frame:extendedart is:paper promo:boosterfun"
+      count: 4
       rate: 1
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:"legendary creature" -(Ajani, Sleeper Agent)'
+      count: 3
       rate: 4
     - query: 'r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:"legendary creature"'
+      count: 4
       rate: 8
     - query: 'r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:"legendary creature"'
+      count: 9
       rate: 12
   foil_with_showcase:
     foil: true
@@ -80,10 +93,13 @@ sheets:
       - use: rare_has_no_showcase
         rate: 24
       - rawquery: "e:dmu Ajani, Sleeper Agent -is:foilonly -frame:extendedart is:paper promo:boosterfun"
+        count: 4
         rate: 1
       - rawquery: "e:dmu Sheoldred, the Apocalypse -is:foilonly -frame:extendedart is:paper promo:boosterfun number<=427"
+        count: 2
         rate: 2
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Ajani, Sleeper Agent or Sheoldred, the Apocalypse)'
+        count: 9
         rate: 4 
       - use: mythic_has_showcase
         rate: 8

--- a/data/boosters/dmu-set.yaml
+++ b/data/boosters/dmu-set.yaml
@@ -20,6 +20,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   wildcard:
     any:
     - use: common
@@ -34,20 +35,26 @@ sheets:
       - use: rare_has_no_showcase
         rate: 24
       - rawquery: "e:dmu number:282-286"
+        count: 5
         rate: 24
       - rawquery: "e:dmc number:1-28 r:r"
+        count: 22
         rate: 24
       - rawquery: "e:dmu Ajani, Sleeper Agent -is:foilonly -frame:extendedart is:paper promo:boosterfun"
+        count: 4
         rate: 1
       - rawquery: "e:dmu Sheoldred, the Apocalypse -is:foilonly -frame:extendedart is:paper promo:boosterfun number<=427"
+        count: 2
         rate: 2
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Ajani, Sleeper Agent or Sheoldred, the Apocalypse)'
+        count: 9
         rate: 4 
       - use: mythic_has_showcase
         rate: 8
       - use: mythic_has_no_showcase
         rate: 12
       - rawquery: "e:dmc number:1-28 r:m"
+        count: 6
         rate: 12
       chance: 125
   the_list:
@@ -80,19 +87,25 @@ sheets:
       # commander cards (dmc #1-28) that the nonfoil wildcard slot carries but
       # this foil slot was missing
       - rawquery: "e:dmu number:282-286"
+        count: 5
         rate: 24
       - rawquery: "e:dmc number:1-28 r:r"
+        count: 6
         rate: 24
       - rawquery: "e:dmu Ajani, Sleeper Agent -is:foilonly -frame:extendedart is:paper promo:boosterfun"
+        count: 4
         rate: 1
       - rawquery: "e:dmu Sheoldred, the Apocalypse -is:foilonly -frame:extendedart is:paper promo:boosterfun number<=427"
+        count: 2
         rate: 2
       - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Ajani, Sleeper Agent or Sheoldred, the Apocalypse)'
+        count: 9
         rate: 4
       - use: mythic_has_showcase
         rate: 8
       - use: mythic_has_no_showcase
         rate: 12
       - rawquery: "e:dmc number:1-28 r:m"
+        count: 6
         rate: 12
       chance: 3

--- a/data/boosters/dom-theme-b.yaml
+++ b/data/boosters/dom-theme-b.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/dom-theme-g.yaml
+++ b/data/boosters/dom-theme-g.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/dom-theme-r.yaml
+++ b/data/boosters/dom-theme-r.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/dom-theme-u.yaml
+++ b/data/boosters/dom-theme-u.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/dom-theme-w.yaml
+++ b/data/boosters/dom-theme-w.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 6
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/dsk-collector-sample.yaml
+++ b/data/boosters/dsk-collector-sample.yaml
@@ -19,20 +19,26 @@ sheets:
     foil: true
     any:
     - query: "r:u -alt:({lurking_evil} or {showcase})"
+      count: 92
       rate: 4
     - query: "r:u alt:({lurking_evil} or {showcase})"
+      count: 8
       rate: 3
     - rawquery: "r:u ({lurking_evil} or {showcase})"
+      count: 8
       rate: 1
   booster_fun:
     any:
     - rawquery: "r:m {two_instances}"
+      count: 2
       rate: 1
     - rawquery: "r:m {any_boosterfun} -alt:{two_instances}"
+      count: 14
       rate: 2
     - rawquery: "r:r {two_instances}"
       rate: 2
     - rawquery: "r:r {any_boosterfun} -alt:{two_instances}"
+      count: 46
       rate: 4
   foil_booster_fun:
     foil: true

--- a/data/boosters/dsk-collector.yaml
+++ b/data/boosters/dsk-collector.yaml
@@ -25,57 +25,76 @@ sheets:
     foil: true
     any:
     - query: "r:c -alt:{lurking_evil} -(t:land -terramorphic)"
+      count: 79
       rate: 4
     - query: "r:c alt:{lurking_evil}"
+      count: 2
       rate: 3
     - rawquery: "r:c {lurking_evil}"
+      count: 2
       rate: 1
   foil_uncommon:
     # Showcase treatments 1/4 for relevant cards
     foil: true
     any:
     - query: "r:u -alt:({lurking_evil} or {showcase})"
+      count: 92
       rate: 4
     - query: "r:u alt:({lurking_evil} or {showcase})"
+      count: 8
       rate: 3
     - rawquery: "r:u ({lurking_evil} or {showcase})"
+      count: 8
       rate: 1
   foil_basic:
     foil: true
     query: "t:basic is:fullart"
+    count: 5
   foil_rare_mythic:
     foil: true
     any:
     - rawquery: "r:r {lurking_evil}"
+      count: 7
       rate: 2
     - query: "r:r alt:{lurking_evil}"
+      count: 7
       rate: 6
     - query: "r:r -alt:{lurking_evil}"
+      count: 53
       rate: 8
     - rawquery: "r:m {lurking_evil}"
+      count: 2
       rate: 1
     - query: "r:m alt:{lurking_evil}"
+      count: 2
       rate: 3
     - query: "r:m -alt:{lurking_evil}"
+      count: 18
       rate: 4
   showcase_commander:
     any:
     - rawquery: "e:dsc number<=8"
+      count: 8
       rate: 1
     - rawquery: "e:dsc frame:extendedart"
+      count: 27
       rate: 2
   foil_showcase_commander:
     foil: true
     rawquery: "e:dsc number<=8"
+    count: 8
   booster_fun:
     any:
     - rawquery: "r:m {two_instances}"
+      count: 2
       rate: 1
     - rawquery: "r:m {any_boosterfun} -alt:{two_instances}"
+      count: 19
       rate: 2
     - rawquery: "r:r {two_instances} -number:417" # 417 is the BaB
       rate: 2
     - rawquery: "r:r {any_boosterfun} -alt:{two_instances} -number:417"
+      count: 59
       rate: 4
   foil_booster_fun:
     foil: true
@@ -83,10 +102,13 @@ sheets:
     - use: booster_fun
       chance: 859
     - rawquery: "e:{set} number:386-395"
+      count: 10
       chance: 90
     - rawquery: "e:{set} number:396-405"
+      count: 10
       chance: 10
     - rawquery: "e:{set} number:406-410"
+      count: 5
       chance: 10
     - set: spg
       code: "DSK"

--- a/data/boosters/dsk-play.yaml
+++ b/data/boosters/dsk-play.yaml
@@ -27,19 +27,25 @@ sheets:
     # Showcase treatments 1/4 for relevant cards
     any:
     - query: "r:c -alt:{lurking_evil} -(t:land -terramorphic)"
+      count: 79
       rate: 4
     - query: "r:c alt:{lurking_evil}"
+      count: 2
       rate: 3
     - rawquery: "r:c {lurking_evil}"
+      count: 2
       rate: 1
   uncommon:
     # Showcase treatments 1/4 for relevant cards
     any:
     - query: "r:u -alt:({lurking_evil} or {showcase})"
+      count: 92
       rate: 4
     - query: "r:u alt:({lurking_evil} or {showcase})"
+      count: 8
       rate: 3
     - rawquery: "r:u ({lurking_evil} or {showcase})"
+      count: 8
       rate: 1
   land:
     # Article: full-art manor lands 16.7% (the 5 full-art basics), regular
@@ -48,10 +54,13 @@ sheets:
     # with the regular basics.
     any:
     - query: "t:basic is:fullart"
+      count: 5
       chance: 1
     - query: "t:basic -is:fullart"
+      count: 10
       chance: 2
     - query: "r:c t:land -terramorphic"
+      count: 10
       chance: 3
   foil_land:
     foil: true
@@ -60,23 +69,31 @@ sheets:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "r:m {two_instances}"
+      count: 6
       rate: 1
     - rawquery: "r:m {any_boosterfun} -alt:{two_instances}"
+      count: 12
       rate: 2
     - query: "r:m alt:{any_boosterfun}"
+      count: 15
       rate: 6
     - query: "r:m -alt:{any_boosterfun}"
+      count: 5
       rate: 8
   rare_with_showcase:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "r:r {two_instances}"
+      count: 14
       rate: 1
     - rawquery: "r:r {any_boosterfun} -alt:{two_instances}"
+      count: 39
       rate: 2
     - query: "r:r alt:{any_boosterfun}"
+      count: 46
       rate: 6
     - query: "r:r -alt:{any_boosterfun}"
+      count: 14
       rate: 8
   rare_mythic_with_showcase:
     any:

--- a/data/boosters/dst-fat-pack.yaml
+++ b/data/boosters/dst-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:mrd t:basic"
+    count: 20

--- a/data/boosters/dtk-fat-pack.yaml
+++ b/data/boosters/dtk-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:dtk t:basic"
+    count: 15

--- a/data/boosters/dtk-prerelease-atarka.yaml
+++ b/data/boosters/dtk-prerelease-atarka.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 28
   promo:
     foil: true
     any:
     - rawquery: "e:pdtk r:m (w:atarka or (id<=rg and -w:*)) promo:prerelease"
+      count: 1
       rate: 1
     - rawquery: "e:pdtk r:r (w:atarka or (id<=rg and -w:*)) promo:prerelease"
+      count: 7
       rate: 2

--- a/data/boosters/dtk-prerelease-dromoka.yaml
+++ b/data/boosters/dtk-prerelease-dromoka.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 30
   promo:
     foil: true
     any:
     - rawquery: "e:pdtk r:m (w:dromoka or (id<=gw and -w:*)) promo:prerelease"
+      count: 1
       rate: 1
     - rawquery: "e:pdtk r:r (w:dromoka or (id<=gw and -w:*)) promo:prerelease"
+      count: 7
       rate: 2

--- a/data/boosters/dtk-prerelease-kolaghan.yaml
+++ b/data/boosters/dtk-prerelease-kolaghan.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 27
   promo:
     foil: true
     any:
     - rawquery: "e:pdtk r:m (w:kolaghan or (id<=br and -w:*)) promo:prerelease"
+      count: 1
       rate: 1
     - rawquery: "e:pdtk r:r (w:kolaghan or (id<=br and -w:*)) promo:prerelease"
+      count: 9
       rate: 2

--- a/data/boosters/dtk-prerelease-ojutai.yaml
+++ b/data/boosters/dtk-prerelease-ojutai.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 26
   promo:
     foil: true
     any:
     - rawquery: "e:pdtk r:m (w:ojutai or (id<=wu and -w:*)) promo:prerelease"
+      count: 1
       rate: 1
     - rawquery: "e:pdtk r:r (w:ojutai or (id<=wu and -w:*)) promo:prerelease"
+      count: 7
       rate: 2

--- a/data/boosters/dtk-prerelease-silumgar.yaml
+++ b/data/boosters/dtk-prerelease-silumgar.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 28
   promo:
     foil: true
     any:
     - rawquery: "e:pdtk r:m (w:silumgar or (id<=ub and -w:*)) promo:prerelease"
+      count: 1
       rate: 1
     - rawquery: "e:pdtk r:r (w:silumgar or (id<=ub and -w:*)) promo:prerelease"
+      count: 7
       rate: 2

--- a/data/boosters/ecl-play.yaml
+++ b/data/boosters/ecl-play.yaml
@@ -51,8 +51,10 @@ sheets:
   rare_mythic:
     any:
       - rawquery: "e:{set} number:1-268 r:r" # Regular rare
+        count: 65
         rate: 2
       - rawquery: "e:{set} number:1-268 r:m" # Regular mythic
+        count: 22
         rate: 1
 
   uncommon_fable:
@@ -81,8 +83,10 @@ sheets:
   # Assumes all boosterfun use 2:1 ratio, even though that's for sure not true for the Collector Booster
     any:
     - rawquery: "{boosterfun} r:r"
+      count: 36
       rate: 2
     - rawquery: "{boosterfun} r:m"
+      count: 22
       rate: 1
 
   wildcard:

--- a/data/boosters/eld-collector.yaml
+++ b/data/boosters/eld-collector.yaml
@@ -44,14 +44,20 @@ sheets:
     foil: true
     any:
     - query: "r:r"
+      count: 53
       rate: 4
     - rawquery: "e:eld r:r promo:boosterfun"
+      count: 53
       rate: 2
     - query: "r:m"
+      count: 15
       rate: 2
     - rawquery: "e:eld r:m promo:boosterfun"
+      count: 15
       rate: 1
     - rawquery: "e:eld r:r -promo:boosterfun number>=304 -frame:inverted"
+      count: 1
       rate: 4
     - rawquery: "e:eld r:m -promo:boosterfun number>=304 -frame:inverted"
+      count: 6
       rate: 2

--- a/data/boosters/eld-theme-b.yaml
+++ b/data/boosters/eld-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 19
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/eld-theme-g.yaml
+++ b/data/boosters/eld-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 19
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/eld-theme-r.yaml
+++ b/data/boosters/eld-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 19
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/eld-theme-u.yaml
+++ b/data/boosters/eld-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 19
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/eld-theme-w.yaml
+++ b/data/boosters/eld-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 29
       rate: 1
     - query: "r:c -id:c"
+      count: 18
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 19
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/emn-draft.yaml
+++ b/data/boosters/emn-draft.yaml
@@ -47,11 +47,14 @@ sheets:
     foil: true
     any:
     - rawquery: "(e:emn r:c) or (e:soi r:b)"
+      count: 89
       chance: 12
     - query: "r:u"
+      count: 70
       chance: 5
     - use: rare_mythic
       chance: 3
   basic:
     # borrowed basics
     rawquery: "e:soi r:b"
+    count: 15

--- a/data/boosters/eoe-collector.yaml
+++ b/data/boosters/eoe-collector.yaml
@@ -116,34 +116,46 @@ sheets:
     # Chance of getting sheet = 36% + 9% + 18% + 4% = 67%
     any:
     - rawquery: "{stellar_sights} r=r" # Rare Stellar Sights
+      count: 30
       chance: 36
     - rawquery: "{stellar_sights} r=m" # Mythic Stellar Sights
+      count: 15
       chance: 9
     - rawquery: "{poster_stellar_sights} r=r" # Rare Poster Stellar Sights
+      count: 30
       chance: 18
     - rawquery: "{poster_stellar_sights} r=m" # Mythic Poster Stellar Sights
+      count: 15
       chance: 4
   foil_stellar_sights_land:
     # Chance of getting sheet = 22.5%
     foil: true
     any:
     - rawquery: "{stellar_sights} r=r" # Foil Rare Stellar Sights
+      count: 30
       chance: 120 
     - rawquery: "{stellar_sights} r=m" # Foil Mythic Stellar Sights
+      count: 15
       chance: 30 
     - rawquery: "{poster_stellar_sights} r=r" # Foil Rare Poster Stellar Sights
+      count: 30
       chance: 60 
     - rawquery: "{poster_stellar_sights} r=m" # Foil Mythic Poster Stellar Sights
+      count: 15
       chance: 15 
   galaxy_stellar_sights_land:
     # Chance of getting sheet = 10.5% (+ "less than 1%") 
     foil: true
     any:
     - rawquery: "{galaxy_stellar_sights} r=r" # Galaxy Foil Rare Stellar Sights
+      count: 30
       chance: 600 
     - rawquery: "{galaxy_stellar_sights} r=m" # Galaxy Foil Mythic Stellar Sights
+      count: 15
       chance: 150
     - rawquery: "{galaxy_poster_stellar_sights} r=r" # Galaxy Foil Rare Poster Stellar Sights
+      count: 30
       chance: 300 
     - rawquery: "{galaxy_poster_stellar_sights} r=m" # Galaxy Foil Mythic Poster Stellar Sights
+      count: 15
       chance: 75

--- a/data/boosters/eve-draft.yaml
+++ b/data/boosters/eve-draft.yaml
@@ -13,3 +13,4 @@ sheets:
     # balancing algorithm doesn't support heavily multicolor sets
     balanced: false
     query: "r:c"
+    count: 60

--- a/data/boosters/fdn-collector.yaml
+++ b/data/boosters/fdn-collector.yaml
@@ -25,37 +25,49 @@ sheets:
     # Same as foil_common: FDN borderless uncommons appear at full rate.
     foil: true
     rawquery: "e:{set} r:u (is:baseset or number:292-361)"
+    count: 109
   foil_basic:
     foil: true
     query: "t:basic is:fullart"
+    count: 10
   foil_rare_mythic:
     foil: true
     any:
     - query: "r:r"
+      count: 60
       rate: 2
     - query: "r:m"
+      count: 20
       rate: 1
   showcase_rare_mythic:
     any:
     - rawquery: "r:r ({borderless} or {extended})"
+      count: 80
       rate: 2
     - rawquery: "r:m ({borderless} or {extended})"
+      count: 26
       rate: 1
   foil_booster_fun:
     foil: true
     any:
     - rawquery: "r:r ({borderless} or {extended})"
+      count: 80
       chance: 345+296
     - rawquery: "r:m ({borderless} or {extended})"
+      count: 26
       chance: 68+36
     - rawquery: "r:r {mana_foil}"
+      count: 43
       chance: 84
     - rawquery: "r:m {mana_foil}"
+      count: 17
       chance: 16
     - set: spg
       code: "FDN"
       chance: 55
     - rawquery: "{jp_showcase}"
+      count: 10
       chance: 90
     - rawquery: "{fracture_foil}"
+      count: 10
       chance: 10

--- a/data/boosters/fdn-play.yaml
+++ b/data/boosters/fdn-play.yaml
@@ -43,34 +43,46 @@ sheets:
   common_with_showcase:
     any:
     - rawquery: "e:{set} r:c {borderless}"
+      count: 2
       rate: 1
     - query: "r:c alt:{borderless} number<=291"
+      count: 2
       rate: 7
     - query: "r:c -alt:{borderless} number<=291"
+      count: 88
       rate: 8
   uncommon_with_showcase:
     any:
     - rawquery: "e:{set} r:u {borderless}"
+      count: 8
       rate: 1
     - query: "r:u alt:{borderless} number<=291"
+      count: 8
       rate: 7
     - query: "r:u -alt:{borderless} number<=291"
+      count: 93
       rate: 8
   rare_with_showcase:
     any:
     - rawquery: "e:{set} r:r {borderless}"
+      count: 43
       rate: 1
     - query: "r:r alt:{borderless} number<=291"
+      count: 43
       rate: 7
     - query: "r:r -alt:{borderless} number<=291"
+      count: 17
       rate: 8
   mythic_with_showcase:
     any:
     - rawquery: "e:{set} r:m {borderless}"
+      count: 17
       rate: 1
     - query: "r:m alt:{borderless} number<=291"
+      count: 17
       rate: 7
     - query: "r:m -alt:{borderless} number<=291"
+      count: 3
       rate: 8
   rare_mythic_with_showcase:
     any:

--- a/data/boosters/fin-collector-sample.yaml
+++ b/data/boosters/fin-collector-sample.yaml
@@ -11,6 +11,7 @@ pack:
 sheets:
   nonfoil:
     rawquery: "e:fic number:101-208"
+    count: 108
   foil:
     foil: true
     use: nonfoil

--- a/data/boosters/fin-collector.yaml
+++ b/data/boosters/fin-collector.yaml
@@ -108,6 +108,7 @@ sheets:
   non_foil_boosterfun_rare_mythic:
     any:
       - rawquery: "{boosterfun} r:r" # Non-foil main set Booster Fun rare
+        count: 57
         chance: 231 # 23.1%
       - rawquery: "{boosterfun} r:m" # Non-foil main set Booster Fun mythic rare
         chance: 38 # 3.8%

--- a/data/boosters/fin-play.yaml
+++ b/data/boosters/fin-play.yaml
@@ -67,6 +67,7 @@ sheets:
         chance: 26 # 2.6%
         count: 3
       - rawquery: "r:u ({woodblock} or {character})"
+        count: 16
         chance: 57 # 5.7%
       - use: rare_mythic
         chance: 167 # 16.7%
@@ -80,8 +81,10 @@ sheets:
       chance: 100 # 10%
       count: 20
     - rawquery: "e:{set} r:r is:borderless (number<519 or number:577)" # Borderless rare
+      count: 57
       chance: 80 # 8%
     - rawquery: "e:{set} r:m is:borderless (number<519 or number:577)" # Borderless mythic
+      count: 22
       chance: 10 # 1%
     - rawquery: "r:r {artist}"
       chance: 5 # 0.5%
@@ -96,6 +99,7 @@ sheets:
       - use: common
         chance: 5575 # 55.75%
       - query: "{uncommon_without_cid}"
+        count: 108
         chance: 3590
       - query: "r:r"
         chance: 550
@@ -107,10 +111,13 @@ sheets:
         chance: 10
         count: 3
       - rawquery: "{boosterfun} r:u" # Uncommon boosterfun
+        count: 30
         chance: 50
       - rawquery: "{boosterfun} r:r"
+        count: 57
         chance: 100
       - rawquery: "{boosterfun} r:m"
+        count: 22
         chance: 25
       - rawquery: "{regular_cid}"
         chance: 25

--- a/data/boosters/gpt-draft.yaml
+++ b/data/boosters/gpt-draft.yaml
@@ -20,3 +20,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 55

--- a/data/boosters/grn-arena.yaml
+++ b/data/boosters/grn-arena.yaml
@@ -7,5 +7,7 @@ sheets:
   common:
     balanced: true
     query: "r:c not:guildgate"
+    count: 101
   land:
     query: "is:guildgate"
+    count: 10

--- a/data/boosters/grn-draft.yaml
+++ b/data/boosters/grn-draft.yaml
@@ -14,6 +14,7 @@ sheets:
   common:
     balanced: true
     query: "r:c not:guildgate"
+    count: 101
   land:
     query: "is:guildgate"
     count: 10

--- a/data/boosters/grn-theme-boros.yaml
+++ b/data/boosters/grn-theme-boros.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 33
       rate: 1
     - query: "r:c -id:c"
+      count: 32
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 27
       rate: 1
     - query: "r:u -id:c"
+      count: 22
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/grn-theme-dimir.yaml
+++ b/data/boosters/grn-theme-dimir.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 35
       rate: 1
     - query: "r:c -id:c"
+      count: 34
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 20
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/grn-theme-golgari.yaml
+++ b/data/boosters/grn-theme-golgari.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 32
       rate: 1
     - query: "r:c -id:c"
+      count: 31
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 20
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/grn-theme-izzet.yaml
+++ b/data/boosters/grn-theme-izzet.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 32
       rate: 1
     - query: "r:c -id:c"
+      count: 31
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 17
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 12
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/grn-theme-selesnya.yaml
+++ b/data/boosters/grn-theme-selesnya.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 34
       rate: 1
     - query: "r:c -id:c"
+      count: 33
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 26
       rate: 1
     - query: "r:u -id:c"
+      count: 21
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/gtc-draft.yaml
+++ b/data/boosters/gtc-draft.yaml
@@ -14,3 +14,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:rtr r:b"
+    count: 25

--- a/data/boosters/gtc-prerelease-boros.yaml
+++ b/data/boosters/gtc-prerelease-boros.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Aurelia the Warleader"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 34

--- a/data/boosters/gtc-prerelease-dimir.yaml
+++ b/data/boosters/gtc-prerelease-dimir.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Lazav, Dimir Mastermind"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 34

--- a/data/boosters/gtc-prerelease-gruul.yaml
+++ b/data/boosters/gtc-prerelease-gruul.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Borborygmos Enraged"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 34

--- a/data/boosters/gtc-prerelease-orzhov.yaml
+++ b/data/boosters/gtc-prerelease-orzhov.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Obzedat, Ghost Council"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 34

--- a/data/boosters/gtc-prerelease-simic.yaml
+++ b/data/boosters/gtc-prerelease-simic.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Prime Speaker Zegana"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 34

--- a/data/boosters/gtc-six.yaml
+++ b/data/boosters/gtc-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   basic:
     rawquery: "e:rtr t:basic"
+    count: 25

--- a/data/boosters/hou-draft.yaml
+++ b/data/boosters/hou-draft.yaml
@@ -15,8 +15,10 @@ sheets:
     - use: rare_mythic
       chance: 3*7
     - query: "r:u"
+      count: 60
       chance: 5*7
     - query: "r<=c"
+      count: 85
       chance: 12*7
     - rawquery: "e:mp2 number>=31"
       count: 24

--- a/data/boosters/ice-starter.yaml
+++ b/data/boosters/ice-starter.yaml
@@ -11,6 +11,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 121
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/iko-arena.yaml
+++ b/data/boosters/iko-arena.yaml
@@ -16,12 +16,16 @@ sheets:
   nongainland_common_baseset:
     balanced: true
     query: "r:c -is:gainland is:baseset"
+    count: 101
   uncommon_baseset:
     query: "r:u is:baseset"
+    count: 80
   rare_mythic_baseset:
     any:
     - query: "r:r is:baseset"
+      count: 53
       rate: 2
     - query: "r:m is:baseset"
+      count: 15
       rate: 1
 

--- a/data/boosters/iko-box-topper.yaml
+++ b/data/boosters/iko-box-topper.yaml
@@ -6,3 +6,4 @@ sheets:
   box_topper:
     foil: true
     rawquery: "e:iko is:boxtopper"
+    count: 15

--- a/data/boosters/iko-collector-jp.yaml
+++ b/data/boosters/iko-collector-jp.yaml
@@ -30,12 +30,16 @@ sheets:
     foil: true
     any:
     - rawquery: "e:iko r:r frame:extendedart"
+      count: 43
       rate: 2
     - query: "r:r"
+      count: 53
       rate: 4
     - rawquery: "e:iko r:m frame:extendedart"
+      count: 7
       rate: 1
     - query: "r:m"
+      count: 15
       rate: 2
   common_uncommon_showcase:
     filter: "e:iko promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"

--- a/data/boosters/iko-collector.yaml
+++ b/data/boosters/iko-collector.yaml
@@ -30,12 +30,16 @@ sheets:
     foil: true
     any:
     - rawquery: "e:iko r:r frame:extendedart"
+      count: 43
       rate: 2
     - query: "r:r"
+      count: 53
       rate: 4
     - rawquery: "e:iko r:m frame:extendedart"
+      count: 7
       rate: 1
     - query: "r:m"
+      count: 15
       rate: 2
   common_uncommon_showcase:
     filter: "e:iko promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"

--- a/data/boosters/iko-draft.yaml
+++ b/data/boosters/iko-draft.yaml
@@ -19,34 +19,46 @@ sheets:
     balanced: true
     any:
     - rawquery: "e:iko r:c promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"
+      count: 5
       rate: 1
     - query: "r:c alt:(e:iko r:c promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 5
       rate: 2
     - query: "r:c -alt:(e:iko r:c promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart) -is:gainland"
+      count: 96
       rate: 3
   uncommon_with_showcase:
     any:
     - rawquery: "e:iko r:u promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"
+      count: 15
       rate: 1
     - query: "r:u alt:(e:iko r:u promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 15
       rate: 2
     - query: "r:u -alt:(e:iko r:u promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 65
       rate: 3
   rare_with_showcase:
     any:
     - rawquery: "e:iko r:r promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"
+      count: 10
       rate: 1
     - query: "r:r alt:(e:iko r:r promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 10
       rate: 2
     - query: "r:r -alt:(e:iko r:r promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 43
       rate: 3
   mythic_with_showcase:
     any:
     - rawquery: "e:iko r:m promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart"
+      count: 8
       rate: 1
     - query: "r:m alt:(e:iko r:m promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 8
       rate: 2
     - query: "r:m -alt:(e:iko r:m promo:boosterfun -promo:godzillaseries -is:foilonly -frame:extendedart)"
+      count: 7
       rate: 3
   basic_or_gainland:
     # These also have L2/L3 codes, but these aren't actually used by the code

--- a/data/boosters/iko-theme-b.yaml
+++ b/data/boosters/iko-theme-b.yaml
@@ -26,21 +26,27 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 11
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 6
       rate: 2
     - query: "r:r -id:c"
+      count: 3
       rate: 6
     - query: "r:m"
       rate: 1

--- a/data/boosters/iko-theme-g.yaml
+++ b/data/boosters/iko-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 11
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 6
       rate: 2
     - query: "r:r -id:c"
+      count: 3
       rate: 6
     - query: "r:m"
+      count: 1
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/iko-theme-monsters.yaml
+++ b/data/boosters/iko-theme-monsters.yaml
@@ -29,23 +29,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 97
       rate: 1
     - query: "r:c -id:c"
+      count: 93
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 62
       rate: 1
     - query: "r:u -id:c"
+      count: 62
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 49
       rate: 2
     - query: "r:r -id:c"
+      count: 48
       rate: 6
     - query: "r:m"
+      count: 10
       rate: 1
     - query: "r:m -id:c"
+      count: 10
       rate: 3

--- a/data/boosters/iko-theme-r.yaml
+++ b/data/boosters/iko-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 11
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 6
       rate: 2
     - query: "r:r -id:c"
+      count: 3
       rate: 6
     - query: "r:m"
+      count: 1
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/iko-theme-u.yaml
+++ b/data/boosters/iko-theme-u.yaml
@@ -26,21 +26,27 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 11
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 6
       rate: 2
     - query: "r:r -id:c"
+      count: 3
       rate: 6
     - query: "r:m"
       rate: 1

--- a/data/boosters/iko-theme-w.yaml
+++ b/data/boosters/iko-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 11
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 6
       rate: 2
     - query: "r:r -id:c"
+      count: 3
       rate: 6
     - query: "r:m"
+      count: 1
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/inr-collector.yaml
+++ b/data/boosters/inr-collector.yaml
@@ -24,12 +24,15 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:{set} t:basic"
+    count: 10
   foil_rare_mythic:
     foil: true
     any:
     - query: "r:r"
+      count: 72
       chance: 6
     - query: "r:m"
+      count: 23
       chance: 1
   showcase_cu:
     filter: "{any_boosterfun} -{old_frame}"
@@ -44,12 +47,16 @@ sheets:
   booster_fun:
     any:
     - rawquery: "r:m {two_instances}"
+      count: 20
       rate: 1
     - rawquery: "r:m {any_boosterfun} -alt:{two_instances}"
+      count: 10
       rate: 2
     - rawquery: "r:r {two_instances}"
+      count: 22
       rate: 2
     - rawquery: "r:r {any_boosterfun} -alt:{two_instances}"
+      count: 22
       rate: 4
   foil_booster_fun:
     foil: true
@@ -57,6 +64,7 @@ sheets:
     - use: booster_fun
       chance: 5000
     - rawquery: "e:{set} number:491"
+      count: 1
       chance: 1
 
 ########## foil_booster_fun sheet:

--- a/data/boosters/inr-play.yaml
+++ b/data/boosters/inr-play.yaml
@@ -22,11 +22,14 @@ queries:
 sheets:
   basic:
     rawquery: "e:{set} t:basic"
+    count: 10
   foil_basic:
     foil: true
     rawquery: "e:{set} t:basic"
+    count: 10
   sfc_common:
     query: "r:c is:sfc"
+    count: 75
   retro:
     filter: "{old_frame}"
     use: base_1248_by_rarity
@@ -34,28 +37,37 @@ sheets:
     # Showcase treatments 1/4 for relevant cards
     any:
     - query: "r:u -alt:({showcase})"
+      count: 102
       rate: 4
     - query: "r:u alt:({showcase})"
+      count: 2
       rate: 3
     - rawquery: "r:u ({showcase})"
+      count: 2
       rate: 1
   mythic_with_showcase:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "r:m {any_boosterfun}"
+      count: 6
       rate: 1
     - query: "r:m alt:{any_boosterfun}"
+      count: 6
       rate: 3
     - query: "r:m -alt:{any_boosterfun}"
+      count: 17
       rate: 4
   rare_with_showcase:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "r:r {any_boosterfun}"
+      count: 17
       rate: 1
     - query: "r:r alt:{any_boosterfun}"
+      count: 17
       rate: 3
     - query: "r:r -alt:{any_boosterfun}"
+      count: 55
       rate: 4
   rare_mythic_with_showcase:
     any:
@@ -68,18 +80,24 @@ sheets:
     - chance: 700
       any:
       - rawquery: "r:c {any_boosterfun}"
+        count: 4
         rate: 1
       - query: "r:c alt:{any_boosterfun}"
+        count: 4
         rate: 3
       - query: "r:c -alt:{any_boosterfun}"
+        count: 84
         rate: 4
     - chance: 175
       any:
       - rawquery: "r:u {any_boosterfun}"
+        count: 4
         rate: 1
       - query: "r:u alt:{any_boosterfun}"
+        count: 4
         rate: 3
       - query: "r:u -alt:{any_boosterfun}"
+        count: 100
         rate: 4
     - chance: 125
       use: rare_mythic_with_showcase
@@ -89,18 +107,24 @@ sheets:
     - chance: 12
       any:
       - rawquery: "r:c {any_boosterfun}"
+        count: 4
         rate: 1
       - query: "r:c alt:{any_boosterfun}"
+        count: 4
         rate: 3
       - query: "r:c -alt:{any_boosterfun}"
+        count: 84
         rate: 4
     - chance: 5
       any:
       - rawquery: "r:u {any_boosterfun}"
+        count: 4
         rate: 1
       - query: "r:u alt:{any_boosterfun}"
+        count: 4
         rate: 3
       - query: "r:u -alt:{any_boosterfun}"
+        count: 100
         rate: 4
     - chance: 3
       use: rare_mythic_with_showcase

--- a/data/boosters/inv-tournament.yaml
+++ b/data/boosters/inv-tournament.yaml
@@ -9,9 +9,12 @@ sheets:
   basic:
     duplicates: true
     query: "r:b"
+    count: 20
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/isd-six.yaml
+++ b/data/boosters/isd-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 107

--- a/data/boosters/jou-draft.yaml
+++ b/data/boosters/jou-draft.yaml
@@ -21,3 +21,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:ths r:b"
+    count: 20

--- a/data/boosters/jud-draft.yaml
+++ b/data/boosters/jud-draft.yaml
@@ -20,3 +20,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 55

--- a/data/boosters/jud-fat-pack.yaml
+++ b/data/boosters/jud-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:ody t:basic"
+    count: 20

--- a/data/boosters/khm-arena.yaml
+++ b/data/boosters/khm-arena.yaml
@@ -16,3 +16,4 @@ sheets:
   non_basictype_common:
     balanced: true
     query: "r:c -is:basictype"
+    count: 101

--- a/data/boosters/khm-collector.yaml
+++ b/data/boosters/khm-collector.yaml
@@ -25,10 +25,13 @@ sheets:
     foil: true
     any:
     - rawquery: "e:khm promo:boosterfun r:r"
+      count: 54
       rate: 4
     - rawquery: "e:khm promo:boosterfun r:m -(Vorinclex or Valki)"
+      count: 18
       rate: 2
     - rawquery: "e:khm promo:boosterfun r:m (Vorinclex or Valki) number<=400"
+      count: 4
       rate: 1
   rare_mythic_showcase:
     any:

--- a/data/boosters/khm-draft.yaml
+++ b/data/boosters/khm-draft.yaml
@@ -23,6 +23,7 @@ sheets:
   non_basictype_common:
     balanced: true
     query: "r:c -is:basictype"
+    count: 101
   rare_mythic_with_showcase:
     any:
     - use: rare_with_showcase

--- a/data/boosters/khm-set.yaml
+++ b/data/boosters/khm-set.yaml
@@ -35,15 +35,19 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 111
   snow_showcase_theme: # Assuming standard 1/2/4/8 distribution for this slot
     any:
     - query: "r:c t:snow"
+      count: 20
       rate: 8
     - query: "r:u t:snow"
+      count: 11
       rate: 4
     - use: uncommon_showcase
       rate: 4
     - rawquery: "e:khm r:r number:374-393"
+      count: 5
       rate: 2
   rare_mythic_with_showcase:
     any:

--- a/data/boosters/khm-theme-b.yaml
+++ b/data/boosters/khm-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 16
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 10
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/khm-theme-g.yaml
+++ b/data/boosters/khm-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 14
       rate: 1
     - query: "r:u -id:c"
+      count: 10
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/khm-theme-r.yaml
+++ b/data/boosters/khm-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 16
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/khm-theme-u.yaml
+++ b/data/boosters/khm-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 11
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/khm-theme-vikings.yaml
+++ b/data/boosters/khm-theme-vikings.yaml
@@ -27,23 +27,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 75
       rate: 1
     - query: "r:c -id:c"
+      count: 75
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 46
       rate: 1
     - query: "r:u -id:c"
+      count: 46
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 32
       rate: 2
     - query: "r:r -id:c"
+      count: 32
       rate: 6
     - query: "r:m"
+      count: 7
       rate: 1
     - query: "r:m -id:c"
+      count: 7
       rate: 3

--- a/data/boosters/khm-theme-w.yaml
+++ b/data/boosters/khm-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/kld-draft.yaml
+++ b/data/boosters/kld-draft.yaml
@@ -15,8 +15,10 @@ sheets:
     - use: rare_mythic
       chance: 3*8
     - query: "r:u"
+      count: 80
       chance: 5*8
     - query: "r<=c"
+      count: 116
       chance: 12*8-2
     - rawquery: "e:mps number<=30"
       count: 30

--- a/data/boosters/lci-arena.yaml
+++ b/data/boosters/lci-arena.yaml
@@ -9,8 +9,10 @@ sheets:
   cave_basic_land:
     any:
     - query: "t:cave r:c"
+      count: 7
       chance: 7
     - rawquery: "e:lci number:393-402"
+      count: 10
       chance: 3
   dfc_common_uncommon:
     any:

--- a/data/boosters/lci-box-topper-foil.yaml
+++ b/data/boosters/lci-box-topper-foil.yaml
@@ -6,3 +6,4 @@ sheets:
   foil_topper:
     foil: true
     rawquery: "e:lcc number:101-120"
+    count: 20

--- a/data/boosters/lci-box-topper.yaml
+++ b/data/boosters/lci-box-topper.yaml
@@ -5,3 +5,4 @@ pack:
 sheets:
   topper:
     rawquery: "e:lcc number:101-120"
+    count: 20

--- a/data/boosters/lci-bundle-promo.yaml
+++ b/data/boosters/lci-bundle-promo.yaml
@@ -4,3 +4,4 @@ pack:
 sheets:
   bundle_promo:
     rawquery: "e:rex -t:basic is:nonfoil -is:reversibleback"
+    count: 21

--- a/data/boosters/lci-collector-sample.yaml
+++ b/data/boosters/lci-collector-sample.yaml
@@ -12,8 +12,10 @@ sheets:
     - use: rare_showcase
       rate: 4
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -name:"Quintorius Kand"'
+      count: 19
       rate: 2
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper name:"Quintorius Kand"'
+      count: 2
       rate: 1
   foil_rare_mythic_showcase:
     foil: true

--- a/data/boosters/lci-collector.yaml
+++ b/data/boosters/lci-collector.yaml
@@ -27,6 +27,7 @@ pack:
 sheets:
   foil_fullart_land:
     query: "t:basic is:fullart"
+    count: 5
     foil: true
   foil_rare_mythic:
     foil: true
@@ -65,33 +66,42 @@ sheets:
     - rawquery: "e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:r"
       rate: 4
     - rawquery: 'e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:m -name:"Quintorius Kand"'
+      count: 4
       rate: 2
     - rawquery: 'e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:m name:"Quintorius Kand"'
       rate: 1
   jurrasic_world:
     any:
     - rawquery: "e:rex -t:basic -promo:embossed -is:reversibleback"
+      count: 21
       rate: 1
     - rawquery: "e:rex t:basic -promo:embossed -is:reversibleback"
+      count: 5
       rate: 4
   foil_jurrasic_world:
     foil: true
     any:
     - rawquery: "e:rex -t:basic -promo:embossed -is:reversibleback"
+      count: 21
       rate: 1
     - rawquery: "e:rex t:basic -promo:embossed -is:reversibleback"
+      count: 5
       rate: 4
   emblem_jurrasic_world:
     foil: true
     rawquery: "e:rex promo:embossed"
+    count: 19
   foil_showcase_rare_mythic:
     foil: true
     any:
     - rawquery: "e:lci promo:boosterfun r:r"
+      count: 64
       rate: 4
     - rawquery: 'e:lci promo:boosterfun r:m -promo:neonink -name:"Quintorius Kand"'
+      count: 21
       rate: 2
     - rawquery: 'e:lci promo:boosterfun r:m -promo:neonink name:"Quintorius Kand"'
+      count: 2
       rate: 1
     - set: spg
       code: "LCICOLR"
@@ -107,13 +117,18 @@ sheets:
       chance: 1
     - any:
       - rawquery: "e:lci number:410a"
+        count: 1
         rate: 1
       - rawquery: "e:lci number:410e"
+        count: 1
         rate: 2
       - rawquery: "e:lci number:410d"
+        count: 1
         rate: 4
       - rawquery: "e:lci number:410c"
+        count: 1
         rate: 8
       - rawquery: "e:lci number:410f"
+        count: 1
         rate: 16
       chance: 1

--- a/data/boosters/lci-draft.yaml
+++ b/data/boosters/lci-draft.yaml
@@ -14,11 +14,14 @@ sheets:
   sfc_common:
     balanced: true
     query: "r:c is:sfc -t:cave"
+    count: 96
   cave_fullart_land:
     any:
     - query: "t:cave r:c"
+      count: 7
       chance: 7
     - query: "is:fullart t:basic"
+      count: 5
       chance: 3
   dfc_common_uncommon:
     any:
@@ -29,8 +32,10 @@ sheets:
   mythic_with_showcase:
     any:
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -name:"Quintorius Kand"'
+      count: 19
       rate: 1
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper name:"Quintorius Kand"'
+      count: 2
       rate: 2
     - use: mythic_has_showcase
       rate: 4

--- a/data/boosters/lci-gift-bundle-promo.yaml
+++ b/data/boosters/lci-gift-bundle-promo.yaml
@@ -5,3 +5,4 @@ sheets:
   bundle_promo:
     foil: true
     rawquery: "e:rex -t:basic is:foil -is:embossed -is:reversibleback"
+    count: 21

--- a/data/boosters/lci-set.yaml
+++ b/data/boosters/lci-set.yaml
@@ -21,18 +21,23 @@ pack:
 sheets:
   common:
     query: "r:c -t:cave"
+    count: 101
   cave_fullart_land:
     any:
     - query: "t:cave r:c"
+      count: 7
       chance: 7
     - query: "is:fullart t:basic"
+      count: 5
       chance: 3
   foil_cave_fullart_land:
     foil: true
     any:
     - query: "t:cave r:c"
+      count: 7
       chance: 7
     - query: "is:fullart t:basic"
+      count: 5
       chance: 3
   showcase_dfc_common_uncommon:
     any:
@@ -45,8 +50,10 @@ sheets:
   mythic_with_showcase:
     any:
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -name:"Quintorius Kand"'
+      count: 19
       rate: 1
     - rawquery: 'e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper name:"Quintorius Kand"'
+      count: 2
       rate: 2
     - use: mythic_has_showcase
       rate: 4
@@ -64,16 +71,21 @@ sheets:
       - use: mythic_with_showcase
         chance: 22
       - rawquery: "e:rex -t:basic -promo:embossed -is:reversibleback"
+        count: 21
         chance: 21*2
       - rawquery: "e:lcc number:1-16a,69-100 r:r is:front"
+        count: 38
         chance: 39*2
       - chance: 10
         any:
         - rawquery: "e:lcc number:5-16a,69-100 r:m is:front"
+          count: 6
           rate: 3
         - rawquery: "e:lcc number:1-4"
+          count: 4
           rate: 2
         - rawquery: "e:lcc number:17-20"
+          count: 4
           rate: 1
       chance: 125
   the_list:

--- a/data/boosters/lgn-fat-pack.yaml
+++ b/data/boosters/lgn-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:ons t:basic"
+    count: 20

--- a/data/boosters/lrw-tournament.yaml
+++ b/data/boosters/lrw-tournament.yaml
@@ -12,6 +12,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 121
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/ltr-box-topper.yaml
+++ b/data/boosters/ltr-box-topper.yaml
@@ -6,3 +6,4 @@ sheets:
   box_topper:
     foil: true
     rawquery: "e:ltc number:348-377"
+    count: 30

--- a/data/boosters/ltr-collector-special.yaml
+++ b/data/boosters/ltr-collector-special.yaml
@@ -45,6 +45,7 @@ sheets:
     count: 79 + 9
     any:
     - query: "r:u is:scroll -Nazgûl"
+      count: 79
       rate: 9
     - query: "r:u is:scroll Nazgûl"
       rate: 1
@@ -85,6 +86,7 @@ sheets:
   surge_booster_fun_u:
     foil: true
     rawquery: "e:ltr number:794-823 r:u"
+    count: 10
   surge_booster_fun_rm:
     foil: true
     any:
@@ -109,25 +111,33 @@ sheets:
     count: 30
   hildebrant_u:
     rawquery: "e:ltc number:515-534 r:u"
+    count: 5
   silver_hildebrant_u:
     foil: true
     rawquery: "e:ltc number:515-534 r:u"
+    count: 5
   hildebrant_poster_rm:
     any:
     - rawquery: "e:ltc number:515-534 r:r"
+      count: 10
       rate: 2
     - rawquery: "e:ltc number:515-534 r:m"
+      count: 5
       rate: 1
     - rawquery: "e:ltr number:731-750"
+      count: 20
       rate: 1
   foil_hildebrant_poster_rm:
     foil: true
     any:
     - rawquery: "e:ltc number:515-534 r:r"
+      count: 10
       rate: 2
     - rawquery: "e:ltc number:515-534 r:m"
+      count: 5
       rate: 1
     - rawquery: "e:ltr number:731-750 -number:/z/"
+      count: 20
       rate: 1
   serialized_poster:
     foil: true

--- a/data/boosters/ltr-collector.yaml
+++ b/data/boosters/ltr-collector.yaml
@@ -30,9 +30,11 @@ sheets:
   foil_uncommon:
     foil: true
     query: 'r:u -name:"Nazgûl"'
+    count: 79
   foil_basic:
     foil: true
     query: "r:b is:fullart"
+    count: 10
   foil_rare_mythic:
     foil: true
     use: rare_mythic
@@ -45,26 +47,35 @@ sheets:
   uncommon_showcase:
     any:
     - rawquery: "e:{set} r:u frame:showcase -number>451"
+      count: 10
       chance: 91
     - rawquery: 'e:{set} name:"Nazgûl" -number>451'
+      count: 9
       chance: 9
   rare_mythic_showcase:
     any:
     - rawquery: "e:{set} r:r promo:boosterfun frame:showcase alt:(is:borderless -frame:showcase) -is:foilonly -number:299-300 -number>451"
+      count: 9
       rate: 2
     - rawquery: "e:{set} r:r promo:boosterfun frame:showcase -alt:(is:borderless -frame:showcase) -number:299-300 -number>451"
+      count: 5
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun frame:showcase alt:(is:borderless -frame:showcase) -is:foilonly -number:299-300 -number>451"
+      count: 6
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun frame:showcase -alt:(is:borderless -frame:showcase) -number:299-300 -number>451"
       rate: 2
     - rawquery: "e:{set} r:r number:340-345 alt:(e:{set} number:399-451)"
+      count: 2
       rate: 2
     - rawquery: "e:{set} r:r number:340-345 -alt:(e:{set} number:399-451)"
+      count: 3
       rate: 4
     - rawquery: "e:{set} r:m number:340-345"
+      count: 1
       rate: 2
     - rawquery: "e:ltc number:348-377"
+      count: 30
       rate: 2
   borderless_scene:
     filter: "e:{set} number:399-451"
@@ -78,70 +89,95 @@ sheets:
     - query: "r:m -alt:frame:showcase"
       rate: 2
     - query: "r:c alt:frame:showcase"
+      count: 9
       rate: 8
     - query: "r:u alt:frame:showcase"
+      count: 14
       rate: 4
     - query: "r:r alt:(frame:showcase or t:land)"
+      count: 21
       rate: 2
     - query: "r:m alt:frame:showcase"
+      count: 9
       rate: 1
   foil_uncommon_showcase:
     foil: true
     any:
     - rawquery: "e:{set} r:u frame:showcase -number>451"
+      count: 10
       chance: 233
     - rawquery: "e:{set} r:c number:399-451"
+      count: 9
       chance: 418
     - rawquery: "e:{set} r:u number:399-451"
+      count: 14
       chance: 326
     - rawquery: 'e:{set} name:"Nazgûl" -number>451'
+      count: 9
       chance: 23
   nonfoil_sol_ring:
     any:
     - rawquery: "e:ltc number:410"
+      count: 1
       chance: 9
     - rawquery: "e:ltc number:409"
+      count: 1
       chance: 7
     - rawquery: "e:ltc number:408"
+      count: 1
       chance: 3
   serialized_sol_ring: # This currently doesn't work so just using the nonfoil sol rings
     foil: true
     any:
     - rawquery: "e:ltc number:410z"
+      count: 1
       chance: 9
     - rawquery: "e:ltc number:409z"
+      count: 1
       chance: 7
     - rawquery: "e:ltc number:408z"
+      count: 1
       chance: 3
   the_one_ring:
     foil: true
     rawquery: "e:{set} number:0"
+    count: 1
   foil_rare_mythic_showcase:
     foil: true
     any:
     - rawquery: "e:{set} r:r frame:showcase promo:boosterfun alt:(e:{set} number:399-451) -number:299-300 -number>451"
+      count: 9
       rate: 2
     - rawquery: "e:{set} r:m frame:showcase promo:boosterfun alt:(e:{set} number:399-451) -number:299-300 -number>451"
+      count: 4
       rate: 1
     - rawquery: "e:{set} r:r frame:showcase promo:boosterfun -alt:(e:{set} number:399-451) -number:299-300 -number>451"
+      count: 5
       rate: 4
     - rawquery: "e:{set} r:m frame:showcase promo:boosterfun -alt:(e:{set} number:399-451) -number:299-300 -number>451"
+      count: 2
       rate: 2
     - rawquery: "e:{set} r:r number:399-451 alt:(frame:showcase or t:land)"
+      count: 21
       rate: 2
     - rawquery: "e:{set} r:m number:399-451 alt:(frame:showcase)"
+      count: 9
       rate: 1
     - rawquery: "e:{set} r:r number:399-451 -alt:(frame:showcase or t:land)"
       rate: 4
     - rawquery: "e:{set} r:m number:399-451 -alt:(frame:showcase)"
       rate: 2
     - rawquery: "e:{set} r:r number:340-345 alt:(e:{set} number:399-451)"
+      count: 2
       rate: 2
     - rawquery: "e:{set} r:r number:340-345 -alt:(e:{set} number:399-451)"
+      count: 3
       rate: 4
     - rawquery: "e:{set} r:m number:340-345"
+      count: 1
       rate: 2
     - rawquery: "e:ltc r:m frame:extendedart -number:378-407 -number>451"
+      count: 8
       rate: 2
   surge_relic:
     foil: true

--- a/data/boosters/ltr-draft.yaml
+++ b/data/boosters/ltr-draft.yaml
@@ -37,6 +37,7 @@ sheets:
     - use: with_showcase
       chance: 79
     - rawquery: 'e:{set} name:"Nazgûl" -number>451'
+      count: 9
       chance: 1
   mythic_with_showcase:
     filter: "e:{set} r:m"

--- a/data/boosters/ltr-set.yaml
+++ b/data/boosters/ltr-set.yaml
@@ -19,6 +19,7 @@ pack:
 sheets:
   common:
     query: "r:c -number>451"
+    count: 101
   with_showcase:
     any:
     - query: "promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
@@ -43,20 +44,25 @@ sheets:
     - use: with_showcase
       chance: 79
     - rawquery: 'e:{set} name:"Nazgûl" -number>451'
+      count: 9
       chance: 1
   common_uncommon_showcase:
     any:
     - rawquery: "e:{set} r:c -alt:(number:302-331,340-345) number:399-451"
+      count: 9
       rate: 4
     - rawquery: "e:{set} r:c number:302-331,340-345 -alt:(e:{set} number:399-451)"
       rate: 4
     - rawquery: "e:{set} r:c promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
       rate: 2
     - rawquery: "e:{set} r:u -alt:(number:302-331,340-345) number:399-451"
+      count: 10
       rate: 2
     - rawquery: "e:{set} r:u number:302-331,340-345 -alt:(e:{set} number:399-451)"
+      count: 6
       rate: 2
     - rawquery: "e:{set} r:u promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
+      count: 8
       rate: 1
   mythic_with_showcase:
     filter: "e:{set} r:m -number>451"
@@ -73,8 +79,10 @@ sheets:
     # decks). This sheet feeds both the wildcard (nonfoil) and the foil slot, so
     # it covers both finishes at once.
     - rawquery: "e:ltr number:282-286"
+      count: 5
       chance: 10
     - rawquery: "e:ltc number:1-8"
+      count: 8
       chance: 8
   wildcard:
     any:

--- a/data/boosters/m10-six.yaml
+++ b/data/boosters/m10-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m11-six.yaml
+++ b/data/boosters/m11-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m12-six.yaml
+++ b/data/boosters/m12-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m13-six.yaml
+++ b/data/boosters/m13-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m14-duelspromo.yaml
+++ b/data/boosters/m14-duelspromo.yaml
@@ -7,3 +7,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m14-six.yaml
+++ b/data/boosters/m14-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m15-duelspromo.yaml
+++ b/data/boosters/m15-duelspromo.yaml
@@ -7,3 +7,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/m19-arena.yaml
+++ b/data/boosters/m19-arena.yaml
@@ -7,5 +7,7 @@ sheets:
   nonland_common:
     balanced: true
     query: "r:c -t:land"
+    count: 101
   basic_or_common_land:
     query: "t:land r<=common"
+    count: 30

--- a/data/boosters/m19-draft.yaml
+++ b/data/boosters/m19-draft.yaml
@@ -16,5 +16,7 @@ sheets:
   nonland_common:
     balanced: true
     query: "r:c -t:land"
+    count: 101
   basic_or_common_land:
     query: "t:land r<=c"
+    count: 30

--- a/data/boosters/m20-arena.yaml
+++ b/data/boosters/m20-arena.yaml
@@ -7,5 +7,7 @@ sheets:
   nonland_common:
     balanced: true
     query: "r:c -t:land"
+    count: 101
   basic_or_common_land:
     query: "t:land r<=common"
+    count: 31

--- a/data/boosters/m20-draft.yaml
+++ b/data/boosters/m20-draft.yaml
@@ -14,5 +14,7 @@ sheets:
   nonland_common:
     balanced: true
     query: "r:c -t:land"
+    count: 101
   basic_or_common_land:
     query: "t:land r<=c"
+    count: 31

--- a/data/boosters/m20-theme-b.yaml
+++ b/data/boosters/m20-theme-b.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 26
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/m20-theme-g.yaml
+++ b/data/boosters/m20-theme-g.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 26
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/m20-theme-r.yaml
+++ b/data/boosters/m20-theme-r.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 26
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/m20-theme-u.yaml
+++ b/data/boosters/m20-theme-u.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 26
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/m20-theme-w.yaml
+++ b/data/boosters/m20-theme-w.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 26
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 22
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/m21-arena.yaml
+++ b/data/boosters/m21-arena.yaml
@@ -7,6 +7,7 @@ sheets:
   nongainland_common:
     balanced: true
     query: "r:c  -is:gainland"
+    count: 101
   basic_or_gainland:
     # No showcase cards in Arena
     any:

--- a/data/boosters/m21-collector.yaml
+++ b/data/boosters/m21-collector.yaml
@@ -22,12 +22,16 @@ sheets:
     foil: true
     any:
     - query: "r:r"
+      count: 53
       rate: 4
     - rawquery: "e:m21 r:r frame:extendedart"
+      count: 45
       rate: 2
     - query: "r:m"
+      count: 15
       rate: 2
     - rawquery: "e:m21 r:m frame:extendedart -(Rin and Seri, Inseparable)"
+      count: 7
       rate: 1
   extended_art:
     filter: "e:m21 frame:extendedart"
@@ -35,3 +39,4 @@ sheets:
   foil_showcase_basic:
     foil: true
     rawquery: "e:m21 frame:showcase t:basic"
+    count: 5

--- a/data/boosters/m21-draft.yaml
+++ b/data/boosters/m21-draft.yaml
@@ -22,50 +22,68 @@ sheets:
     balanced: true
     any:
     - rawquery: "e:m21 r:c promo:boosterfun"
+      count: 5
       rate: 1
     - query: "r:c -is:gainland alt:(e:m21 promo:boosterfun)"
+      count: 5
       rate: 2
     - query: "r:c -is:gainland -alt:(e:m21 promo:boosterfun)"
+      count: 96
       rate: 3
   rare_mythic:
     # Teferi makes all of this weird so we can't use common sheets
     any:
     - any: # Sheet 1: All normal printings except teferi
       - query: "r:r"
+        count: 53
         rate: 2
       - query: "r:m -(Teferi, Master of Time)"
+        count: 14
         rate: 1
       chance: 17
     - any: # Sheet 2: Showcase cards
       - rawquery: "r:r e:m21 frame:showcase -is:foilonly"
+        count: 5
         rate: 2
       - query: "r:r -alt:(e:m21 frame:showcase -is:foilonly)"
+        count: 48
         rate: 2
       - rawquery: "r:m e:m21 frame:showcase -(Teferi, Master of Time)"
+        count: 5
         rate: 1
       - query: "r:m -t:planeswalker"
+        count: 9
         rate: 1
       chance: 3
     - any: # Sheet 3: Showcase c-r, both borderless and showcase planeswalkers
       - rawquery: "r:r e:m21 frame:showcase -is:foilonly"
+        count: 5
         rate: 2
       - query: "r:r -alt:(e:m21 frame:showcase -is:foilonly)"
+        count: 48
         rate: 2
       - rawquery: "r:m e:m21 frame:showcase -(Teferi, Master of Time)"
+        count: 5
         rate: 1
       - rawquery: "r:m e:m21 is:borderless t:planeswalker -(Teferi, Master of Time)"
+        count: 5
         rate: 1
       - query: "r:m -t:planeswalker"
+        count: 9
         rate: 1
       chance: 3
     - any: # Sheet 4: no planeswalkers except all versions of teferi
       - rawquery: "r:r e:m21 frame:showcase -is:foilonly"
+        count: 5
         rate: 2
       - query: "r:r -alt:(e:m21 frame:showcase -is:foilonly)"
+        count: 48
         rate: 2
       - rawquery: "e:m21 Teferi, Master of Time ++"
+        count: 9
         rate: 1
       - query: "r:m -t:planeswalker"
+        count: 9
         rate: 1
       chance: 3
   basic_or_gainland:
@@ -84,8 +102,10 @@ sheets:
       - use: nongainland_common
         chance: 101
       - query: "t:basic"
+        count: 20
         chance: 20
       - query: "is: gainland"
+        count: 10
         chance: 10
       chance: 12
     - use: uncommon_with_showcase
@@ -100,6 +120,8 @@ sheets:
     # special reprint borderless cards can appear instead of foils
     any:
     - rawquery: "r:r e:m21 is:borderless -t:planeswalker"
+      count: 4
       rate: 2
     - rawquery: "r:m e:m21 is:borderless -t:planeswalker"
+      count: 2
       rate: 1

--- a/data/boosters/mat.yaml
+++ b/data/boosters/mat.yaml
@@ -23,10 +23,13 @@ sheets:
     foil: true
     any:
     - query: "r:u"
+      count: 15
       chance: 5
     - any:
       - query: "r:r"
+        count: 25
         rate: 2
       - query: "r:m"
+        count: 10
         rate: 1
       chance: 1

--- a/data/boosters/mb1-convention-2021.yaml
+++ b/data/boosters/mb1-convention-2021.yaml
@@ -60,3 +60,4 @@ sheets:
     code: "RARE"
   playtest2:
     rawquery: "e:cmb2"
+    count: 121

--- a/data/boosters/mb1-convention.yaml
+++ b/data/boosters/mb1-convention.yaml
@@ -60,3 +60,4 @@ sheets:
     code: "RARE"
   playtest:
     rawquery: "e:cmb1"
+    count: 121

--- a/data/boosters/mb2-draft.yaml
+++ b/data/boosters/mb2-draft.yaml
@@ -49,9 +49,11 @@ sheets:
       count: 70
   future_sight_foil:
     query: "frame:future is:foil"
+    count: 114
     foil: true
   alchemy_acorn:
     query: "is:acorn"
+    count: 7
     foil: true
   white_border:
     any:
@@ -63,3 +65,4 @@ sheets:
       count: 70
   playtest:
     rawquery: "e:{set} is:playtest"
+    count: 120

--- a/data/boosters/mbs-six.yaml
+++ b/data/boosters/mbs-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 60

--- a/data/boosters/mh2-collector.yaml
+++ b/data/boosters/mh2-collector.yaml
@@ -16,6 +16,7 @@ sheets:
     use: common_uncommon
   extended_art_rare:
     rawquery: "e:mh2 frame:extendedart"
+    count: 39
   foil_boosterfun_common_uncommon:
     foil: true
     filter: "(e:mh2 or e:h1r) promo:boosterfun"

--- a/data/boosters/mh2-draft.yaml
+++ b/data/boosters/mh2-draft.yaml
@@ -14,46 +14,64 @@ sheets:
   new_uncommon:
     any:
     - rawquery: "e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:reprint"
+      count: 24
       rate: 1
     - query: "r:u alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart) -is:reprint"
+      count: 24
       rate: 2
     - query: "r:u -alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart) -is:reprint"
+      count: 56
       rate: 3
   new_rare_mythic:
     any:
     - rawquery: "e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper (-is:reprint or is:fetchland)"
+      count: 50
       rate: 4
     - query: "r:r alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) (-is:reprint or is:fetchland)"
+      count: 48
       rate: 8
     - query: "r:r -alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) -is:reprint"
+      count: 12
       rate: 12
     - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:reprint (Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+      count: 18
       rate: 1
     - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:reprint -(Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+      count: 11
       rate: 2
     - query: "r:m alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) -is:reprint"
+      count: 20
       rate: 4
     - query: "r:m -alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) -is:reprint"
       rate: 6
   reprint_to_modern: 
     any:
     - rawquery: "e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper is:reprint"
+      count: 1
       rate: 5
     - query: "r:u alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 1
       rate: 10
     - query: "r:u alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 2
       rate: 13
     - query: "r:u -alt:(e:mh2 promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 17
       rate: 15
     - rawquery: "e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper (is:reprint -is:fetchland)"
+      count: 6
       rate: 2
     - query: "r:r alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) (is:reprint -is:fetchland)"
+      count: 3
       rate: 4
     - query: "r:r -alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 15
       rate: 6
     - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper is:reprint"
+      count: 5
       rate: 1
     - query: "r:m alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 4
       rate: 2
     - query: "r:m -alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
       rate: 3
@@ -72,12 +90,16 @@ sheets:
       chance: 12
     - any:
       - rawquery: "e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 25
         rate: 5
       - query: "r:u alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 25
         rate: 10
       - query: "r:u alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 2
         rate: 13
       - query: "r:u -alt:(e:mh2 promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 73
         rate: 15
       chance: 5
     - any:
@@ -88,8 +110,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 18
         rate: 1
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 16
         rate: 2
       - use: mythic_has_showcase
         rate: 4

--- a/data/boosters/mh2-set.yaml
+++ b/data/boosters/mh2-set.yaml
@@ -36,11 +36,13 @@ pack:
 sheets:
   basic:
     rawquery: "e:mh2 t:basic"
+    count: 10
   foil_basic:
     foil: true
     use: basic
   common:
     query: "r:c"
+    count: 101
   wildcard: # 30% chance for rare/mythic is known, but ratio of common/uncommon is guessed.
     any:
     - use: common
@@ -55,8 +57,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 18
         rate: 1
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 16
         rate: 2
       - use: mythic_has_showcase
         rate: 4
@@ -69,8 +73,10 @@ sheets:
       chance: 78
     - any:
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 18
         rate: 1
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 16
         rate: 2
       - use: mythic_has_showcase
         rate: 4
@@ -92,12 +98,16 @@ sheets:
       chance: 12
     - any:
       - rawquery: "e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+        count: 25
         rate: 5
       - query: "r:u alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 25
         rate: 10
       - query: "r:u alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 2
         rate: 13
       - query: "r:u -alt:(e:mh2 promo:boosterfun -is:foilonly -frame:extendedart)"
+        count: 73
         rate: 15
       chance: 5
     - any:
@@ -108,8 +118,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 18
         rate: 1
       - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Chatterfang or Garth One-Eye or Dakkon or Dihada or Grist or Sword of Hearth and Home or Draco or Svyelun or Tourach)"
+        count: 16
         rate: 2
       - use: mythic_has_showcase
         rate: 4
@@ -119,22 +131,31 @@ sheets:
   reprint_to_modern: 
     any:
     - rawquery: "e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper is:reprint"
+      count: 1
       rate: 5
     - query: "r:u alt:(e:mh2 r:u promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 1
       rate: 10
     - query: "r:u alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 2
       rate: 13
     - query: "r:u -alt:(e:mh2 promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 17
       rate: 15
     - rawquery: "e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper (is:reprint -is:fetchland)"
+      count: 6
       rate: 2
     - query: "r:r alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) (is:reprint -is:fetchland)"
+      count: 3
       rate: 4
     - query: "r:r -alt:(e:mh2 r:r promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 15
       rate: 6
     - rawquery: "e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper is:reprint"
+      count: 5
       rate: 1
     - query: "r:m alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
+      count: 4
       rate: 2
     - query: "r:m -alt:(e:mh2 r:m promo:boosterfun -is:foilonly -frame:extendedart) is:reprint"
       rate: 3

--- a/data/boosters/mh3-collector-sample.yaml
+++ b/data/boosters/mh3-collector-sample.yaml
@@ -26,12 +26,16 @@ sheets:
     foil: true
     any:
     - rawquery: "e:mh3 r:u number:384-441"
+      count: 16
       rate: 4
     - rawquery: "e:mh3 r:c number:384-441"
+      count: 7
       rate: 8
     - rawquery: "e:h2r r:u"
+      count: 6
       rate: 4
     - rawquery: "e:h2r r:c"
+      count: 2
       rate: 8
   showcase_rm:
     # community review (https://github.com/taw/magic-search-engine/issues/442): the
@@ -41,14 +45,17 @@ sheets:
     any:
     - # mythic in two non-retro showcase treatments
       rawquery: "e:{set} number:320-383,442-467 r:m alt:{two_plus_versions_nonretro} -is:foilonly"
+      count: 2
       rate: 3
     - # mythic in one non-retro showcase treatment
       rawquery: "e:{set} r:m {one_version_nonretro} -is:foilonly"
+      count: 20
       rate: 6
     - # rare in one non-retro showcase treatment
       # (without the retro version no rare has two versions left, except the
       # fetchlands, which aren't in this product)
       rawquery: "e:{set} r:r {one_version_nonretro} -is:foilonly"
+      count: 58
       rate: 12
     - rawquery: "e:m3c number:9-16"
       rate: 6
@@ -68,14 +75,17 @@ sheets:
     any:
     - # mythic in two non-retro showcase treatments
       rawquery: "e:{set} number:320-383,442-467 r:m alt:{two_plus_versions_nonretro} -is:foilonly"
+      count: 2
       rate: 3
     - # mythic in one non-retro showcase treatment
       rawquery: "e:{set} r:m {one_version_nonretro} -is:foilonly"
+      count: 20
       rate: 6
     - # rare in one non-retro showcase treatment
       # (without the retro version no rare has two versions left, except the
       # fetchlands, which aren't in this product)
       rawquery: "e:{set} r:r {one_version_nonretro} -is:foilonly"
+      count: 58
       rate: 12
     - rawquery: "e:m3c number:9-16"
       rate: 6

--- a/data/boosters/mh3-collector.yaml
+++ b/data/boosters/mh3-collector.yaml
@@ -17,17 +17,23 @@ sheets:
   foil_eldrazi_land:
     foil: true
     rawquery: "e:mh3 number:304-308"
+    count: 5
   retro_cu:
     any:
     - rawquery: "e:mh3 r:u number:384-441"
+      count: 16
       rate: 1
     - rawquery: "e:mh3 r:c number:384-441"
+      count: 7
       rate: 2
     - rawquery: "e:mh3 number:309"
+      count: 1
       rate: 1
     - rawquery: "e:h2r r:u"
+      count: 6
       rate: 1
     - rawquery: "e:h2r r:c"
+      count: 2
       rate: 2
   foil_retro_cu:
     foil: true
@@ -66,22 +72,29 @@ sheets:
     any:
     - # two versions mythic
       rawquery: "e:mh3 number:320-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:320-361,381-383,442-446a)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:384-441))) -is:foilonly"
+      count: 14
       rate: 3
     - # one version mythic
       rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+      count: 17
       rate: 6
     - # three versions rare
       rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+      count: 15
       rate: 4
     - # two versions rare
       rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+      count: 36
       rate: 6
     - # one version rare
       rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+      count: 43
       rate: 12
     - rawquery: "e:h2r r:m"
+      count: 6
       rate: 6
     - rawquery: "e:h2r r:r"
+      count: 2
       rate: 12
   foil_showcase_rm:
     foil: true
@@ -90,27 +103,36 @@ sheets:
       any:
       - # two versions mythic
         rawquery: "e:mh3 number:320-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:320-361,381-383,442-446a)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:384-441))) -is:foilonly"
+        count: 14
         rate: 3
       - # one version mythic
         rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+        count: 17
         rate: 6
       - # three versions rare
         rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+        count: 15
         rate: 4
       - # two versions rare
         rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+        count: 36
         rate: 6
       - # one version rare
         rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+        count: 43
         rate: 12
       - rawquery: "e:h2r r:m"
+        count: 6
         rate: 6
       - rawquery: "e:h2r r:r"
+        count: 2
         rate: 12
       - rawquery: "e:mh3 is:etched r:r"
+        count: 12
         etched: true
         rate: 6
       - rawquery: "e:mh3 is:etched r:m"
+        count: 10
         etched: true
         rate: 3
       - set: spg
@@ -120,6 +142,7 @@ sheets:
         code: "MHTHREECOLLECTOR"
         rate: 3
       - rawquery: "e:mh3 number:468-472"
+        count: 5
         rate: 3
     - chance: 1
       rawquery: "e:mh3 number:381-383 number:/z/"

--- a/data/boosters/mh3-play.yaml
+++ b/data/boosters/mh3-play.yaml
@@ -27,13 +27,17 @@ queries:
 sheets:
   common:
     query: "r:c"
+    count: 80
   land:
     rawquery: "e:mh3 number:304-319 -number:309"
+    count: 15
   foil_land:
     foil: true
     rawquery: "e:mh3 number:304-319 -number:309"
+    count: 15
   new_uncommon:
     query: "r:u -is:reprint"
+    count: 101
   new_rare_mythic:
     any:
     - rawquery: "r:r (is:fetchland or -is:reprint) -is:foilonly {two_instances}"
@@ -66,10 +70,13 @@ sheets:
       any:
       - rate: 1
         rawquery: "e:mh3 r:u number:384-441 is:reprint"
+        count: 4
       - rate: 2
         query: "r:u alt:(e:mh3 number:384-441) is:reprint"
+        count: 4
       - rate: 3
         query: "r:u is:reprint -alt:(e:mh3 number:384-441)"
+        count: 16
     - chance: 213
       any:
       - rawquery: "r:r is:reprint -is:foilonly {any_showcase} -{two_instances}"
@@ -101,34 +108,44 @@ sheets:
     - # common 41.7%
       chance: 417
       query: "r:c"
+      count: 80
     - # uncommon 33.4%
       chance: 334
       query: "r:u -is:reprint -is:dfc"
+      count: 81
     - # double-faced uncommon 8.3%
       chance: 83
       query: "r:u -is:reprint is:dfc"
+      count: 20
     - # rare 6.7% (fetchlands included; new-to-Modern reprints have their own slot)
       chance: 67
       query: "r:r (is:fetchland or -is:reprint) -is:foilonly"
+      count: 60
     - # mythic 1.1%
       chance: 11
       query: "r:m -is:reprint -is:foilonly"
+      count: 20
     - # borderless / profile showcase rare or mythic 0.4%
       chance: 4
       rawquery: "e:mh3 -is:reprint -is:foilonly (r:r or r:m) ({borderless} or {profile})"
+      count: 52
     - # retro frame, any rarity 4.2%
       chance: 42
       rawquery: "e:mh3 number:384-441"
+      count: 58
     - # Commander mythic 4.2%
       chance: 42
       any:
       - rawquery: "e:m3c number:1-8"
+        count: 8
         rate: 4
       - rawquery: "e:m3c number:9-16"
+        count: 8
         rate: 2
     - # full-art Snow-Covered Wastes <0.1%
       chance: 1
       rawquery: "e:mh3 number:309"
+      count: 1
   foil_with_showcase:
     # Traditional foil slot. The article says it mirrors the Wildcard slot's
     # contents (plus foil new-to-Modern cards) but publishes no separate per-rarity
@@ -139,34 +156,44 @@ sheets:
     - # common 41.7%
       chance: 417
       query: "r:c"
+      count: 80
     - # uncommon 33.4%
       chance: 334
       query: "r:u -is:dfc"
+      count: 101
     - # double-faced uncommon 8.3%
       chance: 83
       query: "r:u is:dfc"
+      count: 20
     - # rare 6.7%
       chance: 67
       query: "r:r -is:foilonly"
+      count: 78
     - # mythic 1.1%
       chance: 11
       query: "r:m -is:foilonly"
+      count: 24
     - # borderless / profile showcase rare or mythic 0.4%
       chance: 4
       rawquery: "e:mh3 -is:foilonly (r:r or r:m) ({borderless} or {profile})"
+      count: 69
     - # retro frame, any rarity 4.2%
       chance: 42
       rawquery: "e:mh3 number:384-441"
+      count: 58
     - # Commander mythic 4.2%
       chance: 42
       any:
       - rawquery: "e:m3c number:1-8"
+        count: 8
         rate: 4
       - rawquery: "e:m3c number:9-16"
+        count: 8
         rate: 2
     - # full-art Snow-Covered Wastes <0.1%
       chance: 1
       rawquery: "e:mh3 number:309"
+      count: 1
   special_guest:
     set: spg
     code: "MHTHREE"

--- a/data/boosters/mid-draft.yaml
+++ b/data/boosters/mid-draft.yaml
@@ -35,11 +35,15 @@ sheets:
       chance: 11 * 2
     - any:
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:dfc is:paper t:planeswalker"
+        count: 2
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:dfc is:paper -t:planeswalker"
+        count: 1
         rate: 2
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) is:dfc"
+        count: 2
         rate: 4
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) is:dfc"
+        count: 3
         rate: 6
       chance: 5

--- a/data/boosters/mid-set.yaml
+++ b/data/boosters/mid-set.yaml
@@ -20,6 +20,7 @@ pack:
 sheets:
   sfc_common:
     query: "r:c is:sfc"
+    count: 90
   equinox_common_uncommon:
     any:
     - use: common_showcase
@@ -42,8 +43,10 @@ sheets:
       - use: mythic_with_showcase
         chance: 20
       - rawquery: "e:mic number<=38 r:r"
+        count: 32
         chance: 32*2
       - rawquery: "e:mic number<=38 r:m"
+        count: 6
         chance: 6
       chance: 125
   the_list:

--- a/data/boosters/mid-theme-b.yaml
+++ b/data/boosters/mid-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 10
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 5
       rate: 3

--- a/data/boosters/mid-theme-g.yaml
+++ b/data/boosters/mid-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 9
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/mid-theme-r.yaml
+++ b/data/boosters/mid-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 9
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/mid-theme-u.yaml
+++ b/data/boosters/mid-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 9
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/mid-theme-w.yaml
+++ b/data/boosters/mid-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 15
       rate: 1
     - query: "r:u -id:c"
+      count: 12
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 8
       rate: 2
     - query: "r:r -id:c"
+      count: 6
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/mid-theme-werewolves.yaml
+++ b/data/boosters/mid-theme-werewolves.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 30
       rate: 1
     - query: "r:c -id:c"
+      count: 26
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 20
       rate: 1
     - query: "r:u -id:c"
+      count: 18
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 11
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/mir-starter.yaml
+++ b/data/boosters/mir-starter.yaml
@@ -10,10 +10,13 @@ pack:
 sheets:
   basics:
     query: "r:b"
+    count: 20
     duplicates: true
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/mkm-collector-sample.yaml
+++ b/data/boosters/mkm-collector-sample.yaml
@@ -10,13 +10,17 @@ sheets:
   rare_mythic_showcase:
     any:
     - rawquery: "e:mkm promo:boosterfun r:m -is:serialized"
+      count: 23
       rate: 1
     - rawquery: "e:mkm promo:boosterfun r:r -is:serialized"
+      count: 69
       rate: 2
   foil_rare_mythic_showcase:
     foil: true
     any:
     - rawquery: "e:mkm promo:boosterfun r:m -is:serialized"
+      count: 37
       rate: 1
     - rawquery: "e:mkm promo:boosterfun r:r -is:serialized"
+      count: 69
       rate: 2

--- a/data/boosters/mkm-collector.yaml
+++ b/data/boosters/mkm-collector.yaml
@@ -18,6 +18,7 @@ sheets:
   foil_fullart_basic:
     foil: true
     rawquery: "e:{set} t:basic is:fullart"
+    count: 5
   foil_rare_mythic:
     foil: true
     any:
@@ -34,10 +35,12 @@ sheets:
   foil_extended_commander_rare_mythic:
     foil: true
     rawquery: "e:mkc frame:extendedart r:m"
+    count: 8
   foil_rare_mythic_showcase:
     foil: true
     any: 
     - rawquery: "e:mkm ((number:317-323 -alt:(is:serialized)) or is:serialized)"
+      count: 7
       chance: 1
     - chance: 99
       any:
@@ -45,6 +48,8 @@ sheets:
         code: "MKM"
         rate: 1
       - rawquery: "e:mkm promo:boosterfun r:m -is:serialized"
+        count: 37
         rate: 1
       - rawquery: "e:mkm promo:boosterfun r:r -is:serialized"
+        count: 69
         rate: 2

--- a/data/boosters/mkm-play-arena.yaml
+++ b/data/boosters/mkm-play-arena.yaml
@@ -14,11 +14,14 @@ pack:
 sheets:
   basic:
     query: "t:basic -is:fullart"
+    count: 10
   common:
     query: "r:c"
+    count: 81
   rare_mythic:
     any:
     - query: "r:r -t:land"
+      count: 60
       chance: 120
     - use: mythic
       chance: 20
@@ -26,6 +29,7 @@ sheets:
     any:
     - chance: 1
       query: "r:r t:land"
+      count: 10
     - chance: 5
       any:
       - chance: 700
@@ -50,6 +54,8 @@ sheets:
   the_list:
     any:
     - rawquery: "sheet:MKM_ARENA_CU"
+      count: 30
       rate: 2
     - rawquery: "sheet:MKM_ARENA_RM"
+      count: 20
       rate: 1

--- a/data/boosters/mkm-play.yaml
+++ b/data/boosters/mkm-play.yaml
@@ -20,22 +20,30 @@ sheets:
     any:
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly (Aurelia or Lazav or Niv-Mizzet or Teysa) -number:/z/"
+        count: 8
         rate: 1
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(r:r t:land) -(Aurelia or Lazav or Niv-Mizzet or Teysa)"
+        count: 22
         rate: 2
       - query: "r:r -(r:r t:land) alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(r:r t:land))"
+        count: 26
         rate: 4
       - query: "r:r -(r:r t:land) -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(r:r t:land))"
+        count: 34
         rate: 6
       chance: 120
     - any:
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly (Vannifar or Rakdos or Trostani) -number:/z/"
+        count: 6
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Vannifar or Rakdos or Trostani)"
+        count: 13
         rate: 2
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+        count: 16
         rate: 4
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+        count: 4
         rate: 6
       chance: 20
   wildcard:
@@ -43,8 +51,10 @@ sheets:
     - chance: 1
       any:
       - rawquery: "e:{set} r:r t:land -promo:boosterfun"
+        count: 10
         chance: 7
       - rawquery: "e:{set} r:r t:land promo:boosterfun"
+        count: 10
         chance: 1
     - chance: 5
       any:
@@ -65,22 +75,30 @@ sheets:
       any:
       - any:
         - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly (Aurelia or Lazav or Niv-Mizzet or Teysa) -number:/z/"
+          count: 8
           rate: 1
         - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Aurelia or Lazav or Niv-Mizzet or Teysa)"
+          count: 32
           rate: 2
         - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+          count: 36
           rate: 4
         - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+          count: 34
           rate: 6
         chance: 140
       - any:
         - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly (Vannifar or Rakdos or Trostani) -number:/z/"
+          count: 6
           rate: 1
         - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Vannifar or Rakdos or Trostani)"
+          count: 13
           rate: 2
         - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+          count: 16
           rate: 4
         - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper)"
+          count: 4
           rate: 6
         chance: 20
   the_list:

--- a/data/boosters/mkm-prerelease.yaml
+++ b/data/boosters/mkm-prerelease.yaml
@@ -10,3 +10,4 @@ sheets:
   bonus:
     foil: true
     rawquery: "e:mkm number:430-432"
+    count: 3

--- a/data/boosters/mmq-tournament.yaml
+++ b/data/boosters/mmq-tournament.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   basics:
     query: "r:b"
+    count: 20
     duplicates: true
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/mom-collector-sample.yaml
+++ b/data/boosters/mom-collector-sample.yaml
@@ -16,4 +16,5 @@ sheets:
     use: nonfoil_rare_mythic
   foil_uncommon_mul:
     rawquery: "e:mul r:u number<=50"
+    count: 15
     foil: true

--- a/data/boosters/mom-draft.yaml
+++ b/data/boosters/mom-draft.yaml
@@ -47,8 +47,10 @@ sheets:
     any:
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:dfc is:paper"
+        count: 5
         rate: 1
       - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) is:dfc"
+        count: 5
         rate: 2
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) is:dfc -t:battle"
         rate: 3
@@ -56,8 +58,10 @@ sheets:
       count: 10
     - any:
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:dfc is:paper"
+        count: 5
         rate: 1
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) is:dfc"
+        count: 5
         rate: 2
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) is:dfc -t:battle"
         rate: 3
@@ -86,8 +90,10 @@ sheets:
     count: 65
     any:
     - query: "r:u"
+      count: 20
       chance: 2
     - query: "r:r or r:m"
+      count: 45
       chance: 1
   foil_with_showcase_and_mul:
     foil: true

--- a/data/boosters/mom-jumpstart.yaml
+++ b/data/boosters/mom-jumpstart.yaml
@@ -104,40 +104,53 @@ sheets:
   rare_mythic_white:
     any:
     - rawquery: "e:{set} is:baseset id=w -is:dfc r:r"
+      count: 6
       rate: 4
     - rawquery: "e:{set} is:baseset id=w -is:dfc r:m"
+      count: 2
       rate: 2
     - rawquery: "e:{set} is:baseset id=c r>=r -is:dfc"
+      count: 2
       rate: 1
   rare_mythic_blue:
     any:
     - rawquery: "e:{set} is:baseset id=u -is:dfc r:r"
+      count: 6
       rate: 4
     - rawquery: "e:{set} is:baseset id=u -is:dfc r:m"
       rate: 2
     - rawquery: "e:{set} is:baseset id=c r>=r -is:dfc"
+      count: 2
       rate: 1
   rare_mythic_black:
     any:
     - rawquery: "e:{set} is:baseset id=b -is:dfc r:r"
+      count: 6
       rate: 4
     - rawquery: "e:{set} is:baseset id=b -is:dfc r:m"
       rate: 2
     - rawquery: "e:{set} is:baseset id=c r>=r -is:dfc"
+      count: 2
       rate: 1
   rare_mythic_red:
     any:
     - rawquery: "e:{set} is:baseset id=r -is:dfc r:r"
+      count: 6
       rate: 4
     - rawquery: "e:{set} is:baseset id=r -is:dfc r:m"
+      count: 1
       rate: 2
     - rawquery: "e:{set} is:baseset id=c r>=r -is:dfc"
+      count: 2
       rate: 1
   rare_mythic_green:
     any:
     - rawquery: "e:{set} is:baseset id=g -is:dfc r:r"
+      count: 6
       rate: 4
     - rawquery: "e:{set} is:baseset id=g -is:dfc r:m"
+      count: 1
       rate: 2
     - rawquery: "e:{set} is:baseset id=c r>=r -is:dfc"
+      count: 2
       rate: 1

--- a/data/boosters/mom-prerelease.yaml
+++ b/data/boosters/mom-prerelease.yaml
@@ -10,8 +10,10 @@ sheets:
   promo_teamup:
     any:
     - rawquery: "e:moc promo:prerelease -frame:showcase"
+      count: 3
       chance: 2
     - rawquery: "e:moc promo:prerelease frame:showcase"
+      count: 3
       chance: 1
   promo_teamup_foil:
     foil: true

--- a/data/boosters/mom-set.yaml
+++ b/data/boosters/mom-set.yaml
@@ -42,8 +42,10 @@ sheets:
     count: 65
     any:
     - query: "r:u"
+      count: 20
       chance: 2
     - query: "r:r or r:m"
+      count: 45
       chance: 1
   wildcard:
     any:
@@ -96,8 +98,10 @@ sheets:
     count: 65
     any:
     - query: "r:u"
+      count: 20
       chance: 2
     - query: "r:r or r:m"
+      count: 45
       chance: 1
   mom_foil_with_showcase:
     # the shared base-set foil slot, but with its filter widened to also include

--- a/data/boosters/mrd-tournament.yaml
+++ b/data/boosters/mrd-tournament.yaml
@@ -12,6 +12,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 110
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/msh-play.yaml
+++ b/data/boosters/msh-play.yaml
@@ -124,6 +124,7 @@ sheets:
       - use: rare_mythic
         chance: 75
       - rawquery: "{borderless_land}"
+        count: 5
         chance: 9
 
   non_foil_land:

--- a/data/boosters/nem-fat-pack.yaml
+++ b/data/boosters/nem-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:mmq t:basic"
+    count: 20

--- a/data/boosters/neo-arena.yaml
+++ b/data/boosters/neo-arena.yaml
@@ -20,3 +20,4 @@ sheets:
   sfc_common:
     balanced: true
     query: "r:c is:sfc -is:gainland"
+    count: 101

--- a/data/boosters/neo-collector.yaml
+++ b/data/boosters/neo-collector.yaml
@@ -25,6 +25,7 @@ sheets:
   foil_fullart_land:
     foil: true
     query: "r:b is:fullart"
+    count: 10
   foil_sfc_common:
     foil: true
     balanced: false
@@ -68,19 +69,25 @@ sheets:
   rare_mythic_showcase:
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+      count: 59
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
+      count: 13
       rate: 2
     - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
+      count: 10
       rate: 1
   foil_rare_mythic_showcase:
     foil: true
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -promo:neonink is:paper"
+      count: 118
       rate: 6
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly is:paper number<=505 -Jin-Gitaxias"
+      count: 34
       rate: 3
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly is:paper number<=505 Jin-Gitaxias"
+      count: 3
       rate: 2
   etched_rare_mythic:
     foil: true
@@ -92,8 +99,11 @@ sheets:
     foil: true
     any:
     - rawquery: "e:neo number:429"
+      count: 1
       rate: 1
     - rawquery: "e:neo number:430"
+      count: 1
       rate: 4
     - rawquery: "e:neo number:431"
+      count: 1
       rate: 8

--- a/data/boosters/neo-draft.yaml
+++ b/data/boosters/neo-draft.yaml
@@ -36,26 +36,34 @@ sheets:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart is:sfc is:paper"
+      count: 17
       rate: 1
     - query: "r:c alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart) is:sfc"
+      count: 17
       rate: 3
     - query: "r:c -alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart) is:sfc -is:gainland"
+      count: 84
       rate: 4
   sfc_uncommon_with_showcase:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart is:sfc is:paper"
+      count: 15
       rate: 1
     - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) is:sfc"
+      count: 15
       rate: 3
     - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) is:sfc"
+      count: 65
       rate: 4
   rare_with_showcase:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper"
+      count: 59
       rate: 1
     - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
+      count: 59
       rate: 3
     - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart)"
       rate: 4
@@ -63,10 +71,13 @@ sheets:
     # Showcase treatments 1/4 for relevant cards
     any:
     - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
+      count: 10
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
+      count: 13
       rate: 2
     - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
+      count: 18
       rate: 6
     - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart)"
       rate: 8
@@ -105,8 +116,10 @@ sheets:
       - use: rare_has_no_showcase
         rate: 16
       - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
+        count: 10
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
+        count: 13
         rate: 2
       - use: mythic_has_showcase
         rate: 6

--- a/data/boosters/neo-set.yaml
+++ b/data/boosters/neo-set.yaml
@@ -20,13 +20,17 @@ pack:
 sheets:
   sfc_common:
     query: "r:c is:sfc"
+    count: 111
   basic_or_gainland:
     any:
     - query: "r:b is:fullart"
+      count: 10
       chance: 7
     - query: "is:gainland"
+      count: 10
       chance: 7
     - query: "r:b -is:fullart"
+      count: 10
       chance: 3
   dfc_common_uncommon:
     any:
@@ -42,6 +46,7 @@ sheets:
       - use: common
         rate: 1
       - query: "r:b is:fullart"
+        count: 10
         rate: 1
       chance: 700
     - use: uncommon
@@ -54,16 +59,20 @@ sheets:
       - use: rare_has_no_showcase
         rate: 16
       - rawquery: "e:nec number<=38 r:r"
+        count: 32
         rate: 16
       - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
+        count: 10
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
+        count: 13
         rate: 2
       - use: mythic_has_showcase
         rate: 6
       - use: mythic_has_no_showcase
         rate: 8
       - rawquery: "e:nec number<=38 r:m"
+        count: 6
         rate: 8
       chance: 125
   the_list:
@@ -104,15 +113,19 @@ sheets:
       # foil version of the new-to-Magic Commander cards that only appear in Set
       # and Collector Boosters (nec #31-38); mirrors the nonfoil wildcard slot
       - rawquery: "e:nec number:31-38 r:r"
+        count: 6
         rate: 16
       - rawquery: "e:{set} promo:boosterfun (Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor) number<=416"
+        count: 10
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Jin-Gitaxias or Kaito Shizuki or Tamiyo, Compleated or Tezzeret, Betrayer or The Wandering Emperor)"
+        count: 13
         rate: 2
       - use: mythic_has_showcase
         rate: 6
       - use: mythic_has_no_showcase
         rate: 8
       - rawquery: "e:nec number:31-38 r:m"
+        count: 2
         rate: 8
       chance: 3

--- a/data/boosters/neo-theme-b.yaml
+++ b/data/boosters/neo-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 31
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/neo-theme-g.yaml
+++ b/data/boosters/neo-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 31
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/neo-theme-ninjas.yaml
+++ b/data/boosters/neo-theme-ninjas.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 41
       rate: 1
     - query: "r:c -id:c"
+      count: 30
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 29
       rate: 1
     - query: "r:u -id:c"
+      count: 20
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 19
       rate: 2
     - query: "r:r -id:c"
+      count: 14
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/neo-theme-r.yaml
+++ b/data/boosters/neo-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 31
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/neo-theme-u.yaml
+++ b/data/boosters/neo-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 31
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 26
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 7
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/neo-theme-w.yaml
+++ b/data/boosters/neo-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 31
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/nph-six.yaml
+++ b/data/boosters/nph-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 60

--- a/data/boosters/ody-tournament.yaml
+++ b/data/boosters/ody-tournament.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   basics:
     query: "r:b"
+    count: 20
     duplicates: true
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/ogw-draft.yaml
+++ b/data/boosters/ogw-draft.yaml
@@ -20,8 +20,10 @@ sheets:
     - use: rare_mythic
       chance: 3*8
     - query: "r:u"
+      count: 60
       chance: 5*8
     - rawquery: "(e:ogw r:c) or (e:bfz r:b -number:/a/)"
+      count: 95
       chance: 12*8-2
     - rawquery: "e:exp number>=26"
       count: 20

--- a/data/boosters/one-compleat.yaml
+++ b/data/boosters/one-compleat.yaml
@@ -8,11 +8,14 @@ sheets:
   oil_slick_basics_1:
     fixed: true
     rawquery: "e:one promo:oilslick t:basic"
+    count: 5
     foil: true
   oil_slick_basics_2:
     fixed: true
     foil: true
     rawquery: "e:one promo:oilslick t:basic"
+    count: 5
   oil_slick_mythic:
     rawquery: "e:one promo:oilslick r:m"
+    count: 20
     foil: true

--- a/data/boosters/one-set.yaml
+++ b/data/boosters/one-set.yaml
@@ -129,6 +129,7 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 101
   prototype_praetor:
     rawquery: "promo:concept -promo:stepandcompleat e:one,neo,dmu,snc,khm"
     count: 5
@@ -154,14 +155,17 @@ sheets:
           - use: rare_with_showcase
             chance: 60
           - rawquery: "e:onc r:r is:baseset"
+            count: 6
             chance: 22
           - rawquery: "e:{set} r:r number:404-408"
+            count: 5
             chance: 5
           chance: 6
         - any: # Mythic with commander options
           - use: mythic_with_showcase
             chance: 10
           - rawquery: "e:onc r:m is:baseset"
+            count: 6
             chance: 3
           chance: 1
         chance: 59

--- a/data/boosters/ons-tournament.yaml
+++ b/data/boosters/ons-tournament.yaml
@@ -12,6 +12,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 110
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/otj-collector-sample.yaml
+++ b/data/boosters/otj-collector-sample.yaml
@@ -9,16 +9,21 @@ pack:
 sheets:
   foil_uncommon_breakingnews:
     rawquery: "e:otp r:u number<=65"
+    count: 20
     foil: true
   rare_mythic_showcase:
     any:
     - rawquery: "e:otp r:r number<=65"
+      count: 30
       rate: 2
     - rawquery: "e:otp r:m number<=65"
+      count: 15
       rate: 1
     - rawquery: "e:otj r:r number:287-367"
+      count: 60
       rate: 2
     - rawquery: "e:otj r:m number:287-367"
+      count: 21
       rate: 1
   foil_rare_mythic_showcase:
     foil: true

--- a/data/boosters/otj-collector.yaml
+++ b/data/boosters/otj-collector.yaml
@@ -17,12 +17,15 @@ pack:
 sheets:
   foil_uncommon:
     query: "r:u"
+    count: 100
     foil: true
   foil_fullart_land:
     query: "number:272-276"
+    count: 5
     foil: true
   otp_uncommon:
     rawquery: "e:otp r:u number<=65"
+    count: 20
   foil_otp_uncommon:
     use: otp_uncommon
     foil: true
@@ -30,10 +33,13 @@ sheets:
     foil: true
     any:
     - query: "r:r"
+      count: 60
       rate: 2
     - query: "r:m"
+      count: 20
       rate: 1
     - rawquery: "e:big number<=30"
+      count: 30
       rate: 1
   showcase_rare_mythic:
     filter: "(e:otj number:278-367) or (e:big number:31-60,66-95)"
@@ -41,6 +47,7 @@ sheets:
   foil_commander:
     foil: true
     rawquery: "e:otc number:41-44"
+    count: 4
   commander:
     filter: "e:otc number:1-4,41-76"
     use: rare_mythic

--- a/data/boosters/otj-play.yaml
+++ b/data/boosters/otj-play.yaml
@@ -20,8 +20,10 @@ sheets:
   land:
     any:
     - query: "t:basic"
+      count: 15
       chance: 1
     - query: "t:land number:251-264 r:c -(Mirage Mesa) -(Conduit Pylons)"
+      count: 10
       chance: 1
   foil_land:
     foil: true
@@ -30,8 +32,10 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Oko Ringleader)"
+      count: 2
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Oko Ringleader)"
+      count: 8
       rate: 2
     - use: mythic_has_showcase
       rate: 4
@@ -67,12 +71,14 @@ sheets:
     # 118 : 10 (not per-card equal) -> Big Score ~18.4%, SPG 1/64.
     any:
     - rawquery: "e:big number<=30"
+      count: 30
       chance: 118
     - set: spg
       code: "OTJ"
       chance: 10
   common:
     query: "r:c -(number:251-264 -(Mirage Mesa) -(Conduit Pylons))"
+    count: 81
   breaking_news:
     # Article: in 1 of 3 Play Boosters the Breaking News card is a rare or
     # mythic. base_1248_by_rarity over this commonless pool gave ~48%; use an
@@ -80,6 +86,8 @@ sheets:
     filter: "e:otp number<=65"
     any:
     - query: "r:u"
+      count: 20
       chance: 2
     - query: "r:r or r:m"
+      count: 45
       chance: 1

--- a/data/boosters/pcy-fat-pack.yaml
+++ b/data/boosters/pcy-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:mmq t:basic"
+    count: 20

--- a/data/boosters/pio-arena-1.yaml
+++ b/data/boosters/pio-arena-1.yaml
@@ -10,21 +10,27 @@ pack:
 sheets:
   common:
     query: "r:c -is:guildgate"
+    count: 81
   gate:
     query: "is:guildgate"
+    count: 10
   variety:
     any:
     - query: "r:c -is:guildgate"
+      count: 81
       chance: 1
     - chance: 4
       any:
       - query: "r:u"
+        count: 100
         chance: 5
       - chance: 1
         any:
         - query: "r:r"
+          count: 60
           chance: 4
         - query: "r:m"
+          count: 27
           chance: 1
   planeswalkers:
     filter: "e:pio number:319-358"
@@ -33,7 +39,10 @@ sheets:
       any:
       - chance: 5
         query: "r:u"
+        count: 20
       - chance: 4
         query: "r:c"
+        count: 5
     - chance: 1
       query: "r:m"
+      count: 15

--- a/data/boosters/pio-arena-2.yaml
+++ b/data/boosters/pio-arena-2.yaml
@@ -10,21 +10,27 @@ pack:
 sheets:
   common:
     query: "r:c -is:guildgate"
+    count: 81
   gate:
     query: "is:guildgate"
+    count: 10
   variety:
     any:
     - query: "r:c -is:guildgate"
+      count: 81
       chance: 1
     - chance: 4
       any:
       - query: "r:u"
+        count: 100
         chance: 5
       - chance: 1
         any:
         - query: "r:r"
+          count: 60
           chance: 4
         - query: "r:m"
+          count: 27
           chance: 1
   spells:
     filter: "e:pio number:359-398"
@@ -33,11 +39,15 @@ sheets:
       any:
       - chance: 4
         query: "r:c"
+        count: 5
       - chance: 5
         query: "r:u"
+        count: 20
     - chance: 1
       any:
       - query: "r:m"
+        count: 5
         chance: 1
       - query: "r:r"
+        count: 10
         chance: 5

--- a/data/boosters/pio-arena-3.yaml
+++ b/data/boosters/pio-arena-3.yaml
@@ -10,21 +10,27 @@ pack:
 sheets:
   common:
     query: "r:c -is:guildgate"
+    count: 81
   gate:
     query: "is:guildgate"
+    count: 10
   variety:
     any:
     - query: "r:c -is:guildgate"
+      count: 81
       chance: 1
     - chance: 4
       any:
       - query: "r:u"
+        count: 100
         chance: 5
       - chance: 1
         any:
         - query: "r:r"
+          count: 60
           chance: 4
         - query: "r:m"
+          count: 27
           chance: 1
   devotion:
     filter: "e:pio number:279-318"
@@ -33,7 +39,10 @@ sheets:
       any:
       - chance: 4
         query: "r:c"
+        count: 5
       - chance: 5
         query: "r:u"
+        count: 20
     - chance: 1
       query: "r:m"
+      count: 15

--- a/data/boosters/pip-collector-sample.yaml
+++ b/data/boosters/pip-collector-sample.yaml
@@ -9,11 +9,14 @@ sheets:
   showcase_any:
     any:
     - rawquery: "e:pip number:362-528"
+      count: 167
       rate: 2
     - rawquery: "e:pip number:327-361"
+      count: 35
       rate: 1
   foil_showcase_any:
     foil: true
     use: showcase_any
   showcase_rm:
     rawquery: "e:pip number:362-528"
+    count: 167

--- a/data/boosters/pip-collector.yaml
+++ b/data/boosters/pip-collector.yaml
@@ -18,9 +18,11 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:pip t:basic -promo:surgefoil"
+    count: 10
   surge_basic:
     foil: true
     rawquery: "e:pip t:basic promo:surgefoil"
+    count: 10
   foil_rare_mythic:
     filter: "e:pip number<=316"
     use: rare_mythic
@@ -31,57 +33,76 @@ sheets:
     foil: true
   foil_hail_caesar:
     rawquery: "e:pip deck:\"Hail, Caesar\" number<=316"
+    count: 86
     foil: true
   surge_hail_caesar:
     rawquery: "e:pip alt:(deck:\"Hail, Caesar\") number:529-854"
+    count: 92
     foil: true
   foil_scrappy_survivors:
     rawquery: "e:pip deck:\"Scrappy Survivors\" number<=316"
+    count: 88
     foil: true
   surge_scrappy_survivors:
     rawquery: "e:pip alt:(deck:\"Scrappy Survivors\") number:529-854"
+    count: 94
     foil: true
   foil_science:
     rawquery: "e:pip deck:\"Science!\" number<=316"
+    count: 87
     foil: true
   surge_science:
     rawquery: "e:pip alt:(deck:\"Science!\") number:529-854"
+    count: 93
     foil: true
   foil_mutant_menace:
     rawquery: "e:pip deck:\"Mutant Menace\" number<=316"
+    count: 85
     foil: true
   surge_mutant_menace:
     rawquery: "e:pip alt:(deck:\"Mutant Menace\") number:529-854"
+    count: 91
     foil: true
   extended_reprint:
     rawquery: "e:pip number:447-528"
+    count: 82
   extended_new:
     rawquery: "e:pip number:362-446"
+    count: 85
   foil_extended_reprint:
     rawquery: "e:pip number:447-528"
+    count: 82
     foil: true
   foil_extended_new:
     rawquery: "e:pip number:362-446"
+    count: 85
     foil: true
   surge_extended_reprint:
     rawquery: "e:pip number:975-1056"
+    count: 82
     foil: true
   surge_extended_new:
     rawquery: "e:pip number:890-974"
+    count: 85
     foil: true
   surge_wildcard:
     rawquery: "e:pip number:529-854,890-975 -t:basic"
+    count: 402
     foil: true
   showcase:
     rawquery: "e:pip number:327-361"
+    count: 35
   foil_showcase:
     rawquery: "e:pip number:327-361"
+    count: 35
     foil: true
   surge_showcase:
     rawquery: "e:pip number:855-889"
+    count: 35
     foil: true
   serialized:
     rawquery: "e:pip number:1057-1063"
+    count: 7
     foil: true
   land:
     foil: true

--- a/data/boosters/pls-fat-pack.yaml
+++ b/data/boosters/pls-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:inv t:basic"
+    count: 20

--- a/data/boosters/ptk.yaml
+++ b/data/boosters/ptk.yaml
@@ -7,3 +7,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 55

--- a/data/boosters/rav-draft.yaml
+++ b/data/boosters/rav-draft.yaml
@@ -20,3 +20,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 110

--- a/data/boosters/rav-tournament.yaml
+++ b/data/boosters/rav-tournament.yaml
@@ -12,6 +12,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 110
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/rna-arena.yaml
+++ b/data/boosters/rna-arena.yaml
@@ -7,5 +7,7 @@ sheets:
   common:
     balanced: true
     query: "r:c not:guildgate"
+    count: 101
   land:
     query: "is:guildgate"
+    count: 10

--- a/data/boosters/rna-draft.yaml
+++ b/data/boosters/rna-draft.yaml
@@ -14,6 +14,7 @@ sheets:
   common:
     balanced: true
     query: "r:c not:guildgate"
+    count: 101
   land:
     query: "is:guildgate"
     count: 10

--- a/data/boosters/rna-theme-azorius.yaml
+++ b/data/boosters/rna-theme-azorius.yaml
@@ -23,23 +23,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 34
       rate: 1
     - query: "r:c -id:c"
+      count: 33
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 21
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 16
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/rna-theme-gruul.yaml
+++ b/data/boosters/rna-theme-gruul.yaml
@@ -23,23 +23,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 34
       rate: 1
     - query: "r:c -id:c"
+      count: 33
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 26
       rate: 1
     - query: "r:u -id:c"
+      count: 22
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 14
       rate: 2
     - query: "r:r -id:c"
+      count: 11
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/rna-theme-orzhov.yaml
+++ b/data/boosters/rna-theme-orzhov.yaml
@@ -23,23 +23,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 33
       rate: 1
     - query: "r:c -id:c"
+      count: 32
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 26
       rate: 1
     - query: "r:u -id:c"
+      count: 22
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 12
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/rna-theme-rakdos.yaml
+++ b/data/boosters/rna-theme-rakdos.yaml
@@ -23,23 +23,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 34
       rate: 1
     - query: "r:c -id:c"
+      count: 33
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 25
       rate: 1
     - query: "r:u -id:c"
+      count: 21
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 18
       rate: 2
     - query: "r:r -id:c"
+      count: 15
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/rna-theme-simic.yaml
+++ b/data/boosters/rna-theme-simic.yaml
@@ -23,23 +23,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 34
       rate: 1
     - query: "r:c -id:c"
+      count: 33
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 26
       rate: 1
     - query: "r:u -id:c"
+      count: 22
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 16
       rate: 2
     - query: "r:r -id:c"
+      count: 13
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/roe-six.yaml
+++ b/data/boosters/roe-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 100

--- a/data/boosters/rtr-prerelease-azorius.yaml
+++ b/data/boosters/rtr-prerelease-azorius.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Isperia, Supreme Judge"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 30

--- a/data/boosters/rtr-prerelease-golgari.yaml
+++ b/data/boosters/rtr-prerelease-golgari.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Jarad Golgari Lich Lord"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 31

--- a/data/boosters/rtr-prerelease-izzet.yaml
+++ b/data/boosters/rtr-prerelease-izzet.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Niv Mizzet"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 31

--- a/data/boosters/rtr-prerelease-rakdos.yaml
+++ b/data/boosters/rtr-prerelease-rakdos.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Rakdos, Lord of Riots"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 31

--- a/data/boosters/rtr-prerelease-selesnya.yaml
+++ b/data/boosters/rtr-prerelease-selesnya.yaml
@@ -10,6 +10,8 @@ sheets:
     - use: rare
       rate: 2
     - query: "Trostani Selesnya's Voice"
+      count: 1
       rate: 1
   common:
     query: "r:c"
+    count: 32

--- a/data/boosters/rtr-six.yaml
+++ b/data/boosters/rtr-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/rvr-draft.yaml
+++ b/data/boosters/rvr-draft.yaml
@@ -19,16 +19,21 @@ sheets:
   common:
     balanced: true
     query: "r:c -t:gate"
+    count: 100
   uncommon:
     query: "r:u -signet"
+    count: 80
   mana_slot:
     any:
     - chance: 58
       query: "t:gate"
+      count: 10
     - chance: 33
       query: "signet"
+      count: 10
     - chance: 9
       query: "(is:shockland or Chromatic Lantern)"
+      count: 11
   retro_common_uncommon:
     filter: "e:{set} number:302-415"
     use: common_uncommon
@@ -38,35 +43,48 @@ sheets:
   rare_mythic_with_showcase:
     any:
     - rawquery: "e:{set} r:r is:borderless -is:foilonly -frame:extendedart is:paper -(is:shockland or Chromatic Lantern)"
+      count: 16
       rate: 2
     - query: "r:r alt:(e:{set} r:r is:borderless -is:foilonly -frame:extendedart) -(is:shockland or Chromatic Lantern)"
+      count: 15
       rate: 4
     - query: "r:r -alt:(e:{set} r:r is:borderless -is:foilonly -frame:extendedart) -(is:shockland or Chromatic Lantern)"
+      count: 45
       rate: 6
     - rawquery: "e:{set} r:m is:borderless -is:foilonly -frame:extendedart is:paper"
+      count: 13
       rate: 1
     - query: "r:m alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+      count: 13
       rate: 2
     - query: "r:m -alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+      count: 7
       rate: 3
   foil_with_showcase:
     foil: true
     any:
     - query: "r:c"
+      count: 110
       chance: 12
     - query: "r:u"
+      count: 90
       chance: 5
     - any:
       - rawquery: "e:{set} r:r is:borderless -is:foilonly -frame:extendedart is:paper -is:shockland"
+        count: 17
         rate: 2
       - query: "r:r alt:(e:{set} r:r is:borderless -is:foilonly -frame:extendedart) -is:shockland"
+        count: 16
         rate: 4
       - query: "r:r -alt:(e:{set} r:r is:borderless -is:foilonly -frame:extendedart -is:shockland)"
+        count: 55
         rate: 6
       - rawquery: "e:{set} r:m is:borderless -is:foilonly -frame:extendedart is:paper"
+        count: 13
         rate: 1
       - query: "r:r alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
         rate: 2
       - query: "r:r -alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+        count: 71
         rate: 3
       chance: 3

--- a/data/boosters/scg-fat-pack.yaml
+++ b/data/boosters/scg-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:ons t:basic"
+    count: 20

--- a/data/boosters/shm-draft.yaml
+++ b/data/boosters/shm-draft.yaml
@@ -13,3 +13,4 @@ sheets:
     # balancing algorithm doesn't support heavily multicolor sets
     balanced: false
     query: "r:c"
+    count: 121

--- a/data/boosters/shm-tournament.yaml
+++ b/data/boosters/shm-tournament.yaml
@@ -12,6 +12,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 121
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/slc-encyclopedia.yaml
+++ b/data/boosters/slc-encyclopedia.yaml
@@ -31,263 +31,342 @@ sheets:
   slot1:
     any:
     - rawquery: "e:slc number:1"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:1"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:28"
+      count: 1
       foil: true
       chance: 3
   slot2:
     any:
     - rawquery: "e:slc number:2"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:2"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:29"
+      count: 1
       foil: true
       chance: 3
   slot3:
     any:
     - rawquery: "e:slc number:3"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:3"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:30"
+      count: 1
       foil: true
       chance: 3
   slot4:
     any:
     - rawquery: "e:slc number:4"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:4"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:31"
+      count: 1
       foil: true
       chance: 3
   slot5:
     any:
     - rawquery: "e:slc number:5"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:5"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:32"
+      count: 1
       foil: true
       chance: 3
   slot6:
     any:
     - rawquery: "e:slc number:6"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:6"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:33"
+      count: 1
       foil: true
       chance: 3
   slot7:
     any:
     - rawquery: "e:slc number:7"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:7"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:34"
+      count: 1
       foil: true
       chance: 3
   slot8:
     any:
     - rawquery: "e:slc number:8"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:8"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:35"
+      count: 1
       foil: true
       chance: 3
   slot9:
     any:
     - rawquery: "e:slc number:9"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:9"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:36"
+      count: 1
       foil: true
       chance: 3
   slot10:
     any:
     - rawquery: "e:slc number:10"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:10"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:37"
+      count: 1
       foil: true
       chance: 3
   slot11:
     any:
     - rawquery: "e:slc number:11"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:11"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:38"
+      count: 1
       foil: true
       chance: 3
   slot12:
     any:
     - rawquery: "e:slc number:12"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:12"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:39"
+      count: 1
       foil: true
       chance: 3
   slot13:
     any:
     - rawquery: "e:slc number:13"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:13"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:40"
+      count: 1
       foil: true
       chance: 3
   slot14:
     any:
     - rawquery: "e:slc number:14"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:14"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:41"
+      count: 1
       foil: true
       chance: 3
   slot15:
     any:
     - rawquery: "e:slc number:15"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:15"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:42"
+      count: 1
       foil: true
       chance: 3
   slot16:
     any:
     - rawquery: "e:slc number:16"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:16"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:43"
+      count: 1
       foil: true
       chance: 3
   slot17:
     any:
     - rawquery: "e:slc number:17"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:17"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:44"
+      count: 1
       foil: true
       chance: 3
   slot18:
     any:
     - rawquery: "e:slc number:18"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:18"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:45"
+      count: 1
       foil: true
       chance: 3
   slot19:
     any:
     - rawquery: "e:slc number:19"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:19"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:46"
+      count: 1
       foil: true
       chance: 3
   slot20:
     any:
     - rawquery: "e:slc number:20"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:20"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:47"
+      count: 1
       foil: true
       chance: 3
   slot21:
     any:
     - rawquery: "e:slc number:21"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:21"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:48"
+      count: 1
       foil: true
       chance: 3
   slot22:
     any:
     - rawquery: "e:slc number:22"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:22"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:49"
+      count: 1
       foil: true
       chance: 3
   slot23:
     any:
     - rawquery: "e:slc number:23"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:23"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:50"
+      count: 1
       foil: true
       chance: 3
   slot24:
     any:
     - rawquery: "e:slc number:24"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:24"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:51"
+      count: 1
       foil: true
       chance: 3
   slot25:
     any:
     - rawquery: "e:slc number:25"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:25"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:52"
+      count: 1
       foil: true
       chance: 3
   slot26:
     any:
     - rawquery: "e:slc number:26"
+      count: 1
       chance: 70
     - rawquery: "e:slc number:26"
+      count: 1
       foil: true
       chance: 27
     - rawquery: "e:slc number:53"
+      count: 1
       foil: true
       chance: 3
   slot27:
     rawquery: "e:slc number:27"
+    count: 1
     foil: true

--- a/data/boosters/slc.yaml
+++ b/data/boosters/slc.yaml
@@ -35,213 +35,274 @@ sheets:
   slot1:
     any:
     - rawquery: "e:slc number:1993"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1993"
+      count: 1
       foil: true
       chance: 3
   slot2:
     any:
     - rawquery: "e:slc number:1994"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1994"
+      count: 1
       foil: true
       chance: 3
   slot3:
     any:
     - rawquery: "e:slc number:1995"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1995"
+      count: 1
       foil: true
       chance: 3
   slot4:
     any:
     - rawquery: "e:slc number:1996"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1996"
+      count: 1
       foil: true
       chance: 3
   slot5:
     any:
     - rawquery: "e:slc number:1997"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1997"
+      count: 1
       foil: true
       chance: 3
   slot6:
     any:
     - rawquery: "e:slc number:1998"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1998"
+      count: 1
       foil: true
       chance: 3
   slot7:
     any:
     - rawquery: "e:slc number:1999"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:1999"
+      count: 1
       foil: true
       chance: 3
   slot8:
     any:
     - rawquery: "e:slc number:2000"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2000"
+      count: 1
       foil: true
       chance: 3
   slot9:
     any:
     - rawquery: "e:slc number:2001"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2001"
+      count: 1
       foil: true
       chance: 3
   slot10:
     any:
     - rawquery: "e:slc number:2002"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2002"
+      count: 1
       foil: true
       chance: 3
   slot11:
     any:
     - rawquery: "e:slc number:2003"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2003"
+      count: 1
       foil: true
       chance: 3
   slot12:
     any:
     - rawquery: "e:slc number:2004"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2004"
+      count: 1
       foil: true
       chance: 3
   slot13:
     any:
     - rawquery: "e:slc number:2005"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2005"
+      count: 1
       foil: true
       chance: 3
   slot14:
     any:
     - rawquery: "e:slc number:2006"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2006"
+      count: 1
       foil: true
       chance: 3
   slot15:
     any:
     - rawquery: "e:slc number:2007"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2007"
+      count: 1
       foil: true
       chance: 3
   slot16:
     any:
     - rawquery: "e:slc number:2008"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2008"
+      count: 1
       foil: true
       chance: 3
   slot17:
     any:
     - rawquery: "e:slc number:2009"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2009"
+      count: 1
       foil: true
       chance: 3
   slot18:
     any:
     - rawquery: "e:slc number:2010"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2010"
+      count: 1
       foil: true
       chance: 3
   slot19:
     any:
     - rawquery: "e:slc number:2011"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2011"
+      count: 1
       foil: true
       chance: 3
   slot20:
     any:
     - rawquery: "e:slc number:2012"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2012"
+      count: 1
       foil: true
       chance: 3
   slot21:
     any:
     - rawquery: "e:slc number:2013"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2013"
+      count: 1
       foil: true
       chance: 3
   slot22:
     any:
     - rawquery: "e:slc number:2014"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2014"
+      count: 1
       foil: true
       chance: 3
   slot23:
     any:
     - rawquery: "e:slc number:2015"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2015"
+      count: 1
       foil: true
       chance: 3
   slot24:
     any:
     - rawquery: "e:slc number:2016"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2016"
+      count: 1
       foil: true
       chance: 3
   slot25:
     any:
     - rawquery: "e:slc number:2017"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2017"
+      count: 1
       foil: true
       chance: 3
   slot26:
     any:
     - rawquery: "e:slc number:2018"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2018"
+      count: 1
       foil: true
       chance: 3
   slot27:
     any:
     - rawquery: "e:slc number:2019"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2019"
+      count: 1
       foil: true
       chance: 3
   slot28:
     any:
     - rawquery: "e:slc number:2020"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2020"
+      count: 1
       foil: true
       chance: 3
   slot29:
     any:
     - rawquery: "e:slc number:2021"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2021"
+      count: 1
       foil: true
       chance: 3
   slot30:
     any:
     - rawquery: "e:slc number:2022"
+      count: 1
       chance: 7
     - rawquery: "e:slc number:2022"
+      count: 1
       foil: true
       chance: 3
   slot31:
     rawquery: "e:slc number:2023"
+    count: 1
     foil: true

--- a/data/boosters/sld-blueprint-mk1.yaml
+++ b/data/boosters/sld-blueprint-mk1.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   blueprint_mk1:
     rawquery: "e:sld number>=603 number<=607"
+    count: 5
     foil: true

--- a/data/boosters/sld-blueprint-mk2.yaml
+++ b/data/boosters/sld-blueprint-mk2.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   blueprint_mk2:
     rawquery: "e:sld number>=691 number<=695"
+    count: 5
     foil: true

--- a/data/boosters/sld-chaos-emeralds.yaml
+++ b/data/boosters/sld-chaos-emeralds.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   chaos_emeralds:
     rawquery: "e:sld number>=7031 number<=7037"
+    count: 7
     foil: true

--- a/data/boosters/sld-fin-elementals.yaml
+++ b/data/boosters/sld-fin-elementals.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   fin_elementals:
     rawquery: "e:sld number>=7004 number<=7008"
+    count: 5
     foil: true

--- a/data/boosters/sld-stainedglass-b.yaml
+++ b/data/boosters/sld-stainedglass-b.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_black:
     rawquery: "e:sld number>=501 number<=536 color>=black"
+    count: 9
     foil: true

--- a/data/boosters/sld-stainedglass-c.yaml
+++ b/data/boosters/sld-stainedglass-c.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_colorless:
     rawquery: "e:sld number>=501 number<=536 color=c"
+    count: 2
     foil: true

--- a/data/boosters/sld-stainedglass-g.yaml
+++ b/data/boosters/sld-stainedglass-g.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_green:
     rawquery: "e:sld number>=501 number<=536 color>=green"
+    count: 11
     foil: true

--- a/data/boosters/sld-stainedglass-iwd.yaml
+++ b/data/boosters/sld-stainedglass-iwd.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_iwd:
     rawquery: "e:sld number=505,507,508,510,512,513,516,518,519,525,528,530,531,532,533,534,535,536"
+    count: 18
     foil: true

--- a/data/boosters/sld-stainedglass-r.yaml
+++ b/data/boosters/sld-stainedglass-r.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_red:
     rawquery: "e:sld number>=501 number<=536 color>=red"
+    count: 11
     foil: true

--- a/data/boosters/sld-stainedglass-tattoo.yaml
+++ b/data/boosters/sld-stainedglass-tattoo.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_tattoo:
     rawquery: "e:sld number=504,506,507,508,510,513,515,518,524,526,527,529,530,531,533"
+    count: 15
     foil: true

--- a/data/boosters/sld-stainedglass-u.yaml
+++ b/data/boosters/sld-stainedglass-u.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_blue:
     rawquery: "e:sld number>=501 number<=536 color>=blue"
+    count: 11
     foil: true

--- a/data/boosters/sld-stainedglass-uncommon.yaml
+++ b/data/boosters/sld-stainedglass-uncommon.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_uncommon:
     rawquery: "e:sld number>=501 number<=536 rarity=u"
+    count: 20
     foil: true

--- a/data/boosters/sld-stainedglass-w.yaml
+++ b/data/boosters/sld-stainedglass-w.yaml
@@ -4,4 +4,5 @@ pack:
 sheets:
   stainedglass_white:
     rawquery: "e:sld number>=501 number<=536 color>=white"
+    count: 10
     foil: true

--- a/data/boosters/snc-collector.yaml
+++ b/data/boosters/snc-collector.yaml
@@ -27,6 +27,7 @@ sheets:
   foil_fullart_basic:
     foil: true
     query: "r:b is:fullart"
+    count: 10
   foil_rare_mythic:
     foil: true
     use: rare_mythic
@@ -39,12 +40,16 @@ sheets:
   rare_mythic_showcase:
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper is:triome"
+      count: 10
       rate: 2
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:triome"
+      count: 26
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
+      count: 8
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
+      count: 10
       rate: 2
   gilded_common_uncommon_showcase:
     foil: true
@@ -66,10 +71,14 @@ sheets:
     foil: true
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly is:paper is:triome"
+      count: 10
       rate: 2
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly is:paper -is:triome"
+      count: 55
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly is:paper (t:planeswalker or Urabrask) number<=360"
+      count: 8
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly is:paper -t:planeswalker -Urabrask"
+      count: 16
       rate: 2

--- a/data/boosters/snc-draft.yaml
+++ b/data/boosters/snc-draft.yaml
@@ -23,8 +23,10 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper is:triome"
+      count: 10
       rate: 1
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:triome"
+      count: 26
       rate: 2
     - use: rare_has_showcase
       rate: 4
@@ -34,8 +36,10 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
+      count: 8
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
+      count: 10
       rate: 2
     - use: mythic_has_showcase
       rate: 4
@@ -64,16 +68,20 @@ sheets:
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper is:triome"
+        count: 10
         rate: 2
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:triome"
+        count: 26
         rate: 4
       - use: rare_has_showcase
         rate: 8
       - use: rare_has_no_showcase
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
+        count: 8
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4

--- a/data/boosters/snc-prerelease-brokers.yaml
+++ b/data/boosters/snc-prerelease-brokers.yaml
@@ -12,10 +12,13 @@ sheets:
   intro_set:
     fixed: true
     query: "(t:land id:0) or (r:c c:3)"
+    count: 2
   land:
     query: "t:land id:2"
+    count: 2
   common:
     query: "r:c -t:land -(r:c c:3)"
+    count: 41
   prerelease_promo:
     filter: "e:psnc promo:prerelease"
     use: rare_mythic

--- a/data/boosters/snc-prerelease-cabaretti.yaml
+++ b/data/boosters/snc-prerelease-cabaretti.yaml
@@ -12,10 +12,13 @@ sheets:
   intro_set:
     fixed: true
     query: "(t:land id:0) or (r:c c:3)"
+    count: 2
   land:
     query: "t:land id:2"
+    count: 2
   common:
     query: "r:c -t:land -(r:c c:3)"
+    count: 43
   prerelease_promo:
     filter: "e:psnc promo:prerelease"
     use: rare_mythic

--- a/data/boosters/snc-prerelease-maestros.yaml
+++ b/data/boosters/snc-prerelease-maestros.yaml
@@ -12,10 +12,13 @@ sheets:
   intro_set:
     fixed: true
     query: "(t:land id:0) or (r:c c:3)"
+    count: 2
   land:
     query: "t:land id:2"
+    count: 2
   common:
     query: "r:c -t:land -(r:c c:3)"
+    count: 42
   prerelease_promo:
     filter: "e:psnc promo:prerelease"
     use: rare_mythic

--- a/data/boosters/snc-prerelease-obscura.yaml
+++ b/data/boosters/snc-prerelease-obscura.yaml
@@ -12,10 +12,13 @@ sheets:
   intro_set:
     fixed: true
     query: "(t:land id:0) or (r:c c:3)"
+    count: 2
   land:
     query: "t:land id:2"
+    count: 2
   common:
     query: "r:c -t:land -(r:c c:3)"
+    count: 42
   prerelease_promo:
     filter: "e:psnc promo:prerelease"
     use: rare_mythic

--- a/data/boosters/snc-prerelease-riveteers.yaml
+++ b/data/boosters/snc-prerelease-riveteers.yaml
@@ -12,10 +12,13 @@ sheets:
   intro_set:
     fixed: true
     query: "(t:land id:0) or (r:c c:3)"
+    count: 2
   land:
     query: "t:land id:2"
+    count: 2
   common:
     query: "r:c -t:land -(r:c c:3)"
+    count: 43
   prerelease_promo:
     filter: "e:psnc promo:prerelease"
     use: rare_mythic

--- a/data/boosters/snc-set.yaml
+++ b/data/boosters/snc-set.yaml
@@ -28,6 +28,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   basic:
     any:
     - query: "r:b number<272"
@@ -47,8 +48,10 @@ sheets:
       chance: 175
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper is:triome"
+        count: 10
         rate: 2
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:triome"
+        count: 26
         rate: 4
       - use: rare_has_showcase
         rate: 8
@@ -59,16 +62,20 @@ sheets:
       # "e:snc number<=93" - a typo that pointed at the main set (redundant with
       # the showcase entries) instead of the commander set.
       - rawquery: "e:ncc number:1-10,86-93 r:r"
+        count: 6
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
+        count: 8
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:ncc number:1-10,86-93 r:m"
+        count: 12
         rate: 6
       chance: 125
   foil_with_showcase:
@@ -82,14 +89,17 @@ sheets:
       - use: common_has_no_showcase
         rate: 3
       - query: "r:b"
+        count: 20
         rate: 3
       chance: 12
     - use: uncommon_with_showcase
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper is:triome"
+        count: 10
         rate: 2
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -is:triome"
+        count: 26
         rate: 4
       - use: rare_has_showcase
         rate: 8
@@ -97,16 +107,20 @@ sheets:
         rate: 12
       # foil New Capenna Commander cards (mirrors the wildcard's nonfoil entry)
       - rawquery: "e:ncc number:1-10,86-93 r:r"
+        count: 6
         rate: 12
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (t:planeswalker or Urabrask) number<=360"
+        count: 8
         rate: 1
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -t:planeswalker -Urabrask"
+        count: 10
         rate: 2
       - use: mythic_has_showcase
         rate: 4
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:ncc number:1-10,86-93 r:m"
+        count: 12
         rate: 6
       chance: 3
   gilded_foil:
@@ -116,8 +130,10 @@ sheets:
     filter: "e:snc promo:gilded"
     any:
     - query: "r:c or r:u"
+      count: 20
       chance: 3
     - query: "r:r or r:m"
+      count: 25
       chance: 1
   the_list:
     any:

--- a/data/boosters/snc-theme-brokers.yaml
+++ b/data/boosters/snc-theme-brokers.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 45
       rate: 1
     - query: "r:c -id:c"
+      count: 38
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 33
       rate: 1
     - query: "r:u -id:c"
+      count: 28
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 21
       rate: 2
     - query: "r:r -id:c"
+      count: 19
       rate: 6
     - query: "r:m"
+      count: 10
       rate: 1
     - query: "r:m -id:c"
+      count: 9
       rate: 3

--- a/data/boosters/snc-theme-cabaretti.yaml
+++ b/data/boosters/snc-theme-cabaretti.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 47
       rate: 1
     - query: "r:c -id:c"
+      count: 40
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 34
       rate: 1
     - query: "r:u -id:c"
+      count: 29
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 22
       rate: 2
     - query: "r:r -id:c"
+      count: 20
       rate: 6
     - query: "r:m"
+      count: 7
       rate: 1
     - query: "r:m -id:c"
+      count: 6
       rate: 3

--- a/data/boosters/snc-theme-maestros.yaml
+++ b/data/boosters/snc-theme-maestros.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 46
       rate: 1
     - query: "r:c -id:c"
+      count: 39
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 34
       rate: 1
     - query: "r:u -id:c"
+      count: 29
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 21
       rate: 2
     - query: "r:r -id:c"
+      count: 19
       rate: 6
     - query: "r:m"
+      count: 7
       rate: 1
     - query: "r:m -id:c"
+      count: 6
       rate: 3

--- a/data/boosters/snc-theme-obscura.yaml
+++ b/data/boosters/snc-theme-obscura.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 46
       rate: 1
     - query: "r:c -id:c"
+      count: 39
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 35
       rate: 1
     - query: "r:u -id:c"
+      count: 30
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 22
       rate: 2
     - query: "r:r -id:c"
+      count: 20
       rate: 6
     - query: "r:m"
+      count: 8
       rate: 1
     - query: "r:m -id:c"
+      count: 7
       rate: 3

--- a/data/boosters/snc-theme-riveteers.yaml
+++ b/data/boosters/snc-theme-riveteers.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 47
       rate: 1
     - query: "r:c -id:c"
+      count: 40
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 33
       rate: 1
     - query: "r:u -id:c"
+      count: 28
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 22
       rate: 2
     - query: "r:r -id:c"
+      count: 20
       rate: 6
     - query: "r:m"
+      count: 7
       rate: 1
     - query: "r:m -id:c"
+      count: 6
       rate: 3

--- a/data/boosters/sok-fat-pack.yaml
+++ b/data/boosters/sok-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:chk t:basic"
+    count: 20

--- a/data/boosters/som-six.yaml
+++ b/data/boosters/som-six.yaml
@@ -13,3 +13,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/stx-arena.yaml
+++ b/data/boosters/stx-arena.yaml
@@ -37,9 +37,12 @@ sheets:
   nonlesson_common:
     balanced: true
     query: "-t:lesson r:c"
+    count: 96
   nonlesson_rare_mythic:
     any:
     - query: "-t:lesson r:r"
+      count: 64
       rate: 2
     - query: "-t:lesson r:m"
+      count: 20
       rate: 1

--- a/data/boosters/stx-collector.yaml
+++ b/data/boosters/stx-collector.yaml
@@ -33,6 +33,7 @@ sheets:
   foil_sta_uncommon:
     foil: true
     rawquery: "e:sta r:u"
+    count: 36
   foil_alt_art_wild:
     foil: true
     filter: "(e:stx promo:boosterfun) or (e:sta)"

--- a/data/boosters/stx-draft.yaml
+++ b/data/boosters/stx-draft.yaml
@@ -46,6 +46,7 @@ sheets:
   nonlesson_common:
     balanced: true
     query: "-t:lesson r:c"
+    count: 96
   nonlesson_rare_mythic:
     any:
     - query: "-t:lesson r:r"
@@ -69,12 +70,14 @@ sheets:
       - use: uncommon
         rate: 1
       - rawquery: "e:sta r:u is:baseset"
+        count: 18
         rate: 1
       chance: 5
     - any:
       - use: rare
         rate: 6
       - rawquery: "e:sta r:r is:baseset"
+        count: 30
         rate: 6
       - use: mythic_showcase
         rate: 1
@@ -83,5 +86,6 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 3
       - rawquery: "e:sta r:m is:baseset"
+        count: 15
         rate: 3
       chance: 3

--- a/data/boosters/stx-jp.yaml
+++ b/data/boosters/stx-jp.yaml
@@ -45,6 +45,7 @@ sheets:
   nonlesson_common:
     balanced: true
     query: "-t:lesson r:c"
+    count: 96
   nonlesson_rare_mythic:
     any:
     - query: "-t:lesson r:r"
@@ -68,12 +69,14 @@ sheets:
       - use: uncommon
         rate: 2
       - rawquery: "e:sta r:u"
+        count: 36
         rate: 1
       chance: 5
     - any:
       - use: rare
         rate: 12
       - rawquery: "e:sta r:r"
+        count: 60
         rate: 6
       - use: mythic_showcase
         rate: 2
@@ -82,5 +85,6 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:sta r:m"
+        count: 30
         rate: 3
       chance: 3

--- a/data/boosters/stx-set-jp.yaml
+++ b/data/boosters/stx-set-jp.yaml
@@ -36,13 +36,16 @@ pack:
 sheets:
   basic:
     rawquery: "e:stx t:basic"
+    count: 10
   foil_basic:
     foil: true
     use: basic
   common:
     query: "r:c -t:lesson"
+    count: 96
   uncommon:
     query: "r:u -t:lesson"
+    count: 75
   wildcard:
     any:
     - use: common
@@ -51,12 +54,14 @@ sheets:
       - use: uncommon
         rate: 2
       - rawquery: "e:sta r:u "
+        count: 36
         rate: 1
       chance: 175
     - any:
       - use: rare
         rate: 12
       - rawquery: "e:sta r:r"
+        count: 60
         rate: 6
       - use: mythic_showcase
         rate: 2
@@ -65,6 +70,7 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:sta r:m"
+        count: 30
         rate: 3
       chance: 125
   foil_with_showcase:
@@ -76,12 +82,14 @@ sheets:
       - use: uncommon
         rate: 2
       - rawquery: "e:sta r:u"
+        count: 36
         rate: 1
       chance: 5
     - any:
       - use: rare
         rate: 12
       - rawquery: "e:sta r:r"
+        count: 60
         rate: 6
       - use: mythic_showcase
         rate: 2
@@ -90,6 +98,7 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:sta r:m"
+        count: 30
         rate: 3
       chance: 3
   sta:

--- a/data/boosters/stx-set.yaml
+++ b/data/boosters/stx-set.yaml
@@ -36,13 +36,16 @@ pack:
 sheets:
   basic:
     rawquery: "e:stx t:basic"
+    count: 10
   foil_basic:
     foil: true
     use: basic
   common:
     query: "r:c -t:lesson"
+    count: 96
   uncommon:
     query: "r:u -t:lesson"
+    count: 75
   wildcard:
     any:
     - use: common
@@ -51,12 +54,14 @@ sheets:
       - use: uncommon
         rate: 1
       - rawquery: "e:sta r:u is:baseset"
+        count: 18
         rate: 1
       chance: 175
     - any:
       - use: rare
         rate: 6
       - rawquery: "e:sta r:r is:baseset"
+        count: 30
         rate: 6
       - use: mythic_showcase
         rate: 1
@@ -65,6 +70,7 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 3
       - rawquery: "e:sta r:m is:baseset"
+        count: 15
         rate: 3
       chance: 125
   foil_with_showcase:
@@ -76,12 +82,14 @@ sheets:
       - use: uncommon
         rate: 1
       - rawquery: "e:sta r:u is:baseset"
+        count: 18
         rate: 1
       chance: 5
     - any:
       - use: rare
         rate: 12
       - rawquery: "e:sta r:r is:baseset"
+        count: 30
         rate: 12
       - use: mythic_showcase
         rate: 2
@@ -90,6 +98,7 @@ sheets:
       - use: mythic_has_no_showcase
         rate: 6
       - rawquery: "e:sta r:m is:baseset"
+        count: 15
         rate: 6
       chance: 3
   sta:

--- a/data/boosters/stx-theme-lorehold.yaml
+++ b/data/boosters/stx-theme-lorehold.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 40
       rate: 1
     - query: "r:c -id:c"
+      count: 30
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 28
       rate: 1
     - query: "r:u -id:c"
+      count: 23
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 24
       rate: 2
     - query: "r:r -id:c"
+      count: 20
       rate: 6
     - query: "r:m"
+      count: 6
       rate: 1
     - query: "r:m -id:c"
+      count: 5
       rate: 3

--- a/data/boosters/stx-theme-prismari.yaml
+++ b/data/boosters/stx-theme-prismari.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 39
       rate: 1
     - query: "r:c -id:c"
+      count: 29
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 29
       rate: 1
     - query: "r:u -id:c"
+      count: 24
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 21
       rate: 2
     - query: "r:r -id:c"
+      count: 17
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/stx-theme-quandrix.yaml
+++ b/data/boosters/stx-theme-quandrix.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 39
       rate: 1
     - query: "r:c -id:c"
+      count: 29
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 28
       rate: 1
     - query: "r:u -id:c"
+      count: 23
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 21
       rate: 2
     - query: "r:r -id:c"
+      count: 17
       rate: 6
     - query: "r:m"
+      count: 6
       rate: 1
     - query: "r:m -id:c"
+      count: 5
       rate: 3

--- a/data/boosters/stx-theme-silverquill.yaml
+++ b/data/boosters/stx-theme-silverquill.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 40
       rate: 1
     - query: "r:c -id:c"
+      count: 30
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 28
       rate: 1
     - query: "r:u -id:c"
+      count: 23
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 22
       rate: 2
     - query: "r:r -id:c"
+      count: 18
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/stx-theme-witherbloom.yaml
+++ b/data/boosters/stx-theme-witherbloom.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 40
       rate: 1
     - query: "r:c -id:c"
+      count: 30
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 27
       rate: 1
     - query: "r:u -id:c"
+      count: 22
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 23
       rate: 2
     - query: "r:r -id:c"
+      count: 19
       rate: 6
     - query: "r:m"
+      count: 6
       rate: 1
     - query: "r:m -id:c"
+      count: 5
       rate: 3

--- a/data/boosters/tdm-collector.yaml
+++ b/data/boosters/tdm-collector.yaml
@@ -37,20 +37,25 @@ sheets:
   non_foil_draconic_c_u:
     any:
     - rawquery: "{draconic_showcase} r:c"
+      count: 6
       chance: 546
     - rawquery: "{draconic_showcase} r:u"
+      count: 15
       chance: 454
   foil_draconic_c_u:
     foil: true
     use: non_foil_draconic_c_u
   non_foil_basic:
     rawquery: "{dragons_eye_basic}"
+    count: 5
   foil_basic:
     foil: true
     any:
     - rawquery: "{dragons_eye_basic}"
+      count: 5
       chance: 11
     - rawquery: "{presence_basic}"
+      count: 5
       chance: 100
   foil_rare_mythic:
     foil: true
@@ -58,54 +63,75 @@ sheets:
   commander:
     any:
     - rawquery: "e:tdc number:1-10"
+      count: 10
       rate: 1
     - rawquery: "e:tdc number:51-90"
+      count: 40
       rate: 2
   booster_fun:
     any:
     - rawquery: "{draconic_showcase} r:r"
+      count: 5
       chance: 64
     - rawquery: "{draconic_showcase} r:m"
+      count: 9
       chance: 46
     - rawquery: "{clan_card} r:r"
+      count: 36
       chance: 515
     - rawquery: "{clan_card} r:m"
+      count: 14
       chance: 82
     - rawquery: "{borderless_alternate_art} r:r"
+      count: 15
       chance: 215
     - rawquery: "{borderless_alternate_art} r:m"
+      count: 1
       chance: 7
     - rawquery: "{reversible_dragons} r:r"
+      count: 5
       chance: 64
     - rawquery: "{reversible_dragons} r:m"
+      count: 1
       chance: 7
   foil_booster_fun:
     foil: true
     any:
     - rawquery: "{draconic_showcase} r:r"
+      count: 5
       chance: 530
     - rawquery: "{draconic_showcase} r:m"
+      count: 9
       chance: 390
     - rawquery: "{clan_card} r:r"
+      count: 36
       chance: 4270
     - rawquery: "{clan_card} r:m"
+      count: 14
       chance: 680
     - rawquery: "{borderless_alternate_art} r:r"
+      count: 15
       chance: 1780
     - rawquery: "{borderless_alternate_art} r:m"
+      count: 1
       chance: 60
     - rawquery: "{reversible_dragons} r:r"
+      count: 5
       chance: 530
     - rawquery: "{reversible_dragons} r:m"
+      count: 1
       chance: 60
     - rawquery: "{ghostfire}"
+      count: 10
       chance: 900
     - rawquery: "{halo_foil_ghostfire}"
+      count: 10
       chance: 100
     - set: spg
       code: "TDM"
       chance: 600
     - rawquery: "e:spg number:114-118"
+      count: 5
       chance: 100
     - rawquery: "{serialized_mox}"
       chance: 2

--- a/data/boosters/tdm-play.yaml
+++ b/data/boosters/tdm-play.yaml
@@ -58,8 +58,10 @@ sheets:
   boosterfun_r_m:
     any:
     - rawquery: "{boosterfun} r:r"
+      count: 61
       rate: 2
     - rawquery: "{boosterfun} r:m"
+      count: 25
       rate: 1
 
   wildcard:

--- a/data/boosters/thb-collector.yaml
+++ b/data/boosters/thb-collector.yaml
@@ -41,14 +41,17 @@ sheets:
     # U/R/M rates guessed to be at 4x/2x/1x multiples
     any:
     - query: "r:u t:saga"
+      count: 5
       rate: 4
     - use: uncommon_showcase
       rate: 4
     - query: "r:r t:saga"
+      count: 4
       rate: 2
     - use: mythic_showcase
       rate: 1
     - query: "r:m t:saga"
+      count: 1
       rate: 1
   foil_showcase:
     # 15th Collector slot: a traditional-foil constellation/showcase card
@@ -67,10 +70,14 @@ sheets:
     foil: true
     any:
     - rawquery: "e:thb r:r promo:boosterfun"
+      count: 49
       rate: 2
     - query: "r:r"
+      count: 53
       rate: 4
     - rawquery: "e:thb r:m promo:boosterfun"
+      count: 14
       rate: 1
     - query: "r:m"
+      count: 15
       rate: 2

--- a/data/boosters/thb-draft.yaml
+++ b/data/boosters/thb-draft.yaml
@@ -18,6 +18,7 @@ sheets:
   # assuming this works the same as uncommons, no proof
     any:
     - query: "r:r"
+      count: 53
       chance: 106
     - use: mythic_with_showcase
       chance: 15

--- a/data/boosters/thb-theme-b.yaml
+++ b/data/boosters/thb-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 10
       rate: 6
     - query: "r:m"
+      count: 1
       rate: 1
     - query: "r:m -id:c"
+      count: 1
       rate: 3

--- a/data/boosters/thb-theme-g.yaml
+++ b/data/boosters/thb-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/thb-theme-r.yaml
+++ b/data/boosters/thb-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/thb-theme-u.yaml
+++ b/data/boosters/thb-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/thb-theme-w.yaml
+++ b/data/boosters/thb-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/tmp-starter.yaml
+++ b/data/boosters/tmp-starter.yaml
@@ -8,10 +8,13 @@ pack:
 sheets:
   basics:
     query: "r:b"
+    count: 20
     duplicates: true
   common_with_duplicates:
     query: "r:c"
+    count: 110
     duplicates: true
   uncommon_with_duplicates:
     query: "r:u"
+    count: 110
     duplicates: true

--- a/data/boosters/tor-fat-pack.yaml
+++ b/data/boosters/tor-fat-pack.yaml
@@ -7,3 +7,4 @@ sheets:
   foil_basic:
     foil: true
     rawquery: "e:ody t:basic"
+    count: 20

--- a/data/boosters/tsp-draft.yaml
+++ b/data/boosters/tsp-draft.yaml
@@ -16,10 +16,13 @@ sheets:
     foil: true
     any:
     - query: "r:r"
+      count: 80
       chance: 1
     - query: "r:u"
+      count: 80
       chance: 2
     - query: "r<=c"
+      count: 141
       chance: 4
     - rawquery: "e:tsb"
       count: 121

--- a/data/boosters/tsr-draft.yaml
+++ b/data/boosters/tsr-draft.yaml
@@ -11,6 +11,7 @@ pack:
 sheets:
   special:
     rawquery: "e:{set} r:s"
+    count: 121
   foil:
     # no idea about the rates
     foil: true
@@ -18,8 +19,11 @@ sheets:
     - use: rare_mythic
       chance: 1
     - query: "r:u"
+      count: 100
       chance: 2
     - query: "r:c"
+      count: 121
       chance: 4
     - rawquery: "e:{set} r:s"
+      count: 121
       chance: 1

--- a/data/boosters/ugl-draft.yaml
+++ b/data/boosters/ugl-draft.yaml
@@ -7,3 +7,4 @@ sheets:
   common:
     balanced: false
     query: "r:c"
+    count: 33

--- a/data/boosters/uma-box-topper.yaml
+++ b/data/boosters/uma-box-topper.yaml
@@ -6,3 +6,4 @@ sheets:
   box_topper:
     foil: true
     rawquery: "e:puma"
+    count: 40

--- a/data/boosters/unf-box-topper.yaml
+++ b/data/boosters/unf-box-topper.yaml
@@ -6,3 +6,4 @@ sheets:
   foil_shockland:
     foil: true
     rawquery: "e:unf is:shockland -is:galaxyfoil"
+    count: 10

--- a/data/boosters/unf-collector.yaml
+++ b/data/boosters/unf-collector.yaml
@@ -41,24 +41,31 @@ sheets:
     foil: true
     any:
     - rawquery: "e:unf r:b number:486-490"
+      count: 5
       chance: 3
     - rawquery: "e:unf r:b number:491-495"
+      count: 5
       chance: 1
   foil_shock:
     foil: true
     rawquery: "e:unf number:277-286"
+    count: 10
   galaxy_shock:
     foil: true
     rawquery: "e:unf number:528-537"
+    count: 10
   foil_common:
     foil: true
     query: "r:c -t:attraction is:paper"
+    count: 80
   foil_uncommon:
     foil: true
     query: "r:u -t:attraction"
+    count: 60
   foil_attraction:
     foil: true
     query: "t:attraction"
+    count: 135
   foil_rare_mythic:
     foil: true
     any:
@@ -71,6 +78,7 @@ sheets:
   foil_un-list:
     foil: true
     rawquery: "e:ulst"
+    count: 62
   galaxy_common_uncommon:
     foil: true
     filter: "e:unf number:287-485"
@@ -82,6 +90,7 @@ sheets:
   foil_uncommon_showcase:
     foil: true
     rawquery: "e:unf number:245-276 r:u"
+    count: 10
   foil_rare_mythic_showcase:
     foil: true
     filter: "e:unf number:245-276"
@@ -89,6 +98,7 @@ sheets:
   galaxy_uncommon_showcase:
     foil: true
     rawquery: "e:unf number:496-527 r:u"
+    count: 10
   galaxy_rare_mythic_showcase:
     foil: true
     filter: "e:unf number:496-527"

--- a/data/boosters/unf-draft.yaml
+++ b/data/boosters/unf-draft.yaml
@@ -30,27 +30,37 @@ sheets:
     count: 10
   common:
     query: "r:c -t:attraction is:paper"
+    count: 80
   uncommon_with_showcase:
     any:
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart -t:attraction is:paper"
+      count: 10
       rate: 1
     - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction"
+      count: 10
       rate: 2
     - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction"
+      count: 50
       rate: 3
   rare_mythic_with_showcase:
     any:
     - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart -t:attraction -t:background is:paper -is:shockland"
+      count: 14
       rate: 2
     - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction -t:background -is:shockland"
+      count: 14
       rate: 4
     - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction -t:background -is:shockland"
+      count: 27
       rate: 6
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -t:attraction -t:background is:paper"
+      count: 8
       rate: 1
     - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction -t:background"
+      count: 8
       rate: 2
     - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart) -t:attraction -t:background"
+      count: 10
       rate: 3
   attraction:
     query: "t:attraction"

--- a/data/boosters/unh-draft.yaml
+++ b/data/boosters/unh-draft.yaml
@@ -17,8 +17,10 @@ sheets:
     foil: true
     any:
       - query: "r<=c"
+        count: 60
         chance: 12
       - query: "r:u"
+        count: 40
         chance: 5
       - query: "r>=r"
         count: 40 + 1 # 40 normal rares + 1 super secret tech

--- a/data/boosters/usg-tournament.yaml
+++ b/data/boosters/usg-tournament.yaml
@@ -13,6 +13,7 @@ sheets:
   common_with_duplicates:
     duplicates: true
     query: "r:c"
+    count: 110
   uncommon_with_duplicates:
     duplicates: true
     use: uncommon

--- a/data/boosters/vma-mtgo.yaml
+++ b/data/boosters/vma-mtgo.yaml
@@ -13,14 +13,19 @@ sheets:
     foil: true
     any:
     - query: "r<=c"
+      count: 101
       chance: 12
     - query: "r:u"
+      count: 80
       chance: 5
     - any:
       - query: "r:r"
+        count: 105
         rate: 4
       - query: "r:m"
+        count: 30
         rate: 2
       - query: "r:s"
+        count: 9
         rate: 1
       chance: 3

--- a/data/boosters/vow-collector.yaml
+++ b/data/boosters/vow-collector.yaml
@@ -38,6 +38,7 @@ sheets:
     use: rare_mythic
   uncommon_dracula:
     rawquery: "e:vow r:u promo:draculaseries"
+    count: 5
   foil_uncommon_dracula:
     foil: true
     use: uncommon_dracula

--- a/data/boosters/vow-draft.yaml
+++ b/data/boosters/vow-draft.yaml
@@ -33,39 +33,52 @@ sheets:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{common_boosterfun} is:sfc is:paper"
+      count: 7
       rate: 1
     - query: "r:c alt:{common_boosterfun} is:sfc"
+      count: 7
       rate: 2
     - query: "r:c -alt:{common_boosterfun} is:sfc"
+      count: 83
       rate: 3
   sfc_uncommon_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{uncommon_boosterfun} is:sfc is:paper"
+      count: 6
       rate: 1
     - query: "r:u alt:{uncommon_boosterfun} is:sfc"
+      count: 6
       rate: 2
     - query: "r:u -alt:{uncommon_boosterfun} is:sfc"
+      count: 54
       rate: 3
   sfc_rare_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{rare_boosterfun} is:sfc is:paper"
+      count: 19
       rate: 1
     - query: "r:r alt:{rare_boosterfun} is:sfc"
+      count: 19
       rate: 2
     - query: "r:r -alt:{rare_boosterfun} is:sfc"
+      count: 34
       rate: 3
   sfc_mythic_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{mythic_boosterfun} is:sfc is:paper t:sorin"
+      count: 2
       rate: 1
     - rawquery: "{mythic_boosterfun} is:sfc is:paper -t:sorin"
+      count: 5
       rate: 2
     - query: "r:m alt:{mythic_boosterfun} is:sfc"
+      count: 6
       rate: 4
     - query: "r:m -alt:{mythic_boosterfun} is:sfc"
+      count: 9
       rate: 6
   dfc_common_with_showcase:
     # Showcase treatments 1/3 for relevant cards
@@ -75,35 +88,46 @@ sheets:
     - query: "r:c alt:{common_boosterfun} is:dfc"
       rate: 2
     - query: "r:c -alt:{common_boosterfun} is:dfc"
+      count: 10
       rate: 3
   dfc_uncommon_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{uncommon_boosterfun} is:dfc is:paper"
+      count: 4
       rate: 1
     - query: "r:u alt:{uncommon_boosterfun} is:dfc"
+      count: 4
       rate: 2
     - query: "r:u -alt:{uncommon_boosterfun} is:dfc"
+      count: 19
       rate: 3
   dfc_rare_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{rare_boosterfun} is:dfc is:paper (Runo Stromkirk)"
+      count: 2
       rate: 1
     - rawquery: "{rare_boosterfun} is:dfc is:paper -(Runo Stromkirk)"
+      count: 4
       rate: 2
     - query: "r:r alt:{rare_boosterfun} is:dfc"
+      count: 5
       rate: 4
     - query: "r:r -alt:{rare_boosterfun} is:dfc"
+      count: 6
       rate: 6
   dfc_mythic_with_showcase:
     # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "{mythic_boosterfun} is:dfc is:paper"
+      count: 2
       rate: 1
     - query: "r:m alt:{mythic_boosterfun} is:dfc"
+      count: 2
       rate: 2
     - query: "r:m -alt:{mythic_boosterfun} is:dfc"
+      count: 3
       rate: 3
   sfc_rare_mythic_with_showcase:
     any:

--- a/data/boosters/vow-set.yaml
+++ b/data/boosters/vow-set.yaml
@@ -20,11 +20,14 @@ pack:
 sheets:
   sfc_common:
     query: "r:c is:sfc"
+    count: 90
   showcase_common_uncommon:
     any:
     - rawquery: "e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+      count: 7
       rate: 2
     - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+      count: 10
       rate: 1
     - use: dfc_common
       rate: 2
@@ -39,18 +42,24 @@ sheets:
     - any:
       - any:
         - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+          count: 25
           rate: 1
         - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+          count: 24
           rate: 2
         - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+          count: 40
           rate: 3
         chance: 64*2
       - any:
         - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+          count: 9
           rate: 1
         - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+          count: 8
           rate: 2
         - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+          count: 12
           rate: 3
         chance: 20
       # Only the 8 new-to-Commander cards designed for Set Boosters appear
@@ -59,8 +68,10 @@ sheets:
       # Commander-deck cards) are NOT in Set Boosters. Per-card weight kept
       # at rare 2 : mythic 1, matching the main-set R/M tier.
       - rawquery: "e:voc number:31-38 r:r"
+        count: 6
         chance: 6*2
       - rawquery: "e:voc number:31-38 r:m"
+        count: 2
         chance: 2
       chance: 125
   the_list:
@@ -75,33 +86,45 @@ sheets:
     any:
     - any:
       - rawquery: "e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+        count: 7
         rate: 1
       - query: "r:c alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 7
         rate: 2
       - query: "r:c -alt:(e:{set} r:c promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 93
         rate: 3
       - use: basic
         rate: 3
       chance: 12
     - any:
       - rawquery: "e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+        count: 10
         rate: 1
       - query: "r:u alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 10
         rate: 2
       - query: "r:u -alt:(e:{set} r:u promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 73
         rate: 3
       chance: 5
     - any:
       - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+        count: 25
         rate: 2
       - query: "r:r alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 24
         rate: 4
       - query: "r:r -alt:(e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 40
         rate: 6
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -promo:draculaseries"
+        count: 9
         rate: 1
       - query: "r:m alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 8
         rate: 2
       - query: "r:m -alt:(e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart -promo:draculaseries)"
+        count: 12
         rate: 3
       chance: 3

--- a/data/boosters/vow-theme-b.yaml
+++ b/data/boosters/vow-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 17
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/vow-theme-g.yaml
+++ b/data/boosters/vow-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 17
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/vow-theme-r.yaml
+++ b/data/boosters/vow-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 17
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/vow-theme-u.yaml
+++ b/data/boosters/vow-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 17
       rate: 1
     - query: "r:u -id:c"
+      count: 14
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/vow-theme-vampires.yaml
+++ b/data/boosters/vow-theme-vampires.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 28
       rate: 1
     - query: "r:c -id:c"
+      count: 24
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 24
       rate: 1
     - query: "r:u -id:c"
+      count: 21
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 15
       rate: 2
     - query: "r:r -id:c"
+      count: 12
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/vow-theme-w.yaml
+++ b/data/boosters/vow-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 24
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 16
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 4
       rate: 3

--- a/data/boosters/war-jp.yaml
+++ b/data/boosters/war-jp.yaml
@@ -57,20 +57,27 @@ sheets:
     foil: true
     any:
     - query: "r<=c"
+      count: 116
       chance: 12
     - any:
       - query: "r:u -t:planeswalker"
+        count: 60
         rate: 2
       - query: "r:u t:planeswalker"
+        count: 40
         rate: 1
       chance: 5
     - any:
       - query: "r:r -t:planeswalker"
+        count: 40
         rate: 4
       - query: "r:r t:planeswalker"
+        count: 26
         rate: 2
       - query: "r:m -t:planeswalker"
+        count: 12
         rate: 2
       - query: "r:m t:planeswalker"
+        count: 6
         rate: 1
       chance: 3

--- a/data/boosters/war-theme-b.yaml
+++ b/data/boosters/war-theme-b.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 6
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/war-theme-g.yaml
+++ b/data/boosters/war-theme-g.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 10
       rate: 2
     - query: "r:r -id:c"
+      count: 5
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/war-theme-r.yaml
+++ b/data/boosters/war-theme-r.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 6
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/war-theme-u.yaml
+++ b/data/boosters/war-theme-u.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 11
       rate: 2
     - query: "r:r -id:c"
+      count: 6
       rate: 6
     - query: "r:m"
+      count: 2
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3

--- a/data/boosters/war-theme-w.yaml
+++ b/data/boosters/war-theme-w.yaml
@@ -21,23 +21,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 10
       rate: 2
     - query: "r:r -id:c"
+      count: 5
       rate: 6
     - query: "r:m"
+      count: 3
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/who-collector.yaml
+++ b/data/boosters/who-collector.yaml
@@ -114,6 +114,7 @@ sheets:
   serialized:
     foil: true
     rawquery: "e:who number:/z/"
+    count: 13
   land:
     foil: true
     any:

--- a/data/boosters/woe-collector-sample.yaml
+++ b/data/boosters/woe-collector-sample.yaml
@@ -10,60 +10,81 @@ sheets:
   foil_enchanting_tales_uncommon:
     foil: true
     rawquery: "e:wot r:u number<=63"
+    count: 18
   alt_frame_foil:
     foil: true
     any:
     - use: rare_showcase
       rate: 12
     - rawquery: "(e:woe or e:woc) r:r frame:extendedart"
+      count: 46
       rate: 12
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+      count: 25
       rate: 12
     - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+      count: 5
       rate: 8
     - rawquery: "e:wot r:r number:64-83"
+      count: 5
       rate: 4
     - rawquery: "e:wot r:r number:84-103"
+      count: 5
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+      count: 2
       rate: 3
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+      count: 11
       rate: 6
     - rawquery: "(e:woe or e:woc) r:m frame:extendedart -number:381"
+      count: 14
       rate: 6
     - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
       rate: 6
     - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+      count: 15
       rate: 4
     - rawquery: "e:wot r:m number:64-83"
+      count: 15
       rate: 2
     - rawquery: "e:wot r:m number:84-103"
+      count: 15
       rate: 2
   alt_frame:
     any:
     - use: rare_showcase
       rate: 12
     - rawquery: "(e:woe or e:woc) r:r frame:extendedart"
+      count: 66
       rate: 12
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+      count: 25
       rate: 12
     - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+      count: 5
       rate: 8
     - rawquery: "e:wot r:r number:64-83"
+      count: 5
       rate: 4
     - rawquery: "e:wot r:r number:84-103"
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+      count: 2
       rate: 3
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+      count: 11
       rate: 6
     - rawquery: "(e:woe or e:woc) r:m frame:extendedart"
+      count: 14
       rate: 6
     - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
       rate: 6
     - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+      count: 15
       rate: 4
     - rawquery: "e:wot r:m number:64-83"
+      count: 15
       rate: 2
     - rawquery: "e:wot r:m number:84-103"
       rate: 2

--- a/data/boosters/woe-collector.yaml
+++ b/data/boosters/woe-collector.yaml
@@ -18,11 +18,14 @@ sheets:
   foil_full_art_land:
     foil: true
     query: "r:b number:262-266"
+    count: 5
   enchanting_tales_uncommon:
     rawquery: "e:wot r:u number<=63"
+    count: 18
   foil_enchanting_tales_uncommon:
     foil: true
     rawquery: "e:wot r:u number<=63"
+    count: 18
   foil_rare_mythic:
     foil: true
     use: rare_mythic
@@ -40,16 +43,21 @@ sheets:
   enchanting_tales_rare_mythic:
     any:
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+      count: 25
       rate: 8
     - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+      count: 5
       rate: 6
     - rawquery: "e:wot r:r number:64-83"
+      count: 5
       rate: 2
     - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
       rate: 4
     - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+      count: 15
       rate: 3
     - rawquery: "e:wot r:m number:64-83"
+      count: 15
       rate: 1
   alt_frame_foil:
     foil: true
@@ -61,35 +69,48 @@ sheets:
       - use: rare_showcase
         rate: 12
       - rawquery: "(e:woe or e:woc) r:r frame:extendedart"
+        count: 46
         rate: 12
       - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+        count: 25
         rate: 12
       - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+        count: 5
         rate: 8
       - rawquery: "e:wot r:r number:64-83"
+        count: 5
         rate: 4
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+        count: 2
         rate: 3
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+        count: 11
         rate: 6
       - rawquery: "(e:woe or e:woc) r:m frame:extendedart"
+        count: 14
         rate: 6
       - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
         rate: 6
       - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+        count: 15
         rate: 4
       - rawquery: "e:wot r:m number:64-83"
+        count: 15
         rate: 2
       chance: 972
     - rawquery: "e:wot r:r number:84-103"
+      count: 5
       chance: 11
     - rawquery: "e:wot r:m number:84-103"
+      count: 15
       chance: 17
   rare_mythic_showcase:
     any:
     - use: rare_showcase
       rate: 4
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+      count: 2
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+      count: 11
       rate: 2

--- a/data/boosters/woe-draft.yaml
+++ b/data/boosters/woe-draft.yaml
@@ -14,25 +14,33 @@ sheets:
   enchanting_tales:
     any:
     - rawquery: "e:wot r:u number<64"
+      count: 18
       rate: 16
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+      count: 25
       rate: 8
     - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+      count: 5
       rate: 6
     - rawquery: "e:wot r:r number:64-83"
+      count: 5
       rate: 2
     - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
       rate: 4
     - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+      count: 15
       rate: 3
     - rawquery: "e:wot r:m number:64-83"
+      count: 15
       rate: 1
   mythic_with_showcase:
   # Showcase treatments 1/3 for relevant cards
     any:
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+      count: 2
       rate: 1
     - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+      count: 11
       rate: 2
     - use: mythic_has_showcase
       rate: 4
@@ -65,6 +73,7 @@ sheets:
       - use: uncommon_has_no_showcase
         rate: 3
       - rawquery: "e:wot r:u number<64"
+        count: 18
         rate: 3
       chance: 5
     - any:
@@ -75,20 +84,27 @@ sheets:
       - use: rare_has_no_showcase
         rate: 24
       - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+        count: 25
         rate: 24
       - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+        count: 5
         rate: 18
       - rawquery: "e:wot r:r number:64-83"
+        count: 5
         rate: 6
       - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
         rate: 12
       - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+        count: 15
         rate: 9
       - rawquery: "e:wot r:m number:64-83"
+        count: 15
         rate: 3
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+        count: 2
         rate: 2
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+        count: 11
         rate: 4
       - use: mythic_has_showcase
         rate: 8

--- a/data/boosters/woe-set.yaml
+++ b/data/boosters/woe-set.yaml
@@ -19,6 +19,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   wildcard:
     any:
     - use: common
@@ -27,8 +28,10 @@ sheets:
       - use: uncommon
         rate: 1
       - rawquery: "e:wot r:u -is:foilonly"
+        count: 18
         rate: 1
       - rawquery: "e:woe r:u number:308-322"
+        count: 10
         rate: 1
       chance: 175
     - any:
@@ -42,16 +45,21 @@ sheets:
         count: 22
       - any:
         - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+          count: 25
           rate: 6
         - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+          count: 5
           rate: 4
         - rawquery: "e:wot r:r number:64-83"
+          count: 5
           rate: 2
         chance: 2 * 30
       - any:
         - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+          count: 2
           rate: 1
         - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+          count: 11
           rate: 2
         - use: mythic_has_showcase
           rate: 4
@@ -65,26 +73,34 @@ sheets:
         - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
           rate: 3
         - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+          count: 15
           rate: 2
         - rawquery: "e:wot r:m number:64-83"
+          count: 15
           rate: 1
         chance: 15
       chance: 125
   enchanting_tales:
     any:
     - rawquery: "e:wot r:u number<64"
+      count: 18
       rate: 16
     - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+      count: 25
       rate: 8
     - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+      count: 5
       rate: 6
     - rawquery: "e:wot r:r number:64-83"
+      count: 5
       rate: 2
     - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
       rate: 4
     - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+      count: 15
       rate: 3
     - rawquery: "e:wot r:m number:64-83"
+      count: 15
       rate: 1
   the_list:
     any:
@@ -120,6 +136,7 @@ sheets:
       - use: uncommon_has_no_showcase
         rate: 3
       - rawquery: "e:wot r:u number<64"
+        count: 18
         rate: 3
       chance: 5
     - any:
@@ -133,20 +150,27 @@ sheets:
       - use: rare_has_no_showcase
         rate: 24
       - rawquery: "e:wot r:r -alt:(e:wot number:64-83) number<64"
+        count: 25
         rate: 24
       - rawquery: "e:wot r:r alt:(e:wot number:64-83) number<64"
+        count: 5
         rate: 18
       - rawquery: "e:wot r:r number:64-83"
+        count: 5
         rate: 6
       - rawquery: "e:wot r:m -alt:(e:wot number:64-83) number<64"
         rate: 12
       - rawquery: "e:wot r:m alt:(e:wot number:64-83) number<64"
+        count: 15
         rate: 9
       - rawquery: "e:wot r:m number:64-83"
+        count: 15
         rate: 3
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Kellan)"
+        count: 2
         rate: 2
       - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Kellan or Birthright)"
+        count: 11
         rate: 4
       - use: mythic_has_showcase
         rate: 8

--- a/data/boosters/wwk-draft.yaml
+++ b/data/boosters/wwk-draft.yaml
@@ -14,3 +14,4 @@ sheets:
   basic:
     # borrowed basics
     rawquery: "e:zen r:b -number:/a/"
+    count: 20

--- a/data/boosters/wwk-six.yaml
+++ b/data/boosters/wwk-six.yaml
@@ -13,5 +13,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 60
   basic:
     rawquery: "e:zen t:basic -number:/a/"
+    count: 20

--- a/data/boosters/xln-treasure-chest.yaml
+++ b/data/boosters/xln-treasure-chest.yaml
@@ -10,6 +10,8 @@ sheets:
   promo_transform_land:
     foil: true
     rawquery: "e:pxtc"
+    count: 10
   foil_basic:
     foil: true
     rawquery: "e:pss2"
+    count: 5

--- a/data/boosters/zen-six.yaml
+++ b/data/boosters/zen-six.yaml
@@ -14,3 +14,4 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101

--- a/data/boosters/znr-set.yaml
+++ b/data/boosters/znr-set.yaml
@@ -35,6 +35,7 @@ pack:
 sheets:
   common:
     query: "r:c"
+    count: 101
   wildcard:
     any:
     - use: common

--- a/data/boosters/znr-theme-b.yaml
+++ b/data/boosters/znr-theme-b.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/znr-theme-g.yaml
+++ b/data/boosters/znr-theme-g.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 12
       rate: 2
     - query: "r:r -id:c"
+      count: 8
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/znr-theme-party.yaml
+++ b/data/boosters/znr-theme-party.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 43
       rate: 1
     - query: "r:c -id:c"
+      count: 41
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 41
       rate: 1
     - query: "r:u -id:c"
+      count: 37
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 24
       rate: 2
     - query: "r:r -id:c"
+      count: 24
       rate: 6
     - query: "r:m"
+      count: 7
       rate: 1
     - query: "r:m -id:c"
+      count: 7
       rate: 3

--- a/data/boosters/znr-theme-r.yaml
+++ b/data/boosters/znr-theme-r.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/znr-theme-u.yaml
+++ b/data/boosters/znr-theme-u.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 5
       rate: 1
     - query: "r:m -id:c"
+      count: 3
       rate: 3

--- a/data/boosters/znr-theme-w.yaml
+++ b/data/boosters/znr-theme-w.yaml
@@ -26,23 +26,31 @@ sheets:
     duplicates: true
     any:
     - query: "r:c"
+      count: 25
       rate: 1
     - query: "r:c -id:c"
+      count: 19
       rate: 3
   uncommon:
     duplicates: true
     any:
     - query: "r:u"
+      count: 18
       rate: 1
     - query: "r:u -id:c"
+      count: 13
       rate: 3
   rare_mythic:
     any:
     - query: "r:r"
+      count: 13
       rate: 2
     - query: "r:r -id:c"
+      count: 9
       rate: 6
     - query: "r:m"
+      count: 4
       rate: 1
     - query: "r:m -id:c"
+      count: 2
       rate: 3


### PR DESCRIPTION
Pins the pool size of every non-empty `query`/`rawquery` sheet with a `count:` assertion, so the build warns if a data update unexpectedly changes what a slot draws from. **2122 counts added across 342 booster files.**

### How the values were derived
Each `count:` is the engine's own pool size for that leaf — exactly what `CardSheetFactory#find_cards` computes: `is:front` + `is:foil`/`is:nonfoil` + the fully-resolved query (superfilter + filter + `{...}` substitutions, mirroring the booster indexer), deduped to `PhysicalCard`s.

### Verification
Regenerated `booster_index.json` from the updated sources and built **every** booster (`PackFactory#for` over all booster types), capturing `find_cards`/sheet warnings: **TOTAL WARNINGS: 0**. Every added count matches the current pool exactly. All 592 booster YAMLs parse.

### Deliberately not counted
- **Empty pools** — the repo never uses `count: 0`, and empty foil/mythic subsheets are expected (`find_cards` "can legitimately return 0 results").
- **`common.yaml`** — shared, `{set}`-templated sheets, so no single static count applies.
- **LTR `with_showcase`** — two queries reused via `use:` under four different rarity `filter:`s (and both foil/non-foil); no single static count is valid.

Only inserts `count:` lines next to existing queries; comments/structure preserved.