### PR TITLE
SOS: add Bundle promo pack referenced by sealed-content

### DIFF
--- a/data/boosters/sos-bundle-promo.yaml
+++ b/data/boosters/sos-bundle-promo.yaml
@@ -1,0 +1,7 @@
+name: "{set_name} Bundle Promo Card"
+pack:
+  bundle_promo: 1
+sheets:
+  bundle_promo:
+    foil: true
+    rawquery: "e:sos promo:bundle"


### PR DESCRIPTION
The Secrets of Strixhaven Bundle references pack `sos-bundle-promo`, which didn't exist. Add it: a single traditional-foil Bundle promo card (`e:sos promo:bundle` → Wisdom of Ages). Verified it builds to a 1-card pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)