### PR TITLE
Revert "TMT: add Bundle promo pack referenced by sealed-content"

### DIFF
--- a/data/boosters/tmt-bundle-promo.yaml
+++ b/data/boosters/tmt-bundle-promo.yaml
@@ -1,7 +1,0 @@
-name: "{set_name} Bundle Promo Card"
-pack:
-  bundle_promo: 1
-sheets:
-  bundle_promo:
-    foil: true
-    rawquery: "e:tmt promo:bundle"


### PR DESCRIPTION
Reverts taw/magic-search-engine#497

we don't need single-card boosters