### PR TITLE
BLB: add Bloomburrow Value Booster

### DIFF
--- a/data/boosters/blb-value.yaml
+++ b/data/boosters/blb-value.yaml
@@ -1,0 +1,90 @@
+# Bloomburrow Value Booster.
+# https://magic.wizards.com/en/news/announcements/what-is-a-bloomburrow-value-booster
+# 7 cards: 3 commons, 2 uncommons, 1 wildcard of any rarity, and 1 slot that is
+# "a land, a traditional foil, or a Special Guests card".
+# The announcement gives no drop rates. The commons, uncommons, wildcard and
+# foil reuse the Play booster's sheets. The final slot's land : foil : Special
+# Guests split is undocumented; modeled here as 600 : 385 : 15 (land 60%, foil
+# 38.5%, SPG 1.5% -- the SPG rate matching the Play booster's List slot).
+name: "{set_name} Value Booster"
+pack:
+  common: 3
+  uncommon: 2
+  wildcard: 1
+  bonus:
+  - land: 1
+    chance: 600
+  - foil: 1
+    chance: 385
+  - the_list: 1
+    chance: 15
+sheets:
+  common:
+    query: "r:c"
+    count: 81
+  land:
+    any:
+    - query: "number:262,266,270,274,278"
+      count: 5
+      chance: 4
+    - query: "number:263,267,271,275,279"
+      count: 5
+      chance: 3
+    - query: "number:264,268,272,276,280"
+      count: 5
+      chance: 2
+    - query: "number:265,269,273,277,281"
+      count: 5
+      chance: 1
+  mythic_with_showcase:
+    # Showcase treatments 1/3 for relevant cards
+    any:
+    - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper (Lumra)"
+      count: 2
+      rate: 1
+    - rawquery: "e:{set} r:m promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Lumra)"
+      count: 19
+      rate: 2
+    - use: mythic_has_showcase
+      rate: 4
+    - use: mythic_has_no_showcase
+      rate: 6
+  rare_with_showcase:
+    # Showcase treatments 1/3 for relevant cards
+    any:
+    - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper (Three Tree City)"
+      count: 4
+      rate: 1
+    - rawquery: "e:{set} r:r promo:boosterfun -is:foilonly -frame:extendedart is:paper -(Three Tree City)"
+      count: 36
+      rate: 4
+    - use: rare_has_showcase
+      rate: 8
+    - use: rare_has_no_showcase
+      rate: 12
+  rare_mythic_with_showcase:
+    any:
+    - use: rare_with_showcase
+      chance: 6
+    - use: mythic_with_showcase
+      chance: 1
+  wildcard:
+    any:
+    - chance: 700
+      use: common
+    - chance: 175
+      use: uncommon
+    - chance: 125
+      use: rare_mythic_with_showcase
+  foil:
+    foil: true
+    any:
+    - chance: 12
+      use: common
+    - chance: 5
+      use: uncommon
+    - chance: 3
+      use: rare_mythic_with_showcase
+  the_list:
+    set: spg
+    code: "BLB"

--- a/data/boosters/blb-value.yaml
+++ b/data/boosters/blb-value.yaml
@@ -16,7 +16,7 @@ pack:
     chance: 600
   - foil: 1
     chance: 385
-  - the_list: 1
+  - special_guest: 1
     chance: 15
 sheets:
   common:
@@ -85,6 +85,6 @@ sheets:
       use: uncommon
     - chance: 3
       use: rare_mythic_with_showcase
-  the_list:
+  special_guest:
     set: spg
     code: "BLB"


### PR DESCRIPTION
Models the [Bloomburrow Value Booster](https://magic.wizards.com/en/news/announcements/what-is-a-bloomburrow-value-booster) (sealed-content has the product with empty contents; it's in status.txt as `blb - Bloomburrow Value Booster missing contents`).

**7 cards:** 3 commons · 2 uncommons · 1 wildcard of any rarity · 1 slot that is *a land, a traditional foil, or a Special Guests card*.

Commons, uncommons, wildcard, foil, land and SPG all reuse the existing `blb-play` sheets (so showcase treatments, the Lumra/Three Tree City rates, and the SPG list carry over unchanged).

**Assumption (flagged):** the announcement gives no drop rates, and the final slot's land : foil : Special Guests split is undocumented. Modeled as **600 : 385 : 15** — land 60%, foil 38.5%, SPG 1.5%, with the SPG rate matching the Play booster's List slot. Easy to retune if better data surfaces; this is the first Value Booster in the repo.

Verified end-to-end: E[cards]/pack = **7.0**, E[foil] = **0.385**, E[SPG] = **0.015**, E[nonfoil land] = **0.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)