### PR TITLE
Add GRN/RNA/STX seeded prerelease Guild/College Boosters

### DIFF
--- a/data/boosters/grn-prerelease-boros.yaml
+++ b/data/boosters/grn-prerelease-boros.yaml
@@ -1,0 +1,24 @@
+# Guilds of Ravnica -- seeded prerelease Guild Booster (Boros).
+# Guilds of Ravnica prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Boros"
+filter: "e:grn id<=rw is:baseset (w:boros or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 32
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pgrn r:m (w:boros or (id<=rw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pgrn r:r (w:boros or (id<=rw and -w:*)) promo:prerelease"
+      count: 9
+      rate: 2

--- a/data/boosters/grn-prerelease-dimir.yaml
+++ b/data/boosters/grn-prerelease-dimir.yaml
@@ -1,0 +1,24 @@
+# Guilds of Ravnica -- seeded prerelease Guild Booster (Dimir).
+# Guilds of Ravnica prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Dimir"
+filter: "e:grn id<=ub is:baseset (w:dimir or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 34
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pgrn r:m (w:dimir or (id<=ub and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pgrn r:r (w:dimir or (id<=ub and -w:*)) promo:prerelease"
+      count: 8
+      rate: 2

--- a/data/boosters/grn-prerelease-golgari.yaml
+++ b/data/boosters/grn-prerelease-golgari.yaml
@@ -1,0 +1,24 @@
+# Guilds of Ravnica -- seeded prerelease Guild Booster (Golgari).
+# Guilds of Ravnica prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Golgari"
+filter: "e:grn id<=bg is:baseset (w:golgari or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 31
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pgrn r:m (w:golgari or (id<=bg and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pgrn r:r (w:golgari or (id<=bg and -w:*)) promo:prerelease"
+      count: 9
+      rate: 2

--- a/data/boosters/grn-prerelease-izzet.yaml
+++ b/data/boosters/grn-prerelease-izzet.yaml
@@ -1,0 +1,19 @@
+# Guilds of Ravnica -- seeded prerelease Guild Booster (Izzet).
+# Guilds of Ravnica prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Izzet"
+filter: "e:grn id<=ur is:baseset (w:izzet or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 31
+  promo:
+    foil: true
+    rawquery: "e:pgrn r:r (w:izzet or (id<=ur and -w:*)) promo:prerelease"
+    count: 8

--- a/data/boosters/grn-prerelease-selesnya.yaml
+++ b/data/boosters/grn-prerelease-selesnya.yaml
@@ -1,0 +1,24 @@
+# Guilds of Ravnica -- seeded prerelease Guild Booster (Selesnya).
+# Guilds of Ravnica prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Selesnya"
+filter: "e:grn id<=gw is:baseset (w:selesnya or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:pgrn r:m (w:selesnya or (id<=gw and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:pgrn r:r (w:selesnya or (id<=gw and -w:*)) promo:prerelease"
+      count: 9
+      rate: 2

--- a/data/boosters/grn-prerelease.yaml
+++ b/data/boosters/grn-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true

--- a/data/boosters/rna-prerelease-azorius.yaml
+++ b/data/boosters/rna-prerelease-azorius.yaml
@@ -1,0 +1,19 @@
+# Ravnica Allegiance -- seeded prerelease Guild Booster (Azorius).
+# Ravnica Allegiance prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Azorius"
+filter: "e:rna id<=wu is:baseset (w:azorius or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    rawquery: "e:prna r:r (w:azorius or (id<=wu and -w:*)) promo:prerelease"
+    count: 8

--- a/data/boosters/rna-prerelease-gruul.yaml
+++ b/data/boosters/rna-prerelease-gruul.yaml
@@ -1,0 +1,24 @@
+# Ravnica Allegiance -- seeded prerelease Guild Booster (Gruul).
+# Ravnica Allegiance prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Gruul"
+filter: "e:rna id<=rg is:baseset (w:gruul or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:prna r:m (w:gruul or (id<=rg and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:prna r:r (w:gruul or (id<=rg and -w:*)) promo:prerelease"
+      count: 9
+      rate: 2

--- a/data/boosters/rna-prerelease-orzhov.yaml
+++ b/data/boosters/rna-prerelease-orzhov.yaml
@@ -1,0 +1,24 @@
+# Ravnica Allegiance -- seeded prerelease Guild Booster (Orzhov).
+# Ravnica Allegiance prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Orzhov"
+filter: "e:rna id<=wb is:baseset (w:orzhov or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 32
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:prna r:m (w:orzhov or (id<=wb and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:prna r:r (w:orzhov or (id<=wb and -w:*)) promo:prerelease"
+      count: 8
+      rate: 2

--- a/data/boosters/rna-prerelease-rakdos.yaml
+++ b/data/boosters/rna-prerelease-rakdos.yaml
@@ -1,0 +1,24 @@
+# Ravnica Allegiance -- seeded prerelease Guild Booster (Rakdos).
+# Ravnica Allegiance prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Rakdos"
+filter: "e:rna id<=br is:baseset (w:rakdos or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:prna r:m (w:rakdos or (id<=br and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:prna r:r (w:rakdos or (id<=br and -w:*)) promo:prerelease"
+      count: 11
+      rate: 2

--- a/data/boosters/rna-prerelease-simic.yaml
+++ b/data/boosters/rna-prerelease-simic.yaml
@@ -1,0 +1,24 @@
+# Ravnica Allegiance -- seeded prerelease Guild Booster (Simic).
+# Ravnica Allegiance prerelease kits were seeded by guild: a ~15-card guild-colored pile
+# (11 common + 3 uncommon) plus the folded, guild-colored foil year-stamped promo
+# (2:1 rare:mythic). Seeded via the wedge/guild idiom -- cards in the guild's colors carrying
+# the guild watermark or no watermark, excluding generic colorless. Matches the RTR/GTC model.
+name: "{set_name} Seeded Prerelease Booster Simic"
+filter: "e:rna id<=gu is:baseset (w:simic or -w:*) -(c:c -w:*)"
+pack:
+  common: 11
+  uncommon: 3
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 33
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:prna r:m (w:simic or (id<=gu and -w:*)) promo:prerelease"
+      count: 1
+      rate: 1
+    - rawquery: "e:prna r:r (w:simic or (id<=gu and -w:*)) promo:prerelease"
+      count: 10
+      rate: 2

--- a/data/boosters/rna-prerelease.yaml
+++ b/data/boosters/rna-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true

--- a/data/boosters/stx-prerelease-lorehold.yaml
+++ b/data/boosters/stx-prerelease-lorehold.yaml
@@ -1,0 +1,23 @@
+# Strixhaven: School of Mages -- seeded prerelease College Booster (Lorehold).
+# STX prerelease kits were seeded by college. The College Booster is a 15-card
+# college-colored pile (10 common + 3 uncommon + 1 college-colored nonfoil rare/mythic)
+# plus a folded, ANY-color foil year-stamped promo. Modeled like Streets of New Capenna
+# (the next set): a seeded nonfoil rare_mythic slot AND a separate any-color prerelease_promo.
+# Seeded via the guild idiom -- cards in the college's colors carrying the college watermark
+# or no watermark, excluding generic colorless. The nonfoil rare slot and the promo both
+# use the shared rare_mythic weighting (2:1 rare:mythic).
+name: "{set_name} Seeded Prerelease Booster Lorehold"
+filter: "e:stx id<=rw is:baseset (w:lorehold or -w:*) -(c:c -w:*)"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  prerelease_promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 30
+  prerelease_promo:
+    filter: "e:pstx promo:prerelease"
+    use: rare_mythic
+    foil: true

--- a/data/boosters/stx-prerelease-prismari.yaml
+++ b/data/boosters/stx-prerelease-prismari.yaml
@@ -1,0 +1,23 @@
+# Strixhaven: School of Mages -- seeded prerelease College Booster (Prismari).
+# STX prerelease kits were seeded by college. The College Booster is a 15-card
+# college-colored pile (10 common + 3 uncommon + 1 college-colored nonfoil rare/mythic)
+# plus a folded, ANY-color foil year-stamped promo. Modeled like Streets of New Capenna
+# (the next set): a seeded nonfoil rare_mythic slot AND a separate any-color prerelease_promo.
+# Seeded via the guild idiom -- cards in the college's colors carrying the college watermark
+# or no watermark, excluding generic colorless. The nonfoil rare slot and the promo both
+# use the shared rare_mythic weighting (2:1 rare:mythic).
+name: "{set_name} Seeded Prerelease Booster Prismari"
+filter: "e:stx id<=ur is:baseset (w:prismari or -w:*) -(c:c -w:*)"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  prerelease_promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 29
+  prerelease_promo:
+    filter: "e:pstx promo:prerelease"
+    use: rare_mythic
+    foil: true

--- a/data/boosters/stx-prerelease-quandrix.yaml
+++ b/data/boosters/stx-prerelease-quandrix.yaml
@@ -1,0 +1,23 @@
+# Strixhaven: School of Mages -- seeded prerelease College Booster (Quandrix).
+# STX prerelease kits were seeded by college. The College Booster is a 15-card
+# college-colored pile (10 common + 3 uncommon + 1 college-colored nonfoil rare/mythic)
+# plus a folded, ANY-color foil year-stamped promo. Modeled like Streets of New Capenna
+# (the next set): a seeded nonfoil rare_mythic slot AND a separate any-color prerelease_promo.
+# Seeded via the guild idiom -- cards in the college's colors carrying the college watermark
+# or no watermark, excluding generic colorless. The nonfoil rare slot and the promo both
+# use the shared rare_mythic weighting (2:1 rare:mythic).
+name: "{set_name} Seeded Prerelease Booster Quandrix"
+filter: "e:stx id<=gu is:baseset (w:quandrix or -w:*) -(c:c -w:*)"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  prerelease_promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 29
+  prerelease_promo:
+    filter: "e:pstx promo:prerelease"
+    use: rare_mythic
+    foil: true

--- a/data/boosters/stx-prerelease-silverquill.yaml
+++ b/data/boosters/stx-prerelease-silverquill.yaml
@@ -1,0 +1,23 @@
+# Strixhaven: School of Mages -- seeded prerelease College Booster (Silverquill).
+# STX prerelease kits were seeded by college. The College Booster is a 15-card
+# college-colored pile (10 common + 3 uncommon + 1 college-colored nonfoil rare/mythic)
+# plus a folded, ANY-color foil year-stamped promo. Modeled like Streets of New Capenna
+# (the next set): a seeded nonfoil rare_mythic slot AND a separate any-color prerelease_promo.
+# Seeded via the guild idiom -- cards in the college's colors carrying the college watermark
+# or no watermark, excluding generic colorless. The nonfoil rare slot and the promo both
+# use the shared rare_mythic weighting (2:1 rare:mythic).
+name: "{set_name} Seeded Prerelease Booster Silverquill"
+filter: "e:stx id<=wb is:baseset (w:silverquill or -w:*) -(c:c -w:*)"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  prerelease_promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 30
+  prerelease_promo:
+    filter: "e:pstx promo:prerelease"
+    use: rare_mythic
+    foil: true

--- a/data/boosters/stx-prerelease-witherbloom.yaml
+++ b/data/boosters/stx-prerelease-witherbloom.yaml
@@ -1,0 +1,23 @@
+# Strixhaven: School of Mages -- seeded prerelease College Booster (Witherbloom).
+# STX prerelease kits were seeded by college. The College Booster is a 15-card
+# college-colored pile (10 common + 3 uncommon + 1 college-colored nonfoil rare/mythic)
+# plus a folded, ANY-color foil year-stamped promo. Modeled like Streets of New Capenna
+# (the next set): a seeded nonfoil rare_mythic slot AND a separate any-color prerelease_promo.
+# Seeded via the guild idiom -- cards in the college's colors carrying the college watermark
+# or no watermark, excluding generic colorless. The nonfoil rare slot and the promo both
+# use the shared rare_mythic weighting (2:1 rare:mythic).
+name: "{set_name} Seeded Prerelease Booster Witherbloom"
+filter: "e:stx id<=bg is:baseset (w:witherbloom or -w:*) -(c:c -w:*)"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  prerelease_promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 30
+  prerelease_promo:
+    filter: "e:pstx promo:prerelease"
+    use: rare_mythic
+    foil: true

--- a/data/boosters/stx-prerelease.yaml
+++ b/data/boosters/stx-prerelease.yaml
@@ -1,7 +1,0 @@
-pack:
-  prerelease_promo: 1
-sheets:
-  prerelease_promo:
-    filter: "e:p{set} promo:prerelease"
-    use: rare_mythic
-    foil: true


### PR DESCRIPTION
Adds the seeded prerelease boosters for **Guilds of Ravnica** (5 guilds), **Ravnica Allegiance** (5 guilds), and **Strixhaven: School of Mages** (5 colleges). Two distinct era models — determined from the promo-set color data + official prerelease specs:

## GRN / RNA — folded, guild-colored (like RTR/GTC/DTK)
```
common: 11
uncommon: 3
promo: 1   (foil; e:p<set> guild-colored rare/mythic, 2:1)
```
The `pgrn`/`prna` promo sets contain **only** guild color-pairs (zero colorless), confirming the promo is guild-colored. GRN Izzet and RNA Azorius have no guild mythic promo → rare-only.

## STX — SNC-style (seeded nonfoil rare + folded any-color promo)
```
common: 10
uncommon: 3
rare_mythic: 1        (nonfoil, college-colored)
prerelease_promo: 1   (foil, ANY color -- filter e:pstx, use: rare_mythic)
```
The `pstx` promo set **includes 6 colorless cards** → the stamped promo is any-color, and the official WPN spec lists the College Booster's R/M and the foil promo as separate items. Matches Streets of New Capenna (the next set).

All seeded via the guild idiom (`id<=<colors> is:baseset (w:<faction> or -w:*) -(c:c -w:*)`). Verified against the index: each pack samples to the right size (15 for GRN/RNA/STX) with exactly one foil, zero off-color nonfoil cards, no `count:` warnings. Removes the orphaned generic `grn/rna/stx-prerelease.yaml`.

Companion sealed-content wiring (incl. THB/M21/KHM/MH2): mtgjson/mtg-sealed-content#460

🤖 Generated with [Claude Code](https://claude.com/claude-code)