### PR TITLE
Fix LTR prerelease booster dropping The Shire (pltr 260s)

### DIFF
--- a/data/boosters/ltr-prerelease.yaml
+++ b/data/boosters/ltr-prerelease.yaml
@@ -9,7 +9,9 @@ sheets:
     filter: "e:pltr number<261"
     foil: true
     use: rare_mythic
+    count: 60 + 20 # rares + mythics
   party_scene_promo:
     foil: true
     filter: "e:pltr number:399-404"
     use: base_1248_by_rarity
+    count: 6

--- a/data/boosters/ltr-prerelease.yaml
+++ b/data/boosters/ltr-prerelease.yaml
@@ -4,7 +4,9 @@ pack:
   party_scene_promo: 1
 sheets:
   prerelease_promo:
-    filter: "e:pltr number<=260"
+    # number<261 (not <=260): the stamped promos are suffixed "s" (e.g. 260s),
+    # and "260s" sorts after bare "260", so number<=260 drops The Shire (pltr 260s).
+    filter: "e:pltr number<261"
     foil: true
     use: rare_mythic
   party_scene_promo:


### PR DESCRIPTION
The LTR `prerelease_promo` sheet filtered on `e:pltr number<=260`. The stamped prerelease promos carry an `s` suffix (e.g. `260s`), and `"260s"` sorts **after** bare `"260"`, so `number<=260` silently excluded **The Shire** (`pltr 260s`) — the pool was **79** rares/mythics instead of **80**.

Fix: `number<261`, which includes `260s`. Verified: the sheet pool goes 79 → 80 with The Shire present; the party-scene sheet is unaffected (6).

### Why it matters
This propagated downstream: the 79-card `prereleasePromo` sheet in the mtgjson export (`experimental_export_for_mtgjson.json`) left The Shire's stamped promo unmapped to any product — it shows as productless on mtgban. With this fix it's 80/80.

(Only `260s` was affected — every other stamped promo is numbered well below 260, so the suffix never mattered at the boundary.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)