### PR TITLE
Add DSK Nightmare Bundle and SOS Codex boosters

### DIFF
--- a/data/boosters/dsk-nightmare.yaml
+++ b/data/boosters/dsk-nightmare.yaml
@@ -1,0 +1,17 @@
+# Duskmourn: House of Horror Nightmare Bundle Booster (2 cards).
+# From the Nightmare Bundle: 1 borderless alt-art reprint (Crypt Ghast, Damn,
+# or Exhume) + 1 "Movie Poster" card (Archon of Cruelty, Goryo's Vengeance, or
+# Living Death). All are traditional foil, in the Duskmourn Commander set (dsc).
+# Source: https://magic.wizards.com/en/news/feature/collecting-duskmourn
+#         + Nightmare Bundle product listings (cardgamebase.com, Amazon).
+name: "{set_name} Nightmare Bundle Booster"
+pack:
+  borderless: 1
+  movie_poster: 1
+sheets:
+  borderless:
+    foil: true
+    rawquery: "e:dsc promo:bundle -promo:poster"
+  movie_poster:
+    foil: true
+    rawquery: "e:dsc promo:poster"

--- a/data/boosters/sos-codex-bundle.yaml
+++ b/data/boosters/sos-codex-bundle.yaml
@@ -1,0 +1,12 @@
+# Secrets of Strixhaven Codex Booster (in the Codex Bundle), 2 cards.
+# Contains 2 of 6 alternate-art traditional-foil artifacts: Sol Ring plus the
+# five college Talismans, in the Secrets of Strixhaven Commander set (soc/427-432).
+# Source: https://magic.wizards.com/en/news/feature/collecting-secrets-of-strixhaven
+#         + Codex Bundle product listings (Amazon, thegamer.com).
+name: "{set_name} Codex Booster"
+pack:
+  codex_artifact: 2
+sheets:
+  codex_artifact:
+    foil: true
+    rawquery: "e:soc number:427-432"


### PR DESCRIPTION
Two special 2-card boosters referenced by mtg-sealed-content but not yet defined:

**`dsk-nightmare`** — Duskmourn: House of Horror **Nightmare Bundle Booster**. Per the Nightmare Bundle contents: 1 borderless alt-art reprint (**Crypt Ghast / Damn / Exhume**, `dsc/368–370`) + 1 "Movie Poster" card (**Archon of Cruelty / Goryo's Vengeance / Living Death**, `dsc/371–373`) — all traditional foil.

**`sos-codex-bundle`** — Secrets of Strixhaven **Codex Booster**. 2 of 6 alternate-art foil artifacts: **Sol Ring + the five college Talismans** (`soc/427–432`).

Both verified against the rebuilt index to build to exactly 2-card packs with the correct pools. Sources: the sets' collecting articles plus the Nightmare/Codex Bundle product listings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)