### PR TITLE
Add ECL and SOS prerelease boosters

### DIFF
--- a/data/boosters/ecl-prerelease.yaml
+++ b/data/boosters/ecl-prerelease.yaml
@@ -7,9 +7,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:ecl number:1-268 r:r"
+    - rawquery: "e:ecl r:r is:baseset"
       rate: 2
       count: 65
-    - rawquery: "e:ecl number:1-268 r:m"
+    - rawquery: "e:ecl r:m is:baseset"
       rate: 1
       count: 22

--- a/data/boosters/ecl-prerelease.yaml
+++ b/data/boosters/ecl-prerelease.yaml
@@ -9,5 +9,7 @@ sheets:
     any:
     - rawquery: "e:ecl number:1-268 r:r"
       rate: 2
+      count: 65
     - rawquery: "e:ecl number:1-268 r:m"
       rate: 1
+      count: 22

--- a/data/boosters/ecl-prerelease.yaml
+++ b/data/boosters/ecl-prerelease.yaml
@@ -1,0 +1,13 @@
+# Lorwyn Eclipsed Prerelease Pack promo: 1 traditional-foil rare or mythic from
+# the base set (usual play-booster rare:mythic rate). ECL has no dedicated
+# stamped prerelease promo, so this is a normal base-set rare/mythic in foil.
+pack:
+  promo: 1
+sheets:
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:ecl number:1-268 r:r"
+      rate: 2
+    - rawquery: "e:ecl number:1-268 r:m"
+      rate: 1

--- a/data/boosters/sos-prerelease-lorehold.yaml
+++ b/data/boosters/sos-prerelease-lorehold.yaml
@@ -1,0 +1,33 @@
+# Secrets of Strixhaven seeded prerelease pack -- Lorehold (Red-White).
+# The seeded pile is a plain non-foil pile of the college's colors (id<=rw):
+# 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards).
+# Plus 1 traditional-foil rare/mythic promo from the base set = 15 cards total.
+pack:
+  common: 9
+  uncommon: 4
+  rare_mythic: 1
+  promo: 1
+queries:
+  college: "id<=rw"
+sheets:
+  common:
+    query: "r:c {college}"
+  uncommon:
+    query: "r:u {college}"
+  rare:
+    rawquery: "e:sos r:r number<=254 {college}"
+  mythic:
+    rawquery: "e:sos r:m number<=254 {college}"
+  rare_mythic:
+    any:
+    - use: rare
+      rate: 2
+    - use: mythic
+      rate: 1
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:sos r:r number<=254"
+      rate: 2
+    - rawquery: "e:sos r:m number<=254"
+      rate: 1

--- a/data/boosters/sos-prerelease-lorehold.yaml
+++ b/data/boosters/sos-prerelease-lorehold.yaml
@@ -7,17 +7,19 @@ pack:
   uncommon: 4
   rare_mythic: 1
   promo: 1
-queries:
-  college: "id<=rw"
 sheets:
   common:
-    query: "r:c {college}"
+    query: "r:c id<=rw"
+    count: 34
   uncommon:
-    query: "r:u {college}"
+    query: "r:u id<=rw"
+    count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 {college}"
+    rawquery: "e:sos r:r number<=254 id<=rw"
+    count: 17
   mythic:
-    rawquery: "e:sos r:m number<=254 {college}"
+    rawquery: "e:sos r:m number<=254 id<=rw"
+    count: 6
   rare_mythic:
     any:
     - use: rare
@@ -29,5 +31,7 @@ sheets:
     any:
     - rawquery: "e:sos r:r number<=254"
       rate: 2
+      count: 55
     - rawquery: "e:sos r:m number<=254"
       rate: 1
+      count: 20

--- a/data/boosters/sos-prerelease-lorehold.yaml
+++ b/data/boosters/sos-prerelease-lorehold.yaml
@@ -9,16 +9,16 @@ pack:
   promo: 1
 sheets:
   common:
-    query: "r:c id<=rw"
+    query: "r:c is:baseset id<=rw"
     count: 34
   uncommon:
-    query: "r:u id<=rw"
+    query: "r:u is:baseset id<=rw"
     count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 id<=rw"
-    count: 17
+    rawquery: "e:sos r:r is:baseset id<=rw"
+    count: 20
   mythic:
-    rawquery: "e:sos r:m number<=254 id<=rw"
+    rawquery: "e:sos r:m is:baseset id<=rw"
     count: 6
   rare_mythic:
     any:
@@ -29,9 +29,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:sos r:r number<=254"
+    - rawquery: "e:sos r:r is:baseset"
       rate: 2
-      count: 55
-    - rawquery: "e:sos r:m number<=254"
+      count: 60
+    - rawquery: "e:sos r:m is:baseset"
       rate: 1
       count: 20

--- a/data/boosters/sos-prerelease-prismari.yaml
+++ b/data/boosters/sos-prerelease-prismari.yaml
@@ -7,17 +7,19 @@ pack:
   uncommon: 4
   rare_mythic: 1
   promo: 1
-queries:
-  college: "id<=ur"
 sheets:
   common:
-    query: "r:c {college}"
+    query: "r:c id<=ur"
+    count: 34
   uncommon:
-    query: "r:u {college}"
+    query: "r:u id<=ur"
+    count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 {college}"
+    rawquery: "e:sos r:r number<=254 id<=ur"
+    count: 19
   mythic:
-    rawquery: "e:sos r:m number<=254 {college}"
+    rawquery: "e:sos r:m number<=254 id<=ur"
+    count: 7
   rare_mythic:
     any:
     - use: rare
@@ -29,5 +31,7 @@ sheets:
     any:
     - rawquery: "e:sos r:r number<=254"
       rate: 2
+      count: 55
     - rawquery: "e:sos r:m number<=254"
       rate: 1
+      count: 20

--- a/data/boosters/sos-prerelease-prismari.yaml
+++ b/data/boosters/sos-prerelease-prismari.yaml
@@ -1,0 +1,33 @@
+# Secrets of Strixhaven seeded prerelease pack -- Prismari (Blue-Red).
+# The seeded pile is a plain non-foil pile of the college's colors (id<=ur):
+# 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards).
+# Plus 1 traditional-foil rare/mythic promo from the base set = 15 cards total.
+pack:
+  common: 9
+  uncommon: 4
+  rare_mythic: 1
+  promo: 1
+queries:
+  college: "id<=ur"
+sheets:
+  common:
+    query: "r:c {college}"
+  uncommon:
+    query: "r:u {college}"
+  rare:
+    rawquery: "e:sos r:r number<=254 {college}"
+  mythic:
+    rawquery: "e:sos r:m number<=254 {college}"
+  rare_mythic:
+    any:
+    - use: rare
+      rate: 2
+    - use: mythic
+      rate: 1
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:sos r:r number<=254"
+      rate: 2
+    - rawquery: "e:sos r:m number<=254"
+      rate: 1

--- a/data/boosters/sos-prerelease-prismari.yaml
+++ b/data/boosters/sos-prerelease-prismari.yaml
@@ -9,16 +9,16 @@ pack:
   promo: 1
 sheets:
   common:
-    query: "r:c id<=ur"
+    query: "r:c is:baseset id<=ur"
     count: 34
   uncommon:
-    query: "r:u id<=ur"
+    query: "r:u is:baseset id<=ur"
     count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 id<=ur"
-    count: 19
+    rawquery: "e:sos r:r is:baseset id<=ur"
+    count: 22
   mythic:
-    rawquery: "e:sos r:m number<=254 id<=ur"
+    rawquery: "e:sos r:m is:baseset id<=ur"
     count: 7
   rare_mythic:
     any:
@@ -29,9 +29,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:sos r:r number<=254"
+    - rawquery: "e:sos r:r is:baseset"
       rate: 2
-      count: 55
-    - rawquery: "e:sos r:m number<=254"
+      count: 60
+    - rawquery: "e:sos r:m is:baseset"
       rate: 1
       count: 20

--- a/data/boosters/sos-prerelease-quandrix.yaml
+++ b/data/boosters/sos-prerelease-quandrix.yaml
@@ -7,17 +7,19 @@ pack:
   uncommon: 4
   rare_mythic: 1
   promo: 1
-queries:
-  college: "id<=gu"
 sheets:
   common:
-    query: "r:c {college}"
+    query: "r:c id<=gu"
+    count: 34
   uncommon:
-    query: "r:u {college}"
+    query: "r:u id<=gu"
+    count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 {college}"
+    rawquery: "e:sos r:r number<=254 id<=gu"
+    count: 19
   mythic:
-    rawquery: "e:sos r:m number<=254 {college}"
+    rawquery: "e:sos r:m number<=254 id<=gu"
+    count: 7
   rare_mythic:
     any:
     - use: rare
@@ -29,5 +31,7 @@ sheets:
     any:
     - rawquery: "e:sos r:r number<=254"
       rate: 2
+      count: 55
     - rawquery: "e:sos r:m number<=254"
       rate: 1
+      count: 20

--- a/data/boosters/sos-prerelease-quandrix.yaml
+++ b/data/boosters/sos-prerelease-quandrix.yaml
@@ -9,16 +9,16 @@ pack:
   promo: 1
 sheets:
   common:
-    query: "r:c id<=gu"
+    query: "r:c is:baseset id<=gu"
     count: 34
   uncommon:
-    query: "r:u id<=gu"
+    query: "r:u is:baseset id<=gu"
     count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 id<=gu"
-    count: 19
+    rawquery: "e:sos r:r is:baseset id<=gu"
+    count: 21
   mythic:
-    rawquery: "e:sos r:m number<=254 id<=gu"
+    rawquery: "e:sos r:m is:baseset id<=gu"
     count: 7
   rare_mythic:
     any:
@@ -29,9 +29,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:sos r:r number<=254"
+    - rawquery: "e:sos r:r is:baseset"
       rate: 2
-      count: 55
-    - rawquery: "e:sos r:m number<=254"
+      count: 60
+    - rawquery: "e:sos r:m is:baseset"
       rate: 1
       count: 20

--- a/data/boosters/sos-prerelease-quandrix.yaml
+++ b/data/boosters/sos-prerelease-quandrix.yaml
@@ -1,0 +1,33 @@
+# Secrets of Strixhaven seeded prerelease pack -- Quandrix (Green-Blue).
+# The seeded pile is a plain non-foil pile of the college's colors (id<=gu):
+# 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards).
+# Plus 1 traditional-foil rare/mythic promo from the base set = 15 cards total.
+pack:
+  common: 9
+  uncommon: 4
+  rare_mythic: 1
+  promo: 1
+queries:
+  college: "id<=gu"
+sheets:
+  common:
+    query: "r:c {college}"
+  uncommon:
+    query: "r:u {college}"
+  rare:
+    rawquery: "e:sos r:r number<=254 {college}"
+  mythic:
+    rawquery: "e:sos r:m number<=254 {college}"
+  rare_mythic:
+    any:
+    - use: rare
+      rate: 2
+    - use: mythic
+      rate: 1
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:sos r:r number<=254"
+      rate: 2
+    - rawquery: "e:sos r:m number<=254"
+      rate: 1

--- a/data/boosters/sos-prerelease-silverquill.yaml
+++ b/data/boosters/sos-prerelease-silverquill.yaml
@@ -9,16 +9,16 @@ pack:
   promo: 1
 sheets:
   common:
-    query: "r:c id<=wb"
+    query: "r:c is:baseset id<=wb"
     count: 34
   uncommon:
-    query: "r:u id<=wb"
+    query: "r:u is:baseset id<=wb"
     count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 id<=wb"
-    count: 17
+    rawquery: "e:sos r:r is:baseset id<=wb"
+    count: 20
   mythic:
-    rawquery: "e:sos r:m number<=254 id<=wb"
+    rawquery: "e:sos r:m is:baseset id<=wb"
     count: 8
   rare_mythic:
     any:
@@ -29,9 +29,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:sos r:r number<=254"
+    - rawquery: "e:sos r:r is:baseset"
       rate: 2
-      count: 55
-    - rawquery: "e:sos r:m number<=254"
+      count: 60
+    - rawquery: "e:sos r:m is:baseset"
       rate: 1
       count: 20

--- a/data/boosters/sos-prerelease-silverquill.yaml
+++ b/data/boosters/sos-prerelease-silverquill.yaml
@@ -7,17 +7,19 @@ pack:
   uncommon: 4
   rare_mythic: 1
   promo: 1
-queries:
-  college: "id<=wb"
 sheets:
   common:
-    query: "r:c {college}"
+    query: "r:c id<=wb"
+    count: 34
   uncommon:
-    query: "r:u {college}"
+    query: "r:u id<=wb"
+    count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 {college}"
+    rawquery: "e:sos r:r number<=254 id<=wb"
+    count: 17
   mythic:
-    rawquery: "e:sos r:m number<=254 {college}"
+    rawquery: "e:sos r:m number<=254 id<=wb"
+    count: 8
   rare_mythic:
     any:
     - use: rare
@@ -29,5 +31,7 @@ sheets:
     any:
     - rawquery: "e:sos r:r number<=254"
       rate: 2
+      count: 55
     - rawquery: "e:sos r:m number<=254"
       rate: 1
+      count: 20

--- a/data/boosters/sos-prerelease-silverquill.yaml
+++ b/data/boosters/sos-prerelease-silverquill.yaml
@@ -1,0 +1,33 @@
+# Secrets of Strixhaven seeded prerelease pack -- Silverquill (White-Black).
+# The seeded pile is a plain non-foil pile of the college's colors (id<=wb):
+# 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards).
+# Plus 1 traditional-foil rare/mythic promo from the base set = 15 cards total.
+pack:
+  common: 9
+  uncommon: 4
+  rare_mythic: 1
+  promo: 1
+queries:
+  college: "id<=wb"
+sheets:
+  common:
+    query: "r:c {college}"
+  uncommon:
+    query: "r:u {college}"
+  rare:
+    rawquery: "e:sos r:r number<=254 {college}"
+  mythic:
+    rawquery: "e:sos r:m number<=254 {college}"
+  rare_mythic:
+    any:
+    - use: rare
+      rate: 2
+    - use: mythic
+      rate: 1
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:sos r:r number<=254"
+      rate: 2
+    - rawquery: "e:sos r:m number<=254"
+      rate: 1

--- a/data/boosters/sos-prerelease-witherbloom.yaml
+++ b/data/boosters/sos-prerelease-witherbloom.yaml
@@ -7,17 +7,19 @@ pack:
   uncommon: 4
   rare_mythic: 1
   promo: 1
-queries:
-  college: "id<=bg"
 sheets:
   common:
-    query: "r:c {college}"
+    query: "r:c id<=bg"
+    count: 34
   uncommon:
-    query: "r:u {college}"
+    query: "r:u id<=bg"
+    count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 {college}"
+    rawquery: "e:sos r:r number<=254 id<=bg"
+    count: 18
   mythic:
-    rawquery: "e:sos r:m number<=254 {college}"
+    rawquery: "e:sos r:m number<=254 id<=bg"
+    count: 9
   rare_mythic:
     any:
     - use: rare
@@ -29,5 +31,7 @@ sheets:
     any:
     - rawquery: "e:sos r:r number<=254"
       rate: 2
+      count: 55
     - rawquery: "e:sos r:m number<=254"
       rate: 1
+      count: 20

--- a/data/boosters/sos-prerelease-witherbloom.yaml
+++ b/data/boosters/sos-prerelease-witherbloom.yaml
@@ -1,0 +1,33 @@
+# Secrets of Strixhaven seeded prerelease pack -- Witherbloom (Black-Green).
+# The seeded pile is a plain non-foil pile of the college's colors (id<=bg):
+# 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards).
+# Plus 1 traditional-foil rare/mythic promo from the base set = 15 cards total.
+pack:
+  common: 9
+  uncommon: 4
+  rare_mythic: 1
+  promo: 1
+queries:
+  college: "id<=bg"
+sheets:
+  common:
+    query: "r:c {college}"
+  uncommon:
+    query: "r:u {college}"
+  rare:
+    rawquery: "e:sos r:r number<=254 {college}"
+  mythic:
+    rawquery: "e:sos r:m number<=254 {college}"
+  rare_mythic:
+    any:
+    - use: rare
+      rate: 2
+    - use: mythic
+      rate: 1
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:sos r:r number<=254"
+      rate: 2
+    - rawquery: "e:sos r:m number<=254"
+      rate: 1

--- a/data/boosters/sos-prerelease-witherbloom.yaml
+++ b/data/boosters/sos-prerelease-witherbloom.yaml
@@ -9,16 +9,16 @@ pack:
   promo: 1
 sheets:
   common:
-    query: "r:c id<=bg"
+    query: "r:c is:baseset id<=bg"
     count: 34
   uncommon:
-    query: "r:u id<=bg"
+    query: "r:u is:baseset id<=bg"
     count: 36
   rare:
-    rawquery: "e:sos r:r number<=254 id<=bg"
-    count: 18
+    rawquery: "e:sos r:r is:baseset id<=bg"
+    count: 20
   mythic:
-    rawquery: "e:sos r:m number<=254 id<=bg"
+    rawquery: "e:sos r:m is:baseset id<=bg"
     count: 9
   rare_mythic:
     any:
@@ -29,9 +29,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:sos r:r number<=254"
+    - rawquery: "e:sos r:r is:baseset"
       rate: 2
-      count: 55
-    - rawquery: "e:sos r:m number<=254"
+      count: 60
+    - rawquery: "e:sos r:m is:baseset"
       rate: 1
       count: 20


### PR DESCRIPTION
From Lorwyn Eclipsed onward there's no dedicated stamped prerelease promo — the prerelease "promo" is just **one traditional-foil rare/mythic from the base set** at the normal drop rate. These boosters resolve the `prerelease` / `prerelease-<college>` pack references in mtg-sealed-content.

- **`ecl-prerelease`** — 1 foil rare/mythic from the ECL base set (`number:1-268`, 2:1 rare:mythic).
- **`sos-prerelease-<college>`** ×5 — the Secrets of Strixhaven college prerelease packs are a plain **non-foil pile seeded to the college's colors**: 9 commons + 4 uncommons + 1 rare/mythic (normal rate), no basic lands (14 cards), **plus** the foil base-set promo = 15 cards. Colleges: Lorehold (RW), Prismari (UR), Quandrix (GU), Silverquill (WB), Witherbloom (BG).

All verified against the rebuilt index with non-empty, color-correct pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)