### PR TITLE
MBS: add Mirran and Phyrexian faction boosters

### DIFF
--- a/data/boosters/mbs-mirran.yaml
+++ b/data/boosters/mbs-mirran.yaml
@@ -1,0 +1,32 @@
+# Mirrodin Besieged Mirran faction booster. Cards with a Mirran watermark appear
+# only in Mirran packs (Phyrexian-watermarked cards only in Phyrexian packs);
+# neutral cards -- Tezzeret, Agent of Bolas and the basic lands -- appear in
+# both, so the non-foil slots use "-w:phyrexian" (own faction + neutrals).
+# Foils are unrestricted: a foil of either faction can appear in either pack, so
+# the foil slot keeps the default unfiltered foil sheet.
+# Source: https://mtg.fandom.com/wiki/Mirrodin_Besieged
+name: "{set_name} Mirran Faction Booster"
+pack:
+- basic: 1
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  chance: 31
+- basic: 1
+  common: 9
+  uncommon: 3
+  rare_mythic: 1
+  foil: 1
+  chance: 9
+sheets:
+  common:
+    balanced: true
+    query: "r:c -w:phyrexian"
+  uncommon:
+    query: "r:u -w:phyrexian"
+  rare_mythic:
+    any:
+    - query: "r:r -w:phyrexian"
+      rate: 2
+    - query: "r:m -w:phyrexian"
+      rate: 1

--- a/data/boosters/mbs-phyrexian.yaml
+++ b/data/boosters/mbs-phyrexian.yaml
@@ -1,0 +1,32 @@
+# Mirrodin Besieged Phyrexian faction booster. Cards with a Phyrexian watermark
+# appear only in Phyrexian packs (Mirran-watermarked cards only in Mirran packs);
+# neutral cards -- Tezzeret, Agent of Bolas and the basic lands -- appear in
+# both, so the non-foil slots use "-w:mirran" (own faction + neutrals).
+# Foils are unrestricted: a foil of either faction can appear in either pack, so
+# the foil slot keeps the default unfiltered foil sheet.
+# Source: https://mtg.fandom.com/wiki/Mirrodin_Besieged
+name: "{set_name} Phyrexian Faction Booster"
+pack:
+- basic: 1
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  chance: 31
+- basic: 1
+  common: 9
+  uncommon: 3
+  rare_mythic: 1
+  foil: 1
+  chance: 9
+sheets:
+  common:
+    balanced: true
+    query: "r:c -w:mirran"
+  uncommon:
+    query: "r:u -w:mirran"
+  rare_mythic:
+    any:
+    - query: "r:r -w:mirran"
+      rate: 2
+    - query: "r:m -w:mirran"
+      rate: 1


### PR DESCRIPTION
Mirrodin Besieged boosters shipped in two faction varieties, which weren't modeled (mtg-sealed-content has the products but with empty contents). Adds `mbs-mirran` and `mbs-phyrexian`.

Per the [set's faction rules](https://mtg.fandom.com/wiki/Mirrodin_Besieged): **Mirran-watermarked cards appear only in Mirran packs, Phyrexian only in Phyrexian packs**, and **neutral cards (Tezzeret, Agent of Bolas + basic lands) appear in both**. **Foils are unrestricted** — a foil of either faction can appear in either pack — so the foil slot keeps the default sheet.

Structure mirrors the draft booster (1 basic + 10 common + 3 uncommon + 1 rare/mythic; foil replaces a common 9/40). The non-foil slots filter by `-w:<enemy faction>` (= own faction + neutrals), which cleanly puts the neutral Tezzeret in both packs' mythic pools.

Verified against the card database:

| pool | Mirran | Phyrexian |
|---|---|---|
| common | 30 | 30 |
| uncommon | 20 | 20 |
| rare | 18 | 17 |
| mythic | 5 (incl. Tezzeret) | 6 (incl. Tezzeret) |

All eight pool queries returned the expected counts and Tezzeret resolves into both mythic slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)