### PR TITLE
Add Theros & Journey into Nyx Hero's Path seeded prerelease packs

### DIFF
--- a/data/boosters/jou-prerelease-glory.yaml
+++ b/data/boosters/jou-prerelease-glory.yaml
@@ -1,0 +1,21 @@
+# Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Glory (White).
+# Seeded booster favoring the destiny's color (id<=w), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Dawnbringer Charioteers) and Hero's Path card (Spear of the General) are fixed content on the
+# product in mtg-sealed-content.
+name: "Journey into Nyx Prerelease Pack Forged in Glory"
+filter: "e:jou id<=w is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 12
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:jou (r:r or r:m) id<=w is:baseset"
+    count: 9

--- a/data/boosters/jou-prerelease-glory.yaml
+++ b/data/boosters/jou-prerelease-glory.yaml
@@ -1,14 +1,15 @@
 # Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Glory (White).
-# Seeded booster favoring the destiny's color (id<=w), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Dawnbringer Charioteers) and Hero's Path card (Spear of the General) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=w), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Journey into Nyx Prerelease Pack Forged in Glory"
 filter: "e:jou id<=w is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:jou (r:r or r:m) id<=w is:baseset"
     count: 9
+  promo:
+    foil: true
+    rawquery: "e:pjou promo:prerelease id<=w"
+    count: 1

--- a/data/boosters/jou-prerelease-glory.yaml
+++ b/data/boosters/jou-prerelease-glory.yaml
@@ -6,7 +6,7 @@
 name: "Journey into Nyx Prerelease Pack Forged in Glory"
 filter: "e:jou id<=w is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/jou-prerelease-intellect.yaml
+++ b/data/boosters/jou-prerelease-intellect.yaml
@@ -6,7 +6,7 @@
 name: "Journey into Nyx Prerelease Pack Forged in Intellect"
 filter: "e:jou id<=u is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/jou-prerelease-intellect.yaml
+++ b/data/boosters/jou-prerelease-intellect.yaml
@@ -1,0 +1,21 @@
+# Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Intellect (Blue).
+# Seeded booster favoring the destiny's color (id<=u), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Scourge of Fleets) and Hero's Path card (Cloak of the Philosopher) are fixed content on the
+# product in mtg-sealed-content.
+name: "Journey into Nyx Prerelease Pack Forged in Intellect"
+filter: "e:jou id<=u is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 12
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:jou (r:r or r:m) id<=u is:baseset"
+    count: 9

--- a/data/boosters/jou-prerelease-intellect.yaml
+++ b/data/boosters/jou-prerelease-intellect.yaml
@@ -1,14 +1,15 @@
 # Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Intellect (Blue).
-# Seeded booster favoring the destiny's color (id<=u), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Scourge of Fleets) and Hero's Path card (Cloak of the Philosopher) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=u), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Journey into Nyx Prerelease Pack Forged in Intellect"
 filter: "e:jou id<=u is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:jou (r:r or r:m) id<=u is:baseset"
     count: 9
+  promo:
+    foil: true
+    rawquery: "e:pjou promo:prerelease id<=u"
+    count: 1

--- a/data/boosters/jou-prerelease-pursuit.yaml
+++ b/data/boosters/jou-prerelease-pursuit.yaml
@@ -1,14 +1,15 @@
 # Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Pursuit (Green).
-# Seeded booster favoring the destiny's color (id<=g), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Heroes' Bane) and Hero's Path card (Bow of the Hunter) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=g), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Journey into Nyx Prerelease Pack Forged in Pursuit"
 filter: "e:jou id<=g is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:jou (r:r or r:m) id<=g is:baseset"
     count: 8
+  promo:
+    foil: true
+    rawquery: "e:pjou promo:prerelease id<=g"
+    count: 1

--- a/data/boosters/jou-prerelease-pursuit.yaml
+++ b/data/boosters/jou-prerelease-pursuit.yaml
@@ -6,7 +6,7 @@
 name: "Journey into Nyx Prerelease Pack Forged in Pursuit"
 filter: "e:jou id<=g is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/jou-prerelease-pursuit.yaml
+++ b/data/boosters/jou-prerelease-pursuit.yaml
@@ -1,0 +1,21 @@
+# Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Pursuit (Green).
+# Seeded booster favoring the destiny's color (id<=g), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Heroes' Bane) and Hero's Path card (Bow of the Hunter) are fixed content on the
+# product in mtg-sealed-content.
+name: "Journey into Nyx Prerelease Pack Forged in Pursuit"
+filter: "e:jou id<=g is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 12
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:jou (r:r or r:m) id<=g is:baseset"
+    count: 8

--- a/data/boosters/jou-prerelease-tyranny.yaml
+++ b/data/boosters/jou-prerelease-tyranny.yaml
@@ -1,0 +1,21 @@
+# Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Tyranny (Black).
+# Seeded booster favoring the destiny's color (id<=b), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Doomwake Giant) and Hero's Path card (Lash of the Tyrant) are fixed content on the
+# product in mtg-sealed-content.
+name: "Journey into Nyx Prerelease Pack Forged in Tyranny"
+filter: "e:jou id<=b is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 12
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:jou (r:r or r:m) id<=b is:baseset"
+    count: 9

--- a/data/boosters/jou-prerelease-tyranny.yaml
+++ b/data/boosters/jou-prerelease-tyranny.yaml
@@ -1,14 +1,15 @@
 # Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in Tyranny (Black).
-# Seeded booster favoring the destiny's color (id<=b), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Doomwake Giant) and Hero's Path card (Lash of the Tyrant) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=b), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Journey into Nyx Prerelease Pack Forged in Tyranny"
 filter: "e:jou id<=b is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:jou (r:r or r:m) id<=b is:baseset"
     count: 9
+  promo:
+    foil: true
+    rawquery: "e:pjou promo:prerelease id<=b"
+    count: 1

--- a/data/boosters/jou-prerelease-tyranny.yaml
+++ b/data/boosters/jou-prerelease-tyranny.yaml
@@ -6,7 +6,7 @@
 name: "Journey into Nyx Prerelease Pack Forged in Tyranny"
 filter: "e:jou id<=b is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/jou-prerelease-war.yaml
+++ b/data/boosters/jou-prerelease-war.yaml
@@ -6,7 +6,7 @@
 name: "Journey into Nyx Prerelease Pack Forged in War"
 filter: "e:jou id<=r is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/jou-prerelease-war.yaml
+++ b/data/boosters/jou-prerelease-war.yaml
@@ -1,0 +1,21 @@
+# Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in War (Red).
+# Seeded booster favoring the destiny's color (id<=r), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Spawn of Thraxes) and Hero's Path card (Axe of the Warmonger) are fixed content on the
+# product in mtg-sealed-content.
+name: "Journey into Nyx Prerelease Pack Forged in War"
+filter: "e:jou id<=r is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 12
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:jou (r:r or r:m) id<=r is:baseset"
+    count: 9

--- a/data/boosters/jou-prerelease-war.yaml
+++ b/data/boosters/jou-prerelease-war.yaml
@@ -1,14 +1,15 @@
 # Journey into Nyx "Hero's Path" seeded prerelease pack -- Forged in War (Red).
-# Seeded booster favoring the destiny's color (id<=r), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Spawn of Thraxes) and Hero's Path card (Axe of the Warmonger) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=r), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Journey into Nyx Prerelease Pack Forged in War"
 filter: "e:jou id<=r is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:jou (r:r or r:m) id<=r is:baseset"
     count: 9
+  promo:
+    foil: true
+    rawquery: "e:pjou promo:prerelease id<=r"
+    count: 1

--- a/data/boosters/ths-prerelease-ambition.yaml
+++ b/data/boosters/ths-prerelease-ambition.yaml
@@ -1,0 +1,21 @@
+# Theros "Hero's Path" seeded prerelease pack -- Path of Ambition (Black).
+# Seeded booster favoring the destiny's color (id<=b), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Abhorrent Overlord) and Hero's Path card (The Avenger) are fixed content on the
+# product in mtg-sealed-content.
+name: "Theros Prerelease Pack Path of Ambition"
+filter: "e:ths id<=b is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:ths (r:r or r:m) id<=b is:baseset"
+    count: 12

--- a/data/boosters/ths-prerelease-ambition.yaml
+++ b/data/boosters/ths-prerelease-ambition.yaml
@@ -6,7 +6,7 @@
 name: "Theros Prerelease Pack Path of Ambition"
 filter: "e:ths id<=b is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/ths-prerelease-ambition.yaml
+++ b/data/boosters/ths-prerelease-ambition.yaml
@@ -1,14 +1,15 @@
 # Theros "Hero's Path" seeded prerelease pack -- Path of Ambition (Black).
-# Seeded booster favoring the destiny's color (id<=b), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Abhorrent Overlord) and Hero's Path card (The Avenger) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=b), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Theros Prerelease Pack Path of Ambition"
 filter: "e:ths id<=b is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:ths (r:r or r:m) id<=b is:baseset"
     count: 12
+  promo:
+    foil: true
+    rawquery: "e:pths promo:prerelease id<=b"
+    count: 1

--- a/data/boosters/ths-prerelease-battle.yaml
+++ b/data/boosters/ths-prerelease-battle.yaml
@@ -1,14 +1,15 @@
 # Theros "Hero's Path" seeded prerelease pack -- Path of Battle (Red).
-# Seeded booster favoring the destiny's color (id<=r), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Ember Swallower) and Hero's Path card (The Warrior) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=r), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Theros Prerelease Pack Path of Battle"
 filter: "e:ths id<=r is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:ths (r:r or r:m) id<=r is:baseset"
     count: 13
+  promo:
+    foil: true
+    rawquery: "e:pths promo:prerelease id<=r"
+    count: 1

--- a/data/boosters/ths-prerelease-battle.yaml
+++ b/data/boosters/ths-prerelease-battle.yaml
@@ -1,0 +1,21 @@
+# Theros "Hero's Path" seeded prerelease pack -- Path of Battle (Red).
+# Seeded booster favoring the destiny's color (id<=r), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Ember Swallower) and Hero's Path card (The Warrior) are fixed content on the
+# product in mtg-sealed-content.
+name: "Theros Prerelease Pack Path of Battle"
+filter: "e:ths id<=r is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:ths (r:r or r:m) id<=r is:baseset"
+    count: 13

--- a/data/boosters/ths-prerelease-battle.yaml
+++ b/data/boosters/ths-prerelease-battle.yaml
@@ -6,7 +6,7 @@
 name: "Theros Prerelease Pack Path of Battle"
 filter: "e:ths id<=r is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/ths-prerelease-honor.yaml
+++ b/data/boosters/ths-prerelease-honor.yaml
@@ -1,0 +1,21 @@
+# Theros "Hero's Path" seeded prerelease pack -- Path of Honor (White).
+# Seeded booster favoring the destiny's color (id<=w), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Celestial Archon) and Hero's Path card (The Protector) are fixed content on the
+# product in mtg-sealed-content.
+name: "Theros Prerelease Pack Path of Honor"
+filter: "e:ths id<=w is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:ths (r:r or r:m) id<=w is:baseset"
+    count: 13

--- a/data/boosters/ths-prerelease-honor.yaml
+++ b/data/boosters/ths-prerelease-honor.yaml
@@ -1,14 +1,15 @@
 # Theros "Hero's Path" seeded prerelease pack -- Path of Honor (White).
-# Seeded booster favoring the destiny's color (id<=w), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Celestial Archon) and Hero's Path card (The Protector) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=w), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Theros Prerelease Pack Path of Honor"
 filter: "e:ths id<=w is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:ths (r:r or r:m) id<=w is:baseset"
     count: 13
+  promo:
+    foil: true
+    rawquery: "e:pths promo:prerelease id<=w"
+    count: 1

--- a/data/boosters/ths-prerelease-honor.yaml
+++ b/data/boosters/ths-prerelease-honor.yaml
@@ -6,7 +6,7 @@
 name: "Theros Prerelease Pack Path of Honor"
 filter: "e:ths id<=w is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/ths-prerelease-might.yaml
+++ b/data/boosters/ths-prerelease-might.yaml
@@ -1,0 +1,21 @@
+# Theros "Hero's Path" seeded prerelease pack -- Path of Might (Green).
+# Seeded booster favoring the destiny's color (id<=g), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Anthousa, Setessan Hero) and Hero's Path card (The Hunter) are fixed content on the
+# product in mtg-sealed-content.
+name: "Theros Prerelease Pack Path of Might"
+filter: "e:ths id<=g is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:ths (r:r or r:m) id<=g is:baseset"
+    count: 13

--- a/data/boosters/ths-prerelease-might.yaml
+++ b/data/boosters/ths-prerelease-might.yaml
@@ -1,14 +1,15 @@
 # Theros "Hero's Path" seeded prerelease pack -- Path of Might (Green).
-# Seeded booster favoring the destiny's color (id<=g), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Anthousa, Setessan Hero) and Hero's Path card (The Hunter) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=g), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Theros Prerelease Pack Path of Might"
 filter: "e:ths id<=g is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:ths (r:r or r:m) id<=g is:baseset"
     count: 13
+  promo:
+    foil: true
+    rawquery: "e:pths promo:prerelease id<=g"
+    count: 1

--- a/data/boosters/ths-prerelease-might.yaml
+++ b/data/boosters/ths-prerelease-might.yaml
@@ -6,7 +6,7 @@
 name: "Theros Prerelease Pack Path of Might"
 filter: "e:ths id<=g is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:

--- a/data/boosters/ths-prerelease-wisdom.yaml
+++ b/data/boosters/ths-prerelease-wisdom.yaml
@@ -1,0 +1,21 @@
+# Theros "Hero's Path" seeded prerelease pack -- Path of Wisdom (Blue).
+# Seeded booster favoring the destiny's color (id<=u), like the RTR/GTC guild
+# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
+# The foil promo (Shipbreaker Kraken) and Hero's Path card (The Philosopher) are fixed content on the
+# product in mtg-sealed-content.
+name: "Theros Prerelease Pack Path of Wisdom"
+filter: "e:ths id<=u is:baseset"
+pack:
+  common: 11
+  uncommon: 3
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  uncommon:
+    query: "r:u"
+    count: 14
+  rare_mythic:
+    rawquery: "e:ths (r:r or r:m) id<=u is:baseset"
+    count: 13

--- a/data/boosters/ths-prerelease-wisdom.yaml
+++ b/data/boosters/ths-prerelease-wisdom.yaml
@@ -1,14 +1,15 @@
 # Theros "Hero's Path" seeded prerelease pack -- Path of Wisdom (Blue).
-# Seeded booster favoring the destiny's color (id<=u), like the RTR/GTC guild
-# and BNG "Destined to" prereleases: 11 common + 3 uncommon + 1 rare/mythic = 15.
-# The foil promo (Shipbreaker Kraken) and Hero's Path card (The Philosopher) are fixed content on the
-# product in mtg-sealed-content.
+# The 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the
+# destiny's color (id<=u), plus the guaranteed stamped foil prerelease promo.
+# Modeled like the RTR/GTC guild prereleases. The Hero's Path card is separate
+# (oversized) and lives on the mtg-sealed-content product.
 name: "Theros Prerelease Pack Path of Wisdom"
 filter: "e:ths id<=u is:baseset"
 pack:
   common: 10
   uncommon: 3
   rare_mythic: 1
+  promo: 1
 sheets:
   common:
     query: "r:c"
@@ -19,3 +20,7 @@ sheets:
   rare_mythic:
     rawquery: "e:ths (r:r or r:m) id<=u is:baseset"
     count: 13
+  promo:
+    foil: true
+    rawquery: "e:pths promo:prerelease id<=u"
+    count: 1

--- a/data/boosters/ths-prerelease-wisdom.yaml
+++ b/data/boosters/ths-prerelease-wisdom.yaml
@@ -6,7 +6,7 @@
 name: "Theros Prerelease Pack Path of Wisdom"
 filter: "e:ths id<=u is:baseset"
 pack:
-  common: 11
+  common: 10
   uncommon: 3
   rare_mythic: 1
 sheets:


### PR DESCRIPTION
Completes the Theros-block Hero's Path prereleases (after BNG #517). Theros ("Path of X") and Journey into Nyx ("Forged in X") each had five color-seeded prerelease boosters. The seeded booster is 15 cards including the guaranteed stamped foil promo, so the pack proper is **10 common + 3 uncommon + 1 rare/mythic = 14** (color-filtered); the promo is the 15th.

| Set | Paths → colors |
|-----|----------------|
| THS | Honor=W, Wisdom=U, Ambition=B, Battle=R, Might=G |
| JOU | Glory=W, Intellect=U, Tyranny=B, War=R, Pursuit=G |

`filter: id<=<color> is:baseset`. Path→color→promo→hero verified against WotC's Theros / Journey into Nyx Prerelease Primers. Promos + Hero's Path cards (`thp1`/`thp3`) are fixed content on the kits (`card_count: 15` = 14 pack + 1 promo). All ten build to 14-card color-correct packs; `count:` tags match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)