### PR TITLE
SLD: price-weight the June Handsome Humans bonus pool

### DIFF
--- a/data/boosters/sld-handsome-humans-jun.yaml
+++ b/data/boosters/sld-handsome-humans-jun.yaml
@@ -2,8 +2,8 @@
 # The 2026 Secret Lair drops without a drop-exclusive bonus come with a random
 # foil retro-frame Human (Scryfall's "Handsome Humans" grouping); like the 2025
 # Zippy Zombies, each wave has its own pool. This is the June wave (5 Humans).
-# No market prices yet for these printings, so the pool is equal-weighted --
-# revisit the drop rates once price data exists.
+# Drop rates estimated from foil price differences within the pool
+# (inverse-price, chase normalized to 1) -- Serra Ascendant is the chase.
 name: "SLD Handsome Humans (June 2026)"
 pack:
   humans: 1
@@ -11,18 +11,18 @@ sheets:
   humans:
     foil: true
     any:
-    - rawquery: "e:sld number:7135" # Darien, King of Kjeldor
-      count: 1
-      chance: 1
-    - rawquery: "e:sld number:7138" # Glowrider
-      count: 1
-      chance: 1
     - rawquery: "e:sld number:7139" # Knight of the White Orchid
       count: 1
-      chance: 1
-    - rawquery: "e:sld number:7145" # Serra Ascendant
+      chance: 73
+    - rawquery: "e:sld number:7138" # Glowrider
       count: 1
-      chance: 1
+      chance: 56
+    - rawquery: "e:sld number:7135" # Darien, King of Kjeldor
+      count: 1
+      chance: 22
     - rawquery: "e:sld number:7152" # General's Enforcer
+      count: 1
+      chance: 11
+    - rawquery: "e:sld number:7145" # Serra Ascendant
       count: 1
       chance: 1


### PR DESCRIPTION
Follow-up to #536. The June "Handsome Humans" wave shipped **equal-weighted** because there were no foil market prices for those printings yet. Now that prices exist, weight the pool by **inverse price** (chase normalized to 1), matching how the other bonus pools are rated:

| # | Card | chance |
|---|---|---|
| 7139 | Knight of the White Orchid | 73 |
| 7138 | Glowrider | 56 |
| 7135 | Darien, King of Kjeldor | 22 |
| 7152 | General's Enforcer | 11 |
| 7145 | Serra Ascendant (chase) | 1 |

Cheaper = more common, chase = rarest. YAML validates; all five collector numbers verified against the card data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)