### PR TITLE
SPM: add Gift Bundle promo pack referenced by sealed-content

### DIFF
--- a/data/boosters/spm-bundle-promo.yaml
+++ b/data/boosters/spm-bundle-promo.yaml
@@ -1,0 +1,10 @@
+name: "{set_name} Bundle Promo Card"
+# Only the Gift Bundle references this pack; its promo is the mythic
+# (Gwenom, Remorseless). The regular Bundle's rare promo (Radioactive Spider)
+# is fixed content on that product, not this slot.
+pack:
+  bundle_promo: 1
+sheets:
+  bundle_promo:
+    foil: true
+    rawquery: "e:spm promo:bundle r:m"


### PR DESCRIPTION
The Marvel's Spider-Man Gift Bundle references pack `spm-bundle-promo`, which didn't exist. Its promo is the mythic (Gwenom, Remorseless); the regular Bundle's rare promo (Radioactive Spider) is fixed content on that product, not this slot. Scope the pool to `e:spm promo:bundle r:m`. Verified it builds to a 1-card pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)