### PR TITLE
Add EOE Collector Booster Sample Pack (2 cards)

### DIFF
--- a/data/boosters/eoe-collector-sample.yaml
+++ b/data/boosters/eoe-collector-sample.yaml
@@ -1,0 +1,29 @@
+# Edge of Eternities Collector Booster Sample Pack (included in Commander decks),
+# 2 cards. Per https://www.reddit.com/r/magicTCG/comments/1mit4h9/ :
+#   - 1 traditional-foil card of ANY rarity that is NOT collector-exclusive
+#     (a normal-frame card, just in foil), and
+#   - 1 non-foil extended-art card (exclusive to Collector Boosters).
+# EOE has no showcase commons/uncommons, so slot 1 is a plain any-rarity foil.
+pack:
+  foil_any: 1
+  extended_art: 1
+sheets:
+  foil_any:
+    # "Any rarity possible from a commander pack" -> weight by pool size.
+    foil: true
+    any:
+    - query: "r:c is:baseset"
+      rate: 1
+      count: 81
+    - query: "r:u is:baseset"
+      rate: 1
+      count: 100
+    - query: "r:r is:baseset"
+      rate: 1
+      count: 60
+    - query: "r:m is:baseset"
+      rate: 1
+      count: 20
+  extended_art:
+    rawquery: "e:eoe number:317-356"
+    count: 40


### PR DESCRIPTION
The Edge of Eternities Collector Booster Sample Pack (bundled with Commander decks) is a **2-card** pack. Per [this thread](https://www.reddit.com/r/magicTCG/comments/1mit4h9/) (the accepted answer: *"one foil card that is not exclusive to the collector boosters, one non-foil that is exclusive to the collector boosters"*):

- **`foil_any`** — 1 traditional-foil card of **any rarity** that is *not* collector-exclusive (a normal-frame base-set card in foil; weighted by pool size — 81 C / 100 U / 60 R / 20 M).
- **`extended_art`** — 1 **non-foil** extended-art card, exclusive to Collector Boosters (`e:eoe number:317-356`, 40 cards).

Unlike DFT/TDM, EOE has no showcase commons/uncommons, so slot 1 is a plain any-rarity foil rather than a foil showcase C/U. Builds to a 2-card pack; `count:` tags match the built pools. Resolves the `eoe-collector-sample` reference (card_count already 2 in mtg-sealed-content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)