### PR TITLE
ECL: add Bundle promo pack referenced by sealed-content

### DIFF
--- a/data/boosters/ecl-bundle-promo.yaml
+++ b/data/boosters/ecl-bundle-promo.yaml
@@ -1,0 +1,7 @@
+name: "{set_name} Bundle Promo Card"
+pack:
+  bundle_promo: 1
+sheets:
+  bundle_promo:
+    foil: true
+    rawquery: "e:ecl promo:bundle"


### PR DESCRIPTION
The Lorwyn Eclipsed Bundle references pack `ecl-bundle-promo`, which didn't exist. Add it: a single traditional-foil Bundle promo card (`e:ecl promo:bundle` → Kinbinding). Verified it builds to a 1-card pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)