### PR TITLE
Add count assertions to DSK Nightmare and SOS Codex booster sheets

### DIFF
--- a/data/boosters/dsk-nightmare.yaml
+++ b/data/boosters/dsk-nightmare.yaml
@@ -12,6 +12,8 @@ sheets:
   borderless:
     foil: true
     rawquery: "e:dsc promo:bundle -promo:poster"
+    count: 3
   movie_poster:
     foil: true
     rawquery: "e:dsc promo:poster"
+    count: 3

--- a/data/boosters/sos-codex-bundle.yaml
+++ b/data/boosters/sos-codex-bundle.yaml
@@ -10,3 +10,4 @@ sheets:
   codex_artifact:
     foil: true
     rawquery: "e:soc number:427-432"
+    count: 6


### PR DESCRIPTION
Follow-up to #512. The two sealed-content packs it added — `dsk-nightmare` and `sos-codex-bundle` — were the only booster sheets missing the pool-size `count:` assertions that #511 added everywhere else, because #511 branched off master before #512 merged.

This pins them to their verified pool sizes for parity with the sibling `dft`/`tdm-collector-sample` sheets:

- `dsk-nightmare` — `borderless` (`e:dsc promo:bundle -promo:poster`) → 3, `movie_poster` (`e:dsc promo:poster`) → 3
- `sos-codex-bundle` — `codex_artifact` (`e:soc number:427-432`) → 6

`count:` is a build-time warning-only assertion, so this changes no pack output; it just restores uniform coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)