### PR TITLE
MBS: don't color-balance faction common sheets

### DIFF
--- a/data/boosters/mbs-mirran.yaml
+++ b/data/boosters/mbs-mirran.yaml
@@ -20,7 +20,8 @@ pack:
   chance: 9
 sheets:
   common:
-    balanced: true
+    # Not color-balanced: a single faction's commons don't span all five colors,
+    # so ColorBalancedCardSheet can't be constructed over this filtered pool.
     query: "r:c -w:phyrexian"
   uncommon:
     query: "r:u -w:phyrexian"

--- a/data/boosters/mbs-phyrexian.yaml
+++ b/data/boosters/mbs-phyrexian.yaml
@@ -20,7 +20,8 @@ pack:
   chance: 9
 sheets:
   common:
-    balanced: true
+    # Not color-balanced: a single faction's commons don't span all five colors,
+    # so ColorBalancedCardSheet can't be constructed over this filtered pool.
     query: "r:c -w:mirran"
   uncommon:
     query: "r:u -w:mirran"


### PR DESCRIPTION
The Mirran and Phyrexian faction boosters (added in #526) mark their `common` sheet `balanced: true` over a **faction-filtered** pool (`-w:mirran` / `-w:phyrexian`). But a single faction's commons don't span all five colors:

| | W | U | B | R | G | colorless |
|---|---|---|---|---|---|---|
| Phyrexian pack (`-w:mirran`) | 3 | 5 | 9 | **0** | 6 | 7 |
| Mirran pack (`-w:phyrexian`) | 6 | 4 | **0** | 9 | 3 | 8 |

`ColorBalancedCardSheet` can't be constructed when a color is empty, so both boosters raised **"some colors don't have any cards, this sheet cannot be constructed"** at build time.

This drops `balanced: true` from the `common` sheet in both files (with an explanatory comment). The slot now draws commons from the faction pool without color balancing — the uncommon/rare/mythic sheets were never balanced and are unchanged.

Verified: both boosters now build (`mbs-mirran` → *Mirrodin Besieged Mirran Faction Booster*, `mbs-phyrexian` → *…Phyrexian…*).