### PR TITLE
vow-set: add the four Commander-deck commanders to the wildcard slot

### DIFF
--- a/data/boosters/vow-set.yaml
+++ b/data/boosters/vow-set.yaml
@@ -62,17 +62,25 @@ sheets:
           count: 12
           rate: 3
         chance: 20
-      # Only the 8 new-to-Commander cards designed for Set Boosters appear
-      # here (VOC #31-38: 6 rares + 2 mythics -- the Soulbonders cycle,
-      # Hollowhenge Overlord, Wedding Ring, Umbris). The rest of VOC (the
-      # Commander-deck cards) are NOT in Set Boosters. Per-card weight kept
-      # at rare 2 : mythic 1, matching the main-set R/M tier.
+      # Two groups of Commander cards show up in this slot. First, the 8
+      # new-to-Commander cards designed for Set Boosters (VOC #31-38: 6 rares
+      # + 2 mythics -- the Soulbonders cycle, Hollowhenge Overlord, Wedding
+      # Ring, Umbris); these are not in the Commander decks at all.
       - rawquery: "e:voc number:31-38 r:r"
         count: 6
         chance: 6*2
       - rawquery: "e:voc number:31-38 r:m"
         count: 2
         chance: 2
+      # Second, the four Commander-deck face commanders (VOC #1-4, all mythic),
+      # which the decks include in traditional foil: "Set Boosters also have
+      # the four traditional foil cards from the Commander decks available in
+      # the wildcard slot in a non-foil version." This sheet is non-foil, so
+      # the query resolves to exactly those non-foil printings.
+      # Per-card weight kept at rare 2 : mythic 1, matching the main-set R/M tier.
+      - rawquery: "e:voc number:1-4"
+        count: 4
+        chance: 4
       chance: 125
   the_list:
     any:


### PR DESCRIPTION
The *Innistrad: Crimson Vow* Set Booster wildcard slot only listed the 8 new-to-Commander cards (VOC #31–38), with a comment asserting that the rest of VOC was **not** in Set Boosters. The collecting article contradicts that:

> "In addition to these eight new cards, **Set Boosters also have the four traditional foil cards from the Commander decks available in the wildcard slot in a non-foil version.**"

So the four face commanders — **Millicent, Strefan, Donal and Timothar** (VOC #1–4, all mythic) — belong in the slot too, in non-foil. The sheet is non-foil, so the query resolves to exactly those printings; the Commander decks supply the traditional foil versions.

Per-card weight stays at **rare 2 : mythic 1**, matching the main-set R/M tier, so the four land at the same rate as the other VOC mythics already in the slot.

### Verification

Building the pack (`vow-set`) — the `count: 4` assertion passes, and the EV now includes all four:

```
  Millicent, Restless Revenant #1     0.001506
  Strefan, Maurer Progenitor #2       0.001506
  Donal, Herald of Wings #3           0.001506
  Timothar, Baron of Bats #4          0.001506
  Breathkeeper Seraph #31             0.003012   (rare, 2x mythic)
  Wedding Ring #32                    0.001506   (mythic)
  ...
ALL 4 COMMANDERS PRESENT
total cards/pack: 12.250
```

Rares come out at exactly 2× the mythic rate, and the pack total is unchanged. All non-foil, as the article specifies.

Found via an `is:productless` search: the non-foil printings of VOC #1–4 had no product source anywhere, because nothing recorded them as obtainable from Set Boosters.