### PR TITLE
tla: add the Commander's Bundle promo pack

### DIFF
--- a/data/boosters/tla-commander-bundle.yaml
+++ b/data/boosters/tla-commander-bundle.yaml
@@ -1,0 +1,17 @@
+# Data from https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender
+# The Commander's Bundle includes "5 Non-foil promo cards. Three (3) of these
+# promo cards are the same in each Commander's Bundle." The three fixed staples
+# are Arcane Signet, Sol Ring and Swiftfoot Boots (TLE #315-317); the other two
+# are drawn from the ten tutor / free-spell reprints (TLE #305-314). All promos
+# are non-foil only.
+name: "{set_name} Commander's Bundle Promos"
+pack:
+  fixed_staple: 3
+  reprint: 2
+sheets:
+  fixed_staple:
+    rawquery: "e:tle number:315-317"
+    count: 3
+  reprint:
+    rawquery: "e:tle number:305-314"
+    count: 10


### PR DESCRIPTION
Models the **Avatar: The Last Airbender Commander's Bundle** promo cards as a proper pack instead of a flat decklist.

Per the collecting article: *"5 Non-foil promo cards. Three (3) of these promo cards are the same in each Commander's Bundle."*

- `fixed_staple: 3` over a 3-card sheet (TLE #315–317: Arcane Signet, Sol Ring, Swiftfoot Boots) → all three guaranteed
- `reprint: 2` over a 10-card sheet (TLE #305–314) → 2 distinct of 10

Source: https://magic.wizards.com/en/news/feature/collecting-avatar-the-last-airbender

### Verification

```
PACK: Avatar: The Last Airbender Commander's Bundle Promos
distinct cards: 13   total/pack: 5.000
   #315-317 (staples)  rate=1.000
   #305-314 (reprints) rate=0.200 each
```

Indexes with no count-mismatch or small-sheet warnings. Backs the `pack: {code: commander-bundle}` reference in the mtg-sealed-content Commander's Bundle contents.