### PR TITLE
EOE: add Bundle promo pack referenced by sealed-content

### DIFF
--- a/data/boosters/eoe-bundle-promo.yaml
+++ b/data/boosters/eoe-bundle-promo.yaml
@@ -1,0 +1,7 @@
+name: "{set_name} Bundle Promo Card"
+pack:
+  bundle_promo: 1
+sheets:
+  bundle_promo:
+    foil: true
+    rawquery: "e:eoe promo:bundle"


### PR DESCRIPTION
The Edge of Eternities Bundle references pack `eoe-bundle-promo`, which didn't exist. Add it: a single traditional-foil Bundle promo card (`e:eoe promo:bundle` → Emissary Escort). Verified it builds to a 1-card pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)