### PR TITLE
patch_xmage: stop flagging accented cards (e.g. Ratonhnhakéton) as typos

### DIFF
--- a/indexer/lib/patches/patch_xmage.rb
+++ b/indexer/lib/patches/patch_xmage.rb
@@ -9,12 +9,17 @@ class PatchXmage < Patch
         .readlines
         .map(&:chomp)
         .map{|line| line.split("\t",3)[0,2]}
+        .map{|set, name| [set, strip_accents(name)] }
         .to_set
     end
   end
 
+  # Decompose to NFD and drop the combining marks, so any diacritic is stripped
+  # (the old hand-maintained tr list missed some, e.g. ï). Both the card names
+  # and the XMage names are run through this, so accented cards match instead of
+  # being reported as typos.
   def strip_accents(str)
-    str.tr("äàáââééíöóûûúÉ", "aaaaaeeioouuuE")
+    str.unicode_normalize(:nfd).gsub(/\p{Mn}/, "")
   end
 
   def card_names(card)


### PR DESCRIPTION
Part of #495 — the "Likely typo or spoiler card in XMage card list" warnings.

**Cause:** `PatchXmage` runs the mtgjson card names through `strip_accents` but keeps the XMage names raw. So a card whose name has a diacritic — `Ratonhnhakéton` (acr) — is compared as `Ratonhnhaketon` (card, stripped) vs `Ratonhnhakéton` (XMage, raw), never matches, and gets reported as a typo.

**Fix:**
- Strip the XMage names too, so both sides are normalized consistently.
- Replace the hand-maintained `tr("äàá…","aaa…")` list with `unicode_normalize(:nfd).gsub(/\p{Mn}/, "")`, which strips *any* combining diacritic (the old list also missed some, e.g. `ï` → `Ghïtu`/`Ghitu`).

**Verified** against the current index + `xmage_cards.txt`: `Ratonhnhakéton` now matches in `acr` and is no longer reported. The only remaining "typo" reports are the genuine XMage-only spoiler/playtest sets (`atc`, `calc`), which have no mtgjson counterpart.