### PR TITLE
iko: add the Japanese box topper pack

### DIFF
--- a/data/boosters/iko-box-topper-jp.yaml
+++ b/data/boosters/iko-box-topper-jp.yaml
@@ -1,0 +1,14 @@
+# Data from https://magic.wizards.com/en/news/card-preview/collecting-ikoria-2020-04-02
+# "In Japanese boosters, there are 18 different box topper cards in foil
+# (three found only in Japanese language). In all other languages there are 15
+# box toppers." The three extras are the Japanese-exclusive Godzilla Series
+# Monsters (Mysterious Egg #385, Dirge Bat #386, Crystalline Giant #387), which
+# are not tagged as box toppers themselves, hence the explicit variant:foreign.
+name: "{set_name} Japanese Box Topper Pack"
+pack:
+  box_topper: 1
+sheets:
+  box_topper:
+    foil: true
+    rawquery: "e:iko promo:godzillaseries (is:boxtopper or variant:foreign)"
+    count: 18


### PR DESCRIPTION
Japanese *Ikoria* Draft Booster displays came with a box topper drawn from a **larger pool** than every other language. From the collecting article:

> "In Japanese boosters, there are **18 different box topper cards** in foil (**three found only in Japanese language**). In all other languages there are 15 box toppers."

The three extras are the Japanese-exclusive Godzilla Series Monsters — **Mysterious Egg #385, Dirge Bat #386, Crystalline Giant #387**. They aren't tagged as box toppers themselves (`promo_types` is just `[godzillaseries, boosterfun]`, unlike #380–384 which carry `boxtopper`), so the sheet matches them explicitly via `variant:foreign`.

`iko-box-topper` is left untouched — it stays at the 15 cards other languages get.

### Verification

Query counts against the card database:

```
e:iko is:boxtopper                                            => 15
e:iko promo:godzillaseries variant:foreign                    =>  3   (#385 #386 #387)
e:iko promo:godzillaseries (is:boxtopper or variant:foreign)  => 18   ✓
```

Both packs build, and the `count: 18` assertion passes:

```
Ikoria: Lair of Behemoths Box Topper Pack
   distinct cards: 15   total/pack: 1.000   JP-exclusive present: 0
Ikoria: Lair of Behemoths Japanese Box Topper Pack
   distinct cards: 18   total/pack: 1.000   JP-exclusive present: 3
```

Found while chasing an `is:productless` search: the non-foil/foil printings of #385–387 had no source anywhere.