### PR TITLE
Add SLD Zippy Zombies bonus boosters (2025, per wave)

### DIFF
--- a/data/boosters/sld-zippy-zombies-feb.yaml
+++ b/data/boosters/sld-zippy-zombies-feb.yaml
@@ -1,0 +1,55 @@
+# Secret Lair "Zippy Zombies" bonus pool -- February 2025 wave.
+# The 2025 Secret Lair drops came with a random foil retro-frame Zombie bonus
+# card; the pool grew with each superdrop wave (wave membership from mtgjson
+# per-card release dates, matching Scryfall's "Zippy Zombies" grouping).
+# Drop rates estimated from foil price differences within the pool
+# (inverse-price, chase card normalized to 1).
+name: "SLD Zippy Zombies (February 2025)"
+pack:
+  zombies: 1
+sheets:
+  zombies:
+    foil: true
+    any:
+    - rawquery: "e:sld number:858" # Diregraf Captain
+      count: 1
+      chance: 81
+    - rawquery: "e:sld number:838" # Corpse Connoisseur
+      count: 1
+      chance: 59
+    - rawquery: "e:sld number:849" # Ravenous Rotbelly
+      count: 1
+      chance: 51
+    - rawquery: "e:sld number:837" # Champion of the Perished
+      count: 1
+      chance: 47
+    - rawquery: "e:sld number:841" # Fleshbag Marauder
+      count: 1
+      chance: 32
+    - rawquery: "e:sld number:840" # Diregraf Colossus
+      count: 1
+      chance: 16
+    - rawquery: "e:sld number:848" # Pontiff of Blight
+      count: 1
+      chance: 13
+    - rawquery: "e:sld number:856" # Vindictive Lich
+      count: 1
+      chance: 12
+    - rawquery: "e:sld number:843" # Haakon, Stromgald Scourge
+      count: 1
+      chance: 11
+    - rawquery: "e:sld number:842" # Geralf's Messenger
+      count: 1
+      chance: 10
+    - rawquery: "e:sld number:850" # Relentless Dead
+      count: 1
+      chance: 6
+    - rawquery: "e:sld number:860" # Nekusar, the Mindrazer
+      count: 1
+      chance: 4
+    - rawquery: "e:sld number:844" # Headless Rider
+      count: 1
+      chance: 4
+    - rawquery: "e:sld number:862" # Wilhelt, the Rotcleaver
+      count: 1
+      chance: 1

--- a/data/boosters/sld-zippy-zombies-jun.yaml
+++ b/data/boosters/sld-zippy-zombies-jun.yaml
@@ -1,0 +1,28 @@
+# Secret Lair "Zippy Zombies" bonus pool -- June 2025 wave.
+# The 2025 Secret Lair drops came with a random foil retro-frame Zombie bonus
+# card; the pool grew with each superdrop wave (wave membership from mtgjson
+# per-card release dates, matching Scryfall's "Zippy Zombies" grouping).
+# Drop rates estimated from foil price differences within the pool
+# (inverse-price, chase card normalized to 1).
+name: "SLD Zippy Zombies (June 2025)"
+pack:
+  zombies: 1
+sheets:
+  zombies:
+    foil: true
+    any:
+    - rawquery: "e:sld number:857" # Neheb, Dreadhorde Champion
+      count: 1
+      chance: 43
+    - rawquery: "e:sld number:853" # Stitcher's Supplier
+      count: 1
+      chance: 19
+    - rawquery: "e:sld number:834" # Cleaver Skaab
+      count: 1
+      chance: 19
+    - rawquery: "e:sld number:847" # Phyrexian Crusader
+      count: 1
+      chance: 7
+    - rawquery: "e:sld number:851" # Rot Hulk
+      count: 1
+      chance: 1

--- a/data/boosters/sld-zippy-zombies-mar.yaml
+++ b/data/boosters/sld-zippy-zombies-mar.yaml
@@ -1,0 +1,28 @@
+# Secret Lair "Zippy Zombies" bonus pool -- March 2025 wave.
+# The 2025 Secret Lair drops came with a random foil retro-frame Zombie bonus
+# card; the pool grew with each superdrop wave (wave membership from mtgjson
+# per-card release dates, matching Scryfall's "Zippy Zombies" grouping).
+# Drop rates estimated from foil price differences within the pool
+# (inverse-price, chase card normalized to 1).
+name: "SLD Zippy Zombies (March 2025)"
+pack:
+  zombies: 1
+sheets:
+  zombies:
+    foil: true
+    any:
+    - rawquery: "e:sld number:845" # Liliana's Standard Bearer
+      count: 1
+      chance: 22
+    - rawquery: "e:sld number:839" # Cryptbreaker
+      count: 1
+      chance: 7
+    - rawquery: "e:sld number:854" # Tomb Tyrant
+      count: 1
+      chance: 6
+    - rawquery: "e:sld number:855" # Tormod, the Desecrator
+      count: 1
+      chance: 2
+    - rawquery: "e:sld number:861" # Varina, Lich Queen
+      count: 1
+      chance: 1

--- a/data/boosters/sld-zippy-zombies-may.yaml
+++ b/data/boosters/sld-zippy-zombies-may.yaml
@@ -1,0 +1,28 @@
+# Secret Lair "Zippy Zombies" bonus pool -- May 2025 wave.
+# The 2025 Secret Lair drops came with a random foil retro-frame Zombie bonus
+# card; the pool grew with each superdrop wave (wave membership from mtgjson
+# per-card release dates, matching Scryfall's "Zippy Zombies" grouping).
+# Drop rates estimated from foil price differences within the pool
+# (inverse-price, chase card normalized to 1).
+name: "SLD Zippy Zombies (May 2025)"
+pack:
+  zombies: 1
+sheets:
+  zombies:
+    foil: true
+    any:
+    - rawquery: "e:sld number:859" # Havengul Lich
+      count: 1
+      chance: 90
+    - rawquery: "e:sld number:852" # Rotting Regisaur
+      count: 1
+      chance: 67
+    - rawquery: "e:sld number:835" # Fatestitcher
+      count: 1
+      chance: 50
+    - rawquery: "e:sld number:836" # Undead Alchemist
+      count: 1
+      chance: 30
+    - rawquery: "e:sld number:846" # Mikaeus, the Unhallowed
+      count: 1
+      chance: 1


### PR DESCRIPTION
The 2025 Secret Lair drops came with a random foil retro-frame Zombie bonus card — [Scryfall's "Zippy Zombies" group](https://scryfall.com/sets/sld) (29 cards, SLD 834–862). The pool grew with each superdrop wave, so this adds one booster per wave, with membership derived from mtgjson per-card release dates:

| Booster | Pool |
|---|---|
| `sld-zippy-zombies-feb` | 14 zombies (Feb waves) |
| `sld-zippy-zombies-mar` | 5 — Cryptbreaker, Liliana's Standard Bearer, Tomb Tyrant, Tormod, Varina |
| `sld-zippy-zombies-may` | 5 — Fatestitcher, Undead Alchemist, Mikaeus, Rotting Regisaur, Havengul Lich |
| `sld-zippy-zombies-jun` | 5 — Cleaver Skaab, Phyrexian Crusader, Rot Hulk, Stitcher's Supplier, Neheb |

Drop rates are estimated from foil price differences within each pool (inverse-price, chase normalized to 1) — each wave has a clear chase: Wilhelt (Feb ~0.3%), Varina (Mar ~2.6%), Mikaeus (May ~0.4%), Rot Hulk (Jun ~1.1%).

Verified against the index: each pack yields exactly 1 foil card and covers its full pool at the expected rates.

Referenced by the mtg-sealed-content SLD products (`pack: [code: zippy-zombies-<wave>]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)