### PR TITLE
Add TMT and MSH prerelease boosters (base-set foil promo)

### DIFF
--- a/data/boosters/msh-prerelease.yaml
+++ b/data/boosters/msh-prerelease.yaml
@@ -1,0 +1,15 @@
+# Marvel Super Heroes Prerelease Pack promo: 1 traditional-foil rare or mythic
+# from the base set (normal rare:mythic rate). No dedicated stamped prerelease
+# promo exists for MSH, so this is a base-set rare/mythic in foil.
+pack:
+  promo: 1
+sheets:
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:msh r:r number<277"
+      rate: 2
+      count: 60
+    - rawquery: "e:msh r:m number<277"
+      rate: 1
+      count: 25

--- a/data/boosters/msh-prerelease.yaml
+++ b/data/boosters/msh-prerelease.yaml
@@ -7,9 +7,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:msh r:r number<277"
+    - rawquery: "e:msh r:r is:baseset"
       rate: 2
       count: 60
-    - rawquery: "e:msh r:m number<277"
+    - rawquery: "e:msh r:m is:baseset"
       rate: 1
       count: 25

--- a/data/boosters/tmt-prerelease.yaml
+++ b/data/boosters/tmt-prerelease.yaml
@@ -7,9 +7,9 @@ sheets:
   promo:
     foil: true
     any:
-    - rawquery: "e:tmt r:r number<196"
+    - rawquery: "e:tmt r:r is:baseset"
       rate: 2
       count: 53
-    - rawquery: "e:tmt r:m number<196"
+    - rawquery: "e:tmt r:m is:baseset"
       rate: 1
       count: 15

--- a/data/boosters/tmt-prerelease.yaml
+++ b/data/boosters/tmt-prerelease.yaml
@@ -1,0 +1,15 @@
+# Teenage Mutant Ninja Turtles Prerelease Pack promo: 1 traditional-foil rare
+# or mythic from the base set (normal rare:mythic rate). No dedicated stamped
+# prerelease promo exists for TMT, so this is a base-set rare/mythic in foil.
+pack:
+  promo: 1
+sheets:
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:tmt r:r number<196"
+      rate: 2
+      count: 53
+    - rawquery: "e:tmt r:m number<196"
+      rate: 1
+      count: 15


### PR DESCRIPTION
Like ECL/SOS ([#513](https://github.com/taw/magic-search-engine/pull/513)), Teenage Mutant Ninja Turtles and Marvel Super Heroes have **no stamped prerelease promo** (`e:ptmt`/`e:pmsh promo:prerelease` = 0), so the prerelease promo is **1 traditional-foil rare/mythic from the base set** at the normal 2:1 rate.

- **`tmt-prerelease`** — base set `number<196` (boosterfun starts at 196): 53 R + 15 M.
- **`msh-prerelease`** — base set `number<277`: 60 R + 25 M.

Both verified against the rebuilt index with `count:` assertions matching the built pools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)