### PR TITLE
Add TDM seeded prerelease Clan Boosters

### DIFF
--- a/data/boosters/tdm-prerelease-abzan.yaml
+++ b/data/boosters/tdm-prerelease-abzan.yaml
@@ -1,0 +1,29 @@
+# Tarkir: Dragonstorm -- seeded prerelease Clan Booster (Abzan -- White/Black/Green).
+# Sources:
+# - https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide
+#   (5 clan-seeded prerelease kits: Abzan/Jeskai/Mardu/Sultai/Temur; 14-card seeded booster)
+# - https://draftsim.com/tarkir-dragonstorm-seeded-prerelease-kits/
+# WotC published only the 14-card seeded-booster total, not the slot breakdown, so this
+# reconstructs a 14-card clan-seeded pile: 9 common, 3 uncommon, 1 in-wedge fixing land,
+# 1 rare/mythic. Seeded via the DTK/SNC wedge idiom -- cards in the clan's colors that
+# carry the clan watermark or no watermark (excludes off-clan and generic colorless).
+# The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
+# year-stamped promo is a separate booster (tdm-prerelease), added at the Prerelease Pack level.
+name: "Tarkir: Dragonstorm Seeded Prerelease Booster Abzan"
+filter: "e:tdm id<=wbg is:baseset (w:abzan or -w:*) -(c:c -w:*)"
+pack:
+  common: 9
+  uncommon: 3
+  land: 1
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c -t:land"
+    count: 34
+  uncommon:
+    query: "r:u -t:land"
+    count: 39
+  land:
+    # In-wedge common fixing lands (clan duals + Evolving Wilds).
+    rawquery: "e:tdm is:baseset t:land -t:basic r:c id<=wbg"
+    count: 4

--- a/data/boosters/tdm-prerelease-jeskai.yaml
+++ b/data/boosters/tdm-prerelease-jeskai.yaml
@@ -1,0 +1,29 @@
+# Tarkir: Dragonstorm -- seeded prerelease Clan Booster (Jeskai -- Blue/Red/White).
+# Sources:
+# - https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide
+#   (5 clan-seeded prerelease kits: Abzan/Jeskai/Mardu/Sultai/Temur; 14-card seeded booster)
+# - https://draftsim.com/tarkir-dragonstorm-seeded-prerelease-kits/
+# WotC published only the 14-card seeded-booster total, not the slot breakdown, so this
+# reconstructs a 14-card clan-seeded pile: 9 common, 3 uncommon, 1 in-wedge fixing land,
+# 1 rare/mythic. Seeded via the DTK/SNC wedge idiom -- cards in the clan's colors that
+# carry the clan watermark or no watermark (excludes off-clan and generic colorless).
+# The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
+# year-stamped promo is a separate booster (tdm-prerelease), added at the Prerelease Pack level.
+name: "Tarkir: Dragonstorm Seeded Prerelease Booster Jeskai"
+filter: "e:tdm id<=urw is:baseset (w:jeskai or -w:*) -(c:c -w:*)"
+pack:
+  common: 9
+  uncommon: 3
+  land: 1
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c -t:land"
+    count: 35
+  uncommon:
+    query: "r:u -t:land"
+    count: 38
+  land:
+    # In-wedge common fixing lands (clan duals + Evolving Wilds).
+    rawquery: "e:tdm is:baseset t:land -t:basic r:c id<=urw"
+    count: 4

--- a/data/boosters/tdm-prerelease-mardu.yaml
+++ b/data/boosters/tdm-prerelease-mardu.yaml
@@ -1,0 +1,29 @@
+# Tarkir: Dragonstorm -- seeded prerelease Clan Booster (Mardu -- Red/White/Black).
+# Sources:
+# - https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide
+#   (5 clan-seeded prerelease kits: Abzan/Jeskai/Mardu/Sultai/Temur; 14-card seeded booster)
+# - https://draftsim.com/tarkir-dragonstorm-seeded-prerelease-kits/
+# WotC published only the 14-card seeded-booster total, not the slot breakdown, so this
+# reconstructs a 14-card clan-seeded pile: 9 common, 3 uncommon, 1 in-wedge fixing land,
+# 1 rare/mythic. Seeded via the DTK/SNC wedge idiom -- cards in the clan's colors that
+# carry the clan watermark or no watermark (excludes off-clan and generic colorless).
+# The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
+# year-stamped promo is a separate booster (tdm-prerelease), added at the Prerelease Pack level.
+name: "Tarkir: Dragonstorm Seeded Prerelease Booster Mardu"
+filter: "e:tdm id<=brw is:baseset (w:mardu or -w:*) -(c:c -w:*)"
+pack:
+  common: 9
+  uncommon: 3
+  land: 1
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c -t:land"
+    count: 33
+  uncommon:
+    query: "r:u -t:land"
+    count: 38
+  land:
+    # In-wedge common fixing lands (clan duals + Evolving Wilds).
+    rawquery: "e:tdm is:baseset t:land -t:basic r:c id<=brw"
+    count: 4

--- a/data/boosters/tdm-prerelease-sultai.yaml
+++ b/data/boosters/tdm-prerelease-sultai.yaml
@@ -1,0 +1,29 @@
+# Tarkir: Dragonstorm -- seeded prerelease Clan Booster (Sultai -- Black/Green/Blue).
+# Sources:
+# - https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide
+#   (5 clan-seeded prerelease kits: Abzan/Jeskai/Mardu/Sultai/Temur; 14-card seeded booster)
+# - https://draftsim.com/tarkir-dragonstorm-seeded-prerelease-kits/
+# WotC published only the 14-card seeded-booster total, not the slot breakdown, so this
+# reconstructs a 14-card clan-seeded pile: 9 common, 3 uncommon, 1 in-wedge fixing land,
+# 1 rare/mythic. Seeded via the DTK/SNC wedge idiom -- cards in the clan's colors that
+# carry the clan watermark or no watermark (excludes off-clan and generic colorless).
+# The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
+# year-stamped promo is a separate booster (tdm-prerelease), added at the Prerelease Pack level.
+name: "Tarkir: Dragonstorm Seeded Prerelease Booster Sultai"
+filter: "e:tdm id<=bgu is:baseset (w:sultai or -w:*) -(c:c -w:*)"
+pack:
+  common: 9
+  uncommon: 3
+  land: 1
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c -t:land"
+    count: 35
+  uncommon:
+    query: "r:u -t:land"
+    count: 39
+  land:
+    # In-wedge common fixing lands (clan duals + Evolving Wilds).
+    rawquery: "e:tdm is:baseset t:land -t:basic r:c id<=bgu"
+    count: 4

--- a/data/boosters/tdm-prerelease-temur.yaml
+++ b/data/boosters/tdm-prerelease-temur.yaml
@@ -1,0 +1,29 @@
+# Tarkir: Dragonstorm -- seeded prerelease Clan Booster (Temur -- Green/Blue/Red).
+# Sources:
+# - https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide
+#   (5 clan-seeded prerelease kits: Abzan/Jeskai/Mardu/Sultai/Temur; 14-card seeded booster)
+# - https://draftsim.com/tarkir-dragonstorm-seeded-prerelease-kits/
+# WotC published only the 14-card seeded-booster total, not the slot breakdown, so this
+# reconstructs a 14-card clan-seeded pile: 9 common, 3 uncommon, 1 in-wedge fixing land,
+# 1 rare/mythic. Seeded via the DTK/SNC wedge idiom -- cards in the clan's colors that
+# carry the clan watermark or no watermark (excludes off-clan and generic colorless).
+# The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
+# year-stamped promo is a separate booster (tdm-prerelease), added at the Prerelease Pack level.
+name: "Tarkir: Dragonstorm Seeded Prerelease Booster Temur"
+filter: "e:tdm id<=gru is:baseset (w:temur or -w:*) -(c:c -w:*)"
+pack:
+  common: 9
+  uncommon: 3
+  land: 1
+  rare_mythic: 1
+sheets:
+  common:
+    query: "r:c -t:land"
+    count: 34
+  uncommon:
+    query: "r:u -t:land"
+    count: 38
+  land:
+    # In-wedge common fixing lands (clan duals + Evolving Wilds).
+    rawquery: "e:tdm is:baseset t:land -t:basic r:c id<=gru"
+    count: 4


### PR DESCRIPTION
Adds the five clan-seeded prerelease Clan Boosters for **Tarkir: Dragonstorm** (TDM), mirroring the TLA seeded-prerelease modeling (and the DTK/SNC wedge idiom).

## Seeds (3-color wedges, per the [official WotC prerelease guide](https://magic.wizards.com/en/news/feature/tarkir-dragonstorm-prerelease-guide))
| Clan | Colors |
|------|--------|
| Abzan  | W/B/G |
| Jeskai | U/R/W |
| Mardu  | R/W/B |
| Sultai | B/G/U |
| Temur  | G/U/R |

## Seeded Clan Booster (14 cards)
```
common: 9   (r:c -t:land, seeded to the wedge)
uncommon: 3 (r:u -t:land, seeded)
land: 1     (in-wedge common fixing lands: clan duals + Evolving Wilds)
rare_mythic: 1 (inherits the shared rare_mythic sheet -> rare:mythic = 2:1, seeded)
```
Seeded with the DTK/SNC wedge filter — `e:tdm id<=<wedge> is:baseset (w:<clan> or -w:*) -(c:c -w:*)` — i.e. cards in the clan's colors that carry the clan watermark or no watermark, excluding off-clan and generic colorless cards. Verified: every sampled card sits within the clan's three colors.

## Stamped promo (separate booster)
Per the WotC guide the foil year-stamped rare/mythic is a **separate loose card**, so it stays in the existing `tdm-prerelease` booster (`prerelease_promo: 1`, `use: rare_mythic`, foil, any-color) and is added at the Prerelease Pack level (`pack: [prerelease]`) — the same split as TLA, and the OTJ/DSK/BLB convention.

WotC published only the 14-card seeded-booster total, not the slot breakdown, so the 9/3/1/1 split is a reconstruction. All pool-size `count:` assertions verified against the index; each seeded pack samples to exactly 14 cards (0 foils), the promo booster to 1 foil from `ptdm` at ~6.6:1 rare:mythic.

Companion sealed-content wiring: mtgjson/mtg-sealed-content#456

🤖 Generated with [Claude Code](https://claude.com/claude-code)