### PR TITLE
TMT: add Bundle promo pack referenced by sealed-content

### DIFF
--- a/data/boosters/tmt-bundle-promo.yaml
+++ b/data/boosters/tmt-bundle-promo.yaml
@@ -1,0 +1,7 @@
+name: "{set_name} Bundle Promo Card"
+pack:
+  bundle_promo: 1
+sheets:
+  bundle_promo:
+    foil: true
+    rawquery: "e:tmt promo:bundle"


### PR DESCRIPTION
The Teenage Mutant Ninja Turtles Bundle references pack `tmt-bundle-promo`, which didn't exist. Add it: a single traditional-foil Bundle promo card (`e:tmt promo:bundle` → Shark Shredder, Killer Clone). Verified it builds to a 1-card pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)