### PR TITLE
Fix TLA seeded prerelease Character Boosters to 14 cards

### DIFF
--- a/data/boosters/tla-prerelease-aang.yaml
+++ b/data/boosters/tla-prerelease-aang.yaml
@@ -3,14 +3,15 @@
 # - https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide
 #   (character seed colors: Aang=White, Katara=Blue, Azula=Black, Zuko=Red, Toph=Green)
 # - https://draftsim.com/avatar-seeded-packs/ (seeded pack has "on-color rares, a dual land, plenty of uncommons")
-# 15-card seeded pile matching the RTR/GTC/SNC seeded-prerelease norm: 10 common, 3 uncommon,
+# 14-card seeded pile (per WotC/retailer listings that state "a seeded character themed
+# booster full of 14 cards"): 9 common, 3 uncommon,
 # 1 in-color dual land, 1 rare/mythic -- all seeded to the character's color via the pack filter.
 # The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
 # year-stamped promo is a separate booster (tla-prerelease), added at the Prerelease Pack level.
 name: "Avatar: The Last Airbender Seeded Prerelease Pack Aang"
 filter: "e:tla id<=w is:baseset"
 pack:
-  common: 10
+  common: 9
   uncommon: 3
   land: 1
   rare_mythic: 1

--- a/data/boosters/tla-prerelease-azula.yaml
+++ b/data/boosters/tla-prerelease-azula.yaml
@@ -3,14 +3,15 @@
 # - https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide
 #   (character seed colors: Aang=White, Katara=Blue, Azula=Black, Zuko=Red, Toph=Green)
 # - https://draftsim.com/avatar-seeded-packs/ (seeded pack has "on-color rares, a dual land, plenty of uncommons")
-# 15-card seeded pile matching the RTR/GTC/SNC seeded-prerelease norm: 10 common, 3 uncommon,
+# 14-card seeded pile (per WotC/retailer listings that state "a seeded character themed
+# booster full of 14 cards"): 9 common, 3 uncommon,
 # 1 in-color dual land, 1 rare/mythic -- all seeded to the character's color via the pack filter.
 # The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
 # year-stamped promo is a separate booster (tla-prerelease), added at the Prerelease Pack level.
 name: "Avatar: The Last Airbender Seeded Prerelease Pack Azula"
 filter: "e:tla id<=b is:baseset"
 pack:
-  common: 10
+  common: 9
   uncommon: 3
   land: 1
   rare_mythic: 1

--- a/data/boosters/tla-prerelease-katara.yaml
+++ b/data/boosters/tla-prerelease-katara.yaml
@@ -3,14 +3,15 @@
 # - https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide
 #   (character seed colors: Aang=White, Katara=Blue, Azula=Black, Zuko=Red, Toph=Green)
 # - https://draftsim.com/avatar-seeded-packs/ (seeded pack has "on-color rares, a dual land, plenty of uncommons")
-# 15-card seeded pile matching the RTR/GTC/SNC seeded-prerelease norm: 10 common, 3 uncommon,
+# 14-card seeded pile (per WotC/retailer listings that state "a seeded character themed
+# booster full of 14 cards"): 9 common, 3 uncommon,
 # 1 in-color dual land, 1 rare/mythic -- all seeded to the character's color via the pack filter.
 # The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
 # year-stamped promo is a separate booster (tla-prerelease), added at the Prerelease Pack level.
 name: "Avatar: The Last Airbender Seeded Prerelease Pack Katara"
 filter: "e:tla id<=u is:baseset"
 pack:
-  common: 10
+  common: 9
   uncommon: 3
   land: 1
   rare_mythic: 1

--- a/data/boosters/tla-prerelease-toph.yaml
+++ b/data/boosters/tla-prerelease-toph.yaml
@@ -3,14 +3,15 @@
 # - https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide
 #   (character seed colors: Aang=White, Katara=Blue, Azula=Black, Zuko=Red, Toph=Green)
 # - https://draftsim.com/avatar-seeded-packs/ (seeded pack has "on-color rares, a dual land, plenty of uncommons")
-# 15-card seeded pile matching the RTR/GTC/SNC seeded-prerelease norm: 10 common, 3 uncommon,
+# 14-card seeded pile (per WotC/retailer listings that state "a seeded character themed
+# booster full of 14 cards"): 9 common, 3 uncommon,
 # 1 in-color dual land, 1 rare/mythic -- all seeded to the character's color via the pack filter.
 # The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
 # year-stamped promo is a separate booster (tla-prerelease), added at the Prerelease Pack level.
 name: "Avatar: The Last Airbender Seeded Prerelease Pack Toph"
 filter: "e:tla id<=g is:baseset"
 pack:
-  common: 10
+  common: 9
   uncommon: 3
   land: 1
   rare_mythic: 1

--- a/data/boosters/tla-prerelease-zuko.yaml
+++ b/data/boosters/tla-prerelease-zuko.yaml
@@ -3,14 +3,15 @@
 # - https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide
 #   (character seed colors: Aang=White, Katara=Blue, Azula=Black, Zuko=Red, Toph=Green)
 # - https://draftsim.com/avatar-seeded-packs/ (seeded pack has "on-color rares, a dual land, plenty of uncommons")
-# 15-card seeded pile matching the RTR/GTC/SNC seeded-prerelease norm: 10 common, 3 uncommon,
+# 14-card seeded pile (per WotC/retailer listings that state "a seeded character themed
+# booster full of 14 cards"): 9 common, 3 uncommon,
 # 1 in-color dual land, 1 rare/mythic -- all seeded to the character's color via the pack filter.
 # The rare_mythic slot inherits the shared sheet (rare:mythic = 2:1). The guaranteed foil
 # year-stamped promo is a separate booster (tla-prerelease), added at the Prerelease Pack level.
 name: "Avatar: The Last Airbender Seeded Prerelease Pack Zuko"
 filter: "e:tla id<=r is:baseset"
 pack:
-  common: 10
+  common: 9
   uncommon: 3
   land: 1
   rare_mythic: 1


### PR DESCRIPTION
Follow-up to the merged TLA seeded prerelease boosters (#519).

The seeded Character Booster is **14 cards, not 15**. Retailer listings state "a seeded character themed booster full of **14 cards**" ([Phoenix Comics & Games](https://shop.phoenixseattle.com/blogs/news/avatar-the-last-airbender-prerelease-information)), and the foil year-stamped promo is a separate loose card (per the [WotC guide](https://magic.wizards.com/en/news/feature/avatar-the-last-airbender-prerelease-guide)), so it is not part of that count.

The merged version drew 10 commons (15-card pack). This drops it to **9**, so each seeded booster is:
```
common: 9
uncommon: 3
land: 1
rare_mythic: 1   = 14 cards
```

Verified against the index: each pack now samples to exactly 14 cards, no `count:` warnings.

> Note: the companion sealed-content `card_count` was already set to 14 in mtgjson/mtg-sealed-content#455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)