### PR TITLE
M15: add seeded prerelease boosters (Hunt for the Rarest Beasts)

### DIFF
--- a/data/boosters/m15-prerelease-ambition.yaml
+++ b/data/boosters/m15-prerelease-ambition.yaml
@@ -1,0 +1,25 @@
+# Magic 2015 "Hunt for the Rarest Beasts" seeded prerelease pack -- Hunt with Ambition (Black).
+# 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the path's
+# color (id<=b), plus the guaranteed stamped foil prerelease promo (Indulgent Tormentor).
+# Modeled on the Theros "Hero's Path" seeded prereleases (same era, same mechanic).
+name: "{set_name} Seeded Prerelease Booster Ambition"
+filter: "e:m15 id<=b is:baseset"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 25
+  uncommon:
+    query: "r:u"
+    count: 27
+  rare_mythic:
+    rawquery: "e:m15 (r:r or r:m) id<=b is:baseset"
+    count: 21
+  promo:
+    foil: true
+    rawquery: "e:pm15 promo:prerelease id<=b"
+    count: 1

--- a/data/boosters/m15-prerelease-ferocity.yaml
+++ b/data/boosters/m15-prerelease-ferocity.yaml
@@ -1,0 +1,25 @@
+# Magic 2015 "Hunt for the Rarest Beasts" seeded prerelease pack -- Hunt with Ferocity (Green).
+# 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the path's
+# color (id<=g), plus the guaranteed stamped foil prerelease promo (Phytotitan).
+# Modeled on the Theros "Hero's Path" seeded prereleases (same era, same mechanic).
+name: "{set_name} Seeded Prerelease Booster Ferocity"
+filter: "e:m15 id<=g is:baseset"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 25
+  uncommon:
+    query: "r:u"
+    count: 27
+  rare_mythic:
+    rawquery: "e:m15 (r:r or r:m) id<=g is:baseset"
+    count: 22
+  promo:
+    foil: true
+    rawquery: "e:pm15 promo:prerelease id<=g"
+    count: 1

--- a/data/boosters/m15-prerelease-guile.yaml
+++ b/data/boosters/m15-prerelease-guile.yaml
@@ -1,0 +1,25 @@
+# Magic 2015 "Hunt for the Rarest Beasts" seeded prerelease pack -- Hunt with Guile (Blue).
+# 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the path's
+# color (id<=u), plus the guaranteed stamped foil prerelease promo (Mercurial Pretender).
+# Modeled on the Theros "Hero's Path" seeded prereleases (same era, same mechanic).
+name: "{set_name} Seeded Prerelease Booster Guile"
+filter: "e:m15 id<=u is:baseset"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 25
+  uncommon:
+    query: "r:u"
+    count: 27
+  rare_mythic:
+    rawquery: "e:m15 (r:r or r:m) id<=u is:baseset"
+    count: 22
+  promo:
+    foil: true
+    rawquery: "e:pm15 promo:prerelease id<=u"
+    count: 1

--- a/data/boosters/m15-prerelease-strength.yaml
+++ b/data/boosters/m15-prerelease-strength.yaml
@@ -1,0 +1,25 @@
+# Magic 2015 "Hunt for the Rarest Beasts" seeded prerelease pack -- Hunt with Strength (Red).
+# 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the path's
+# color (id<=r), plus the guaranteed stamped foil prerelease promo (Siege Dragon).
+# Modeled on the Theros "Hero's Path" seeded prereleases (same era, same mechanic).
+name: "{set_name} Seeded Prerelease Booster Strength"
+filter: "e:m15 id<=r is:baseset"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 25
+  uncommon:
+    query: "r:u"
+    count: 27
+  rare_mythic:
+    rawquery: "e:m15 (r:r or r:m) id<=r is:baseset"
+    count: 22
+  promo:
+    foil: true
+    rawquery: "e:pm15 promo:prerelease id<=r"
+    count: 1

--- a/data/boosters/m15-prerelease-valor.yaml
+++ b/data/boosters/m15-prerelease-valor.yaml
@@ -1,0 +1,25 @@
+# Magic 2015 "Hunt for the Rarest Beasts" seeded prerelease pack -- Hunt with Valor (White).
+# 15-card seeded booster: 10 common + 3 uncommon + 1 rare/mythic favoring the path's
+# color (id<=w), plus the guaranteed stamped foil prerelease promo (Resolute Archangel).
+# Modeled on the Theros "Hero's Path" seeded prereleases (same era, same mechanic).
+name: "{set_name} Seeded Prerelease Booster Valor"
+filter: "e:m15 id<=w is:baseset"
+pack:
+  common: 10
+  uncommon: 3
+  rare_mythic: 1
+  promo: 1
+sheets:
+  common:
+    query: "r:c"
+    count: 25
+  uncommon:
+    query: "r:u"
+    count: 27
+  rare_mythic:
+    rawquery: "e:m15 (r:r or r:m) id<=w is:baseset"
+    count: 22
+  promo:
+    foil: true
+    rawquery: "e:pm15 promo:prerelease id<=w"
+    count: 1


### PR DESCRIPTION
Magic 2015's prerelease used five color-themed **Hunt** paths, each a seeded booster favoring the path's color plus a guaranteed stamped foil prerelease promo. These weren't modeled (mtg-sealed-content has the five products with empty contents). Adds the five seeded boosters.

Modeled on the Theros `prerelease-<path>` seeded prereleases — same era and mechanic. M15 cards carry no watermarks, so seeding is by **color identity** (`id<=color`):

| Hunt | Color | Foil promo |
|---|---|---|
| Ambition | Black | Indulgent Tormentor |
| Ferocity | Green | Phytotitan |
| Guile | Blue | Mercurial Pretender |
| Strength | Red | Siege Dragon |
| Valor | White | Resolute Archangel |

Each pack: 10 common + 3 uncommon + 1 rare/mythic (`id<=color`) + 1 foil promo (`e:pm15 promo:prerelease id<=color`) = **15 cards**.

Verified against the card data: all five build to 15 cards with P(promo)=1.0 resolving to the correct color-matched card, no count warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)