### PR TITLE
BLB: rename play booster SPG sheet the_list -> special_guest

### DIFF
--- a/data/boosters/blb-play.yaml
+++ b/data/boosters/blb-play.yaml
@@ -9,7 +9,7 @@ pack:
   - common: 7
     chance: 985
   - common: 6
-    the_list: 1
+    special_guest: 1
     chance: 15
   uncommon: 3
   rare_mythic_with_showcase: 1
@@ -85,6 +85,6 @@ sheets:
       use: uncommon
     - chance: 3
       use: rare_mythic_with_showcase
-  the_list:
+  special_guest:
     set: spg
     code: "BLB"


### PR DESCRIPTION
Bloomburrow's List slot holds **Special Guests** (`set: spg`), a distinct product from **The List** (`plst`). Every post-Bloomburrow Play booster already names this sheet `special_guest` (`dsk`, `fdn`, `dft`, `tdm`, `eoe`, `ecl`, `sos`, `mh3`); `blb-play` was the last Bloomburrow-onward file still calling it `the_list`.

Renames the sheet and its pack reference. Purely cosmetic — verified the build is unchanged (14 cards/pack, SPG rate 1.5%).

Pre-Bloomburrow sets keep `the_list` since theirs genuinely point at The List (`plst`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)