### PR TITLE
Add KTK + FRF seeded prerelease Clan Boosters (old Tarkir block)

### DIFF
--- a/data/boosters/frf-prerelease-abzan.yaml
+++ b/data/boosters/frf-prerelease-abzan.yaml
@@ -1,0 +1,25 @@
+# Fate Reforged -- seeded prerelease Clan Booster (Abzan -- White/Black/Green).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Abzan"
+filter: "e:{set} id<=wbg is:baseset (w:abzan or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 21
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pfrf r:m (w:abzan or (id<=wbg and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pfrf r:r (w:abzan or (id<=wbg and -w:*)) promo:prerelease"
+      count: 6
+      rate: 2

--- a/data/boosters/frf-prerelease-jeskai.yaml
+++ b/data/boosters/frf-prerelease-jeskai.yaml
@@ -1,0 +1,25 @@
+# Fate Reforged -- seeded prerelease Clan Booster (Jeskai -- Blue/Red/White).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Jeskai"
+filter: "e:{set} id<=urw is:baseset (w:jeskai or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 24
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pfrf r:m (w:jeskai or (id<=urw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pfrf r:r (w:jeskai or (id<=urw and -w:*)) promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/frf-prerelease-mardu.yaml
+++ b/data/boosters/frf-prerelease-mardu.yaml
@@ -1,0 +1,25 @@
+# Fate Reforged -- seeded prerelease Clan Booster (Mardu -- Red/White/Black).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Mardu"
+filter: "e:{set} id<=brw is:baseset (w:mardu or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 20
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pfrf r:m (w:mardu or (id<=brw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pfrf r:r (w:mardu or (id<=brw and -w:*)) promo:prerelease"
+      count: 6
+      rate: 2

--- a/data/boosters/frf-prerelease-sultai.yaml
+++ b/data/boosters/frf-prerelease-sultai.yaml
@@ -1,0 +1,25 @@
+# Fate Reforged -- seeded prerelease Clan Booster (Sultai -- Black/Green/Blue).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Sultai"
+filter: "e:{set} id<=bgu is:baseset (w:sultai or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 26
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pfrf r:m (w:sultai or (id<=bgu and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pfrf r:r (w:sultai or (id<=bgu and -w:*)) promo:prerelease"
+      count: 5
+      rate: 2

--- a/data/boosters/frf-prerelease-temur.yaml
+++ b/data/boosters/frf-prerelease-temur.yaml
@@ -1,0 +1,25 @@
+# Fate Reforged -- seeded prerelease Clan Booster (Temur -- Green/Blue/Red).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Temur"
+filter: "e:{set} id<=gru is:baseset (w:temur or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 23
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pfrf r:m (w:temur or (id<=gru and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pfrf r:r (w:temur or (id<=gru and -w:*)) promo:prerelease"
+      count: 6
+      rate: 2

--- a/data/boosters/frf-prerelease.yaml
+++ b/data/boosters/frf-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true

--- a/data/boosters/ktk-prerelease-abzan.yaml
+++ b/data/boosters/ktk-prerelease-abzan.yaml
@@ -1,0 +1,25 @@
+# Khans of Tarkir -- seeded prerelease Clan Booster (Abzan -- White/Black/Green).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Abzan"
+filter: "e:{set} id<=wbg is:baseset (w:abzan or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 36
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pktk r:m (w:abzan or (id<=wbg and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pktk r:r (w:abzan or (id<=wbg and -w:*)) promo:prerelease"
+      count: 9
+      rate: 2

--- a/data/boosters/ktk-prerelease-jeskai.yaml
+++ b/data/boosters/ktk-prerelease-jeskai.yaml
@@ -1,0 +1,25 @@
+# Khans of Tarkir -- seeded prerelease Clan Booster (Jeskai -- Blue/Red/White).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Jeskai"
+filter: "e:{set} id<=urw is:baseset (w:jeskai or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pktk r:m (w:jeskai or (id<=urw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pktk r:r (w:jeskai or (id<=urw and -w:*)) promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ktk-prerelease-mardu.yaml
+++ b/data/boosters/ktk-prerelease-mardu.yaml
@@ -1,0 +1,25 @@
+# Khans of Tarkir -- seeded prerelease Clan Booster (Mardu -- Red/White/Black).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Mardu"
+filter: "e:{set} id<=brw is:baseset (w:mardu or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 38
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pktk r:m (w:mardu or (id<=brw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pktk r:r (w:mardu or (id<=brw and -w:*)) promo:prerelease"
+      count: 8
+      rate: 2

--- a/data/boosters/ktk-prerelease-sultai.yaml
+++ b/data/boosters/ktk-prerelease-sultai.yaml
@@ -1,0 +1,25 @@
+# Khans of Tarkir -- seeded prerelease Clan Booster (Sultai -- Black/Green/Blue).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Sultai"
+filter: "e:{set} id<=bgu is:baseset (w:sultai or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 37
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pktk r:m (w:sultai or (id<=bgu and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pktk r:r (w:sultai or (id<=bgu and -w:*)) promo:prerelease"
+      count: 8
+      rate: 2

--- a/data/boosters/ktk-prerelease-temur.yaml
+++ b/data/boosters/ktk-prerelease-temur.yaml
@@ -1,0 +1,25 @@
+# Khans of Tarkir -- seeded prerelease Clan Booster (Temur -- Green/Blue/Red).
+# Matches the Dragons of Tarkir seeded-prerelease model (same block): a 15-card clan
+# pile (11 common + 4 uncommon) plus the folded, clan-colored foil year-stamped promo.
+# Seeded via the wedge idiom -- cards in the clan's colors that carry the clan watermark
+# or no watermark, excluding generic colorless. The promo is a rare/mythic in the clan's
+# colors (2:1 rare:mythic), which for this era is stamped in the clan's own colors.
+name: "{set_name} Seeded Prerelease Booster Temur"
+filter: "e:{set} id<=gru is:baseset (w:temur or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 4
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pktk r:m (w:temur or (id<=gru and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pktk r:r (w:temur or (id<=gru and -w:*)) promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ktk-prerelease.yaml
+++ b/data/boosters/ktk-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true


### PR DESCRIPTION
Adds the five clan-seeded prerelease Clan Boosters for **Khans of Tarkir** (KTK) and **Fate Reforged** (FRF), completing the old Tarkir block's seeded prereleases (Dragons of Tarkir already has `dtk-prerelease-*`).

## Clans (3-color wedges)
| Clan | Colors |
|------|--------|
| Abzan  | W/B/G |
| Jeskai | U/R/W |
| Mardu  | R/W/B |
| Sultai | B/G/U |
| Temur  | G/U/R |

## Model — matches the existing DTK seeded prereleases
Each booster is a 15-card clan pile plus the folded, clan-colored foil year-stamped promo:
```
common: 11
uncommon: 4
promo: 1   (foil; e:p<set> rare/mythic in-clan, 2:1 rare:mythic)
```
Seeded via the DTK wedge idiom — `e:<set> id<=<wedge> is:baseset (w:<clan> or -w:*) -(c:c -w:*)` — cards in the clan's colors carrying the clan watermark or no watermark, excluding generic colorless.

Unlike the modern any-color stamped promo (TLA/TDM), the 2014-15 prerelease promo is stamped in the **clan's own colors**, so the promo sheet is clan-restricted — identical to the DTK boosters.

Verified against the index: each pack samples to exactly 16 cards with one in-clan foil promo, zero off-wedge cards, no `count:` warnings.

Also removes the now-orphaned generic `ktk-prerelease.yaml` / `frf-prerelease.yaml` (bare any-color promo boosters), superseded by the seeded packs — matching DTK, which has no such generic file.

Companion sealed-content wiring: mtgjson/mtg-sealed-content#457

🤖 Generated with [Claude Code](https://claude.com/claude-code)