### PR TITLE
Remove single-card bundle-promo boosters (represented as fixed cards instead)

### DIFF
--- a/data/boosters/lci-bundle-promo.yaml
+++ b/data/boosters/lci-bundle-promo.yaml
@@ -1,6 +1,0 @@
-name: "{set_name} Bundle Promo Card"
-pack:
-  bundle_promo: 1
-sheets:
-  bundle_promo:
-    rawquery: "e:rex -t:basic is:nonfoil -is:reversibleback"

--- a/data/boosters/lci-gift-bundle-promo.yaml
+++ b/data/boosters/lci-gift-bundle-promo.yaml
@@ -1,7 +1,0 @@
-name: "{set_name} Gift Bundle Promo Card"
-pack:
-  bundle_promo: 1
-sheets:
-  bundle_promo:
-    foil: true
-    rawquery: "e:rex -t:basic is:foil -is:embossed -is:reversibleback"


### PR DESCRIPTION
Bundle "promo packs" whose entire content is a single fixed foil card are better represented as a `card` entry on the product in mtg-sealed-content than as a single-card booster here. Companion PR mtgjson/mtg-sealed-content#446 lists those cards directly and drops the `bundle-promo` pack references (ECL/EOE/SOS/SPM/TMT/LCI).

This removes the now-redundant LCI boosters:
- `data/boosters/lci-bundle-promo.yaml`
- `data/boosters/lci-gift-bundle-promo.yaml`

(Both wrongly drew from the `rex` promo set anyway; the real bundle promo is `Hit the Mother Lode`, lci/404.)

**Kept:** `fin-bundle-promo.yaml` — the Final Fantasy bundle promo is *2 random* foil legendary creatures (a genuine multi-card random pack), which a fixed card list can't represent.

**Ordering:** merge mtgjson/mtg-sealed-content#446 first so LCI products don't briefly reference a removed pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)