### PR TITLE
Add Magic Origins seeded prerelease Boosters (Gideon/Jace/Liliana/Chandra/Nissa)

### DIFF
--- a/data/boosters/ori-prerelease-chandra.yaml
+++ b/data/boosters/ori-prerelease-chandra.yaml
@@ -1,0 +1,28 @@
+# Magic Origins -- seeded prerelease Booster (Chandra, Red).
+# Magic Origins prerelease kits were seeded by planeswalker color (Gideon=White,
+# Jace=Blue, Liliana=Black, Chandra=Red, Nissa=Green). The seeded booster is a small
+# 7-card mono-color pile -- 4 common + 2 uncommon -- plus the folded, color-stamped
+# foil year-stamped promo (a rare, or occasionally a mythic planeswalker), matching
+# community teardowns ("seven cards, all of the color of the box you chose", incl. the
+# stamped foil rare). Cards are strictly on-color (c:<color> id<=<color>: has the color,
+# no off-color splash, no colorless). Same folded, seed-colored model as the
+# Khans/Fate Reforged/Dragons of Tarkir seeded packs.
+name: "{set_name} Seeded Prerelease Booster Chandra"
+filter: "e:ori c:r id<=r is:baseset"
+pack:
+  common: 4
+  uncommon: 2
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 19
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pori r:m c:r id<=r promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pori r:r c:r id<=r promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ori-prerelease-gideon.yaml
+++ b/data/boosters/ori-prerelease-gideon.yaml
@@ -1,0 +1,28 @@
+# Magic Origins -- seeded prerelease Booster (Gideon, White).
+# Magic Origins prerelease kits were seeded by planeswalker color (Gideon=White,
+# Jace=Blue, Liliana=Black, Chandra=Red, Nissa=Green). The seeded booster is a small
+# 7-card mono-color pile -- 4 common + 2 uncommon -- plus the folded, color-stamped
+# foil year-stamped promo (a rare, or occasionally a mythic planeswalker), matching
+# community teardowns ("seven cards, all of the color of the box you chose", incl. the
+# stamped foil rare). Cards are strictly on-color (c:<color> id<=<color>: has the color,
+# no off-color splash, no colorless). Same folded, seed-colored model as the
+# Khans/Fate Reforged/Dragons of Tarkir seeded packs.
+name: "{set_name} Seeded Prerelease Booster Gideon"
+filter: "e:ori c:w id<=w is:baseset"
+pack:
+  common: 4
+  uncommon: 2
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 19
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pori r:m c:w id<=w promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pori r:r c:w id<=w promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ori-prerelease-jace.yaml
+++ b/data/boosters/ori-prerelease-jace.yaml
@@ -1,0 +1,28 @@
+# Magic Origins -- seeded prerelease Booster (Jace, Blue).
+# Magic Origins prerelease kits were seeded by planeswalker color (Gideon=White,
+# Jace=Blue, Liliana=Black, Chandra=Red, Nissa=Green). The seeded booster is a small
+# 7-card mono-color pile -- 4 common + 2 uncommon -- plus the folded, color-stamped
+# foil year-stamped promo (a rare, or occasionally a mythic planeswalker), matching
+# community teardowns ("seven cards, all of the color of the box you chose", incl. the
+# stamped foil rare). Cards are strictly on-color (c:<color> id<=<color>: has the color,
+# no off-color splash, no colorless). Same folded, seed-colored model as the
+# Khans/Fate Reforged/Dragons of Tarkir seeded packs.
+name: "{set_name} Seeded Prerelease Booster Jace"
+filter: "e:ori c:u id<=u is:baseset"
+pack:
+  common: 4
+  uncommon: 2
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 19
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pori r:m c:u id<=u promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pori r:r c:u id<=u promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ori-prerelease-liliana.yaml
+++ b/data/boosters/ori-prerelease-liliana.yaml
@@ -1,0 +1,28 @@
+# Magic Origins -- seeded prerelease Booster (Liliana, Black).
+# Magic Origins prerelease kits were seeded by planeswalker color (Gideon=White,
+# Jace=Blue, Liliana=Black, Chandra=Red, Nissa=Green). The seeded booster is a small
+# 7-card mono-color pile -- 4 common + 2 uncommon -- plus the folded, color-stamped
+# foil year-stamped promo (a rare, or occasionally a mythic planeswalker), matching
+# community teardowns ("seven cards, all of the color of the box you chose", incl. the
+# stamped foil rare). Cards are strictly on-color (c:<color> id<=<color>: has the color,
+# no off-color splash, no colorless). Same folded, seed-colored model as the
+# Khans/Fate Reforged/Dragons of Tarkir seeded packs.
+name: "{set_name} Seeded Prerelease Booster Liliana"
+filter: "e:ori c:b id<=b is:baseset"
+pack:
+  common: 4
+  uncommon: 2
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 19
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pori r:m c:b id<=b promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pori r:r c:b id<=b promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ori-prerelease-nissa.yaml
+++ b/data/boosters/ori-prerelease-nissa.yaml
@@ -1,0 +1,28 @@
+# Magic Origins -- seeded prerelease Booster (Nissa, Green).
+# Magic Origins prerelease kits were seeded by planeswalker color (Gideon=White,
+# Jace=Blue, Liliana=Black, Chandra=Red, Nissa=Green). The seeded booster is a small
+# 7-card mono-color pile -- 4 common + 2 uncommon -- plus the folded, color-stamped
+# foil year-stamped promo (a rare, or occasionally a mythic planeswalker), matching
+# community teardowns ("seven cards, all of the color of the box you chose", incl. the
+# stamped foil rare). Cards are strictly on-color (c:<color> id<=<color>: has the color,
+# no off-color splash, no colorless). Same folded, seed-colored model as the
+# Khans/Fate Reforged/Dragons of Tarkir seeded packs.
+name: "{set_name} Seeded Prerelease Booster Nissa"
+filter: "e:ori c:g id<=g is:baseset"
+pack:
+  common: 4
+  uncommon: 2
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 19
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pori r:m c:g id<=g promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pori r:r c:g id<=g promo:prerelease"
+      count: 7
+      rate: 2

--- a/data/boosters/ori-prerelease.yaml
+++ b/data/boosters/ori-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true


### PR DESCRIPTION
Adds the five planeswalker-seeded prerelease boosters for **Magic Origins** (ORI). (Modern Horizons 3 needs no engine change — `mh3-prerelease.yaml` already exists; its wiring is in the companion sealed-content PR.)

## Seeds (mono-color, by planeswalker)
| Planeswalker | Color |
|--------------|-------|
| Gideon   | White |
| Jace     | Blue  |
| Liliana  | Black |
| Chandra  | Red   |
| Nissa    | Green |

## Seeded booster (7 cards)
Community teardowns describe a 7-card mono-color pile including the stamped foil rare (e.g. an all-red Chandra pack: 1 rare + 2 uncommons + 4 commons):
```
common: 4
uncommon: 2
promo: 1   (foil; e:pori rare/mythic in-color, 2:1 rare:mythic)
```
Cards are filtered by **color** (`c:<color>`) so the pile is strictly on-color. Like the Khans/Fate Reforged/Dragons of Tarkir seeded packs (same 2014-15 era), the promo is **color-stamped** and folded into the seeded booster.

Verified against the index: each pack samples to exactly 7 cards with one on-color foil promo from `pori`, no `count:` warnings.

Also removes the now-orphaned generic `ori-prerelease.yaml` (bare any-color promo booster), superseded by the seeded packs.

Companion sealed-content wiring (MH3 + ORI): mtgjson/mtg-sealed-content#458

🤖 Generated with [Claude Code](https://claude.com/claude-code)