### PR TITLE
RNA: add experimental Collector Booster (15 cards)

### DIFF
--- a/data/boosters/rna-collector.yaml
+++ b/data/boosters/rna-collector.yaml
@@ -1,24 +1,13 @@
 # Experimental Ravnica Allegiance Collector Booster -- a very limited 2019 test
 # run (Japan and North America only), before Collector Boosters became a regular
-# feature with Throne of Eldraine. 15 cards: 10 uncommons, 3 rares/mythics, and
-# 2 foils of any rarity. RNA predates showcase/borderless frames, so plain sheets.
+# feature with Throne of Eldraine. 15 cards: 10 uncommons, 3 rares/mythics
+# (mythic ~1:8 in that slot, which the default rare_mythic weighting already
+# gives for RNA), and 2 foils of any rarity. RNA predates showcase/borderless
+# frames and no special foil odds are documented, so the two foils simply reuse
+# the standard any-rarity foil sheet (the same one the RNA draft booster uses).
 # Sources: https://mtg.wiki/page/Ravnica_Allegiance
 #          https://mtg.fandom.com/wiki/Collector_Booster
 pack:
   uncommon: 10
   rare_mythic: 3
-  foil_any: 2
-sheets:
-  foil_any:
-    # "Any rarity" -> each card equally likely, so rarity frequency tracks pool
-    # size (equal rate per rarity => weight = rate x pool_size).
-    foil: true
-    any:
-    - query: "r:c"
-      rate: 1
-    - query: "r:u"
-      rate: 1
-    - query: "r:r"
-      rate: 1
-    - query: "r:m"
-      rate: 1
+  foil: 2

--- a/data/boosters/rna-collector.yaml
+++ b/data/boosters/rna-collector.yaml
@@ -1,0 +1,24 @@
+# Experimental Ravnica Allegiance Collector Booster -- a very limited 2019 test
+# run (Japan and North America only), before Collector Boosters became a regular
+# feature with Throne of Eldraine. 15 cards: 10 uncommons, 3 rares/mythics, and
+# 2 foils of any rarity. RNA predates showcase/borderless frames, so plain sheets.
+# Sources: https://mtg.wiki/page/Ravnica_Allegiance
+#          https://mtg.fandom.com/wiki/Collector_Booster
+pack:
+  uncommon: 10
+  rare_mythic: 3
+  foil_any: 2
+sheets:
+  foil_any:
+    # "Any rarity" -> each card equally likely, so rarity frequency tracks pool
+    # size (equal rate per rarity => weight = rate x pool_size).
+    foil: true
+    any:
+    - query: "r:c"
+      rate: 1
+    - query: "r:u"
+      rate: 1
+    - query: "r:r"
+      rate: 1
+    - query: "r:m"
+      rate: 1


### PR DESCRIPTION
The Ravnica Allegiance Collector Booster Pack references pack `rna-collector`, which didn't exist. RNA had the **experimental** first Collector Booster — a very limited 2019 test run (Japan/North America only), before Collector Boosters became a regular feature with Throne of Eldraine.

**Contents (15 cards):** 10 uncommons, 3 rares/mythics, 2 foils of *any rarity*.

- The **rare/mythic** slot uses the default `rare_mythic` sheet (2:1 rare:mythic weighted by pool), which yields mythic ≈ 1:8 for RNA — matching the documented "Mythic Rare 1:8 in Rare/Mythic Rare slot."
- The **2 foils** are plain any-rarity foils. No special odds are documented for this experimental product, so they reuse the standard `foil` sheet (the same one the RNA draft booster uses): ~60% C / 25% U / 10% R / 5% M. (An earlier revision used a custom equal-per-rarity sheet that over-weighted rares at 20%; corrected.)

RNA predates showcase/borderless frames, so no special treatments. Verified via the regenerated booster index that it builds to a 15-card pack (10 + 3 + 2) with the foil slot resolving to the standard any-rarity foil sheet.

Sources: [mtg.wiki](https://mtg.wiki/page/Ravnica_Allegiance), [mtg.fandom Collector Booster](https://mtg.fandom.com/wiki/Collector_Booster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)