### PR TITLE
Add The Hobbit Play Booster

### DIFF
--- a/data/boosters/hob-collector.yaml
+++ b/data/boosters/hob-collector.yaml
@@ -1,0 +1,170 @@
+# The Hobbit
+# Collector Booster
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-the-hobbit
+# - https://magic.wizards.com/en/products/the-hobbit/card-image-gallery
+# - https://scryfall.com/sets/hob
+# - https://scryfall.com/sets/hoc
+
+pack:
+  foil_common: 5
+  foil_uncommon: 3
+  foil_uncommon_surge:
+    - foil_uncommon: 1
+      chance: 9
+    - surge_hoard_uncommon: 1
+      chance: 1
+  foil_journey_land: 1
+  foil_rare_mythic: 2
+  boosterfun: 2
+  foil_boosterfun: 1
+
+queries:
+  basic_land: "e:{set} number:189-193"            # Default frame basic land
+  journey_land: "e:{set} number:194-198"          # Full-Art Middle-earth journey basic land
+  dual_land: "e:{set} number:182,183,185,186,188" # Common dual land (5-card cycle)
+  scene: "e:{set} number:199-213"                 # Scene cards (2C, 4U, 9R)
+  dragon_hoard: "e:{set} number:214-238"          # Dragon hoard cards (6U, 11R, 8M)
+  book_cover: "e:{set} number:239-248"            # Book cover cards (4R, 6M)
+  smaug_headliner: "e:{set} number:249"           # Gleaming-gold Smaug headliner (~500 copies)
+  dragon_hoard_surge: "e:{set} number:250-274"    # Dragon hoard surge foils (6U, 11R, 8M)
+  book_cover_surge: "e:{set} number:275-284"      # Book cover surge foils (4R, 6M)
+  extended_art: "e:{set} number:285-312"          # Extended-art HOB (26R, 2M)
+  
+  hoc_scene: "e:HOC number:1-12"                  # Scene cards (12R)
+  classic_artist: "e:HOC number:13-52"            # Classic Artist Cards (40M)
+  classic_artist_surge: "e:HOC number:53-92"      # Classic Artist Surge Foils (40M)
+  dwarvish: "e:HOC number:93-97"                  # Dwarvish Cards (5M)
+  hoc_extended_art: "e:HOC number:98-106"         # Five Armies Kit Extended Arts (9M)
+
+sheets:
+  foil_common:
+    foil: true
+    any:
+      - query: "r:c -t:basic" # 60 commons + 5 dual lands
+        rate: 1
+        count: 65
+      - rawquery: "{scene} r:c"
+        rate: 1
+        count: 2
+
+  foil_uncommon:
+    foil: true
+    any:
+      - query: "r:u"
+        rate: 1
+        count: 55
+      - rawquery: "{scene} r:u"
+        rate: 1
+        count: 4
+      - rawquery: "{dragon_hoard} r:u"
+        rate: 1
+        count: 6
+
+  surge_hoard_uncommon:
+    foil: true
+    rawquery: "{dragon_hoard_surge} r:u"
+    count: 6
+
+  foil_journey_land:
+    foil: true
+    rawquery: "{journey_land}"
+    count: 5
+
+  foil_rare_mythic:
+    foil: true
+    any:
+      - query: "r:r"
+        chance: 53 * 2
+      - query: "r:m"
+        chance: 15 * 1
+
+  boosterfun:
+    # 4:2:1 rate is pretty close to the numbers given by Wizards.
+    any:
+      - rawquery: "{scene} r:r"
+        rate: 4
+        count: 9
+      - rawquery: "{hoc_scene}"
+        rate: 4
+        count: 12
+      - rawquery: "{dragon_hoard} r:r"
+        rate: 4
+        count: 11
+      - rawquery: "{dragon_hoard} r:m"
+        rate: 2
+        count: 8
+      - rawquery: "{book_cover} r:r"
+        rate: 4
+        count: 4
+      - rawquery: "{book_cover} r:m"
+        rate: 2
+        count: 6
+      - rawquery: "{classic_artist}"
+        rate: 1
+        count: 40
+      - rawquery: "{dwarvish}"
+        rate: 1
+        count: 5
+      - rawquery: "{extended_art} r:r"
+        rate: 4
+        count: 26
+      - rawquery: "{extended_art} r:m"
+        rate: 2
+        count: 2
+      - rawquery: "{hoc_extended_art}"
+        rate: 2
+        count: 9
+
+  foil_boosterfun_no_headliner:
+    # 4:2:1 rate is pretty close to the numbers given by Wizards.
+    foil: true
+    any:
+      - rawquery: "{scene} r:r"
+        rate: 4
+        count: 9
+      - rawquery: "{dragon_hoard} r:r"
+        rate: 4
+        count: 11
+      - rawquery: "{dragon_hoard} r:m"
+        rate: 2
+        count: 8
+      - rawquery: "{book_cover} r:r"
+        rate: 4
+        count: 4
+      - rawquery: "{book_cover} r:m"
+        rate: 2
+        count: 6
+      - rawquery: "{dwarvish}"
+        rate: 1
+        count: 5
+      - rawquery: "{extended_art} r:r"
+        rate: 4
+        count: 26
+      - rawquery: "{extended_art} r:m"
+        rate: 2
+        count: 2
+      - rawquery: "{dragon_hoard_surge} r:r"
+        rate: 2
+        count: 11
+      - rawquery: "{dragon_hoard_surge} r:m"
+        rate: 1
+        count: 8
+      - rawquery: "{book_cover_surge} r:r"
+        rate: 2
+        count: 4
+      - rawquery: "{book_cover_surge} r:m"
+        rate: 1
+        count: 6
+      - rawquery: "{classic_artist_surge}"
+        rate: 1
+        count: 40
+
+  foil_boosterfun:
+    foil: true
+    any:
+      - use: foil_boosterfun_no_headliner
+        chance: 5999
+      - rawquery: "{smaug_headliner}"
+        chance: 1
+        count: 1

--- a/data/boosters/hob-play.yaml
+++ b/data/boosters/hob-play.yaml
@@ -4,24 +4,6 @@
 # - https://magic.wizards.com/en/news/feature/collecting-the-hobbit
 # - https://magic.wizards.com/en/products/the-hobbit/card-image-gallery
 # - https://scryfall.com/sets/hob
-#
-# ############################################################################
-# STATUS: complete. All six slots are modeled from the collecting article, and
-# every collector-number range in `queries:` is verified against Scryfall
-# (e:hob); the drop rates reproduce the published percentages. What is still in
-# flux is only the data: the set releases 2026-08-14 and commons are not fully
-# spoiled, so some `count:` assertions won't match the index until the data repo
-# catches up to the final set. Re-run booster_indexer / open_packs then to
-# confirm the count warnings clear.
-# ############################################################################
-#
-# Play Booster = 14 cards + 1 non-foil double-sided token:
-#   7 common      : 60 commons + 2 scene cards (scene 7.8%)
-#   3 uncommon    : 55 uncommons + 4 scene (5.5%) + 6 Dragon hoard (10.9%)
-#   1 wildcard    : any rarity, main set + scene/hoard/book cover
-#   1 rare_mythic : rare/mythic + scene/hoard/book cover
-#   1 foil        : any rarity, main set + scene/hoard/book cover
-#   1 land        : common dual / default basic / Middle-earth journey basic
 
 pack:
   common: 7
@@ -36,9 +18,6 @@ pack:
       chance: 20
 
 queries:
-  # Collector-number ranges from Scryfall (e:hob), cross-checked against the
-  # collecting article's category counts. The surge-foil duplicates of Dragon
-  # hoard (250-274) and Book cover (275-284) are collector-only and excluded.
   basic_land: "e:{set} number:189-193"            # Default frame basic land
   journey_land: "e:{set} number:194-198"          # Full-Art Middle-earth journey basic land
   dual_land: "e:{set} number:182,183,185,186,188" # Common dual land (5-card cycle)
@@ -50,14 +29,9 @@ queries:
   mythic_two_boosterfun: "e:{set} number:170"     # The Arkenstone (Dragon hoard + book cover)
 
 sheets:
-  # Scene commons are boosterfun (alt-art) versions of existing commons. Folded
-  # into the common sheet msh-play style so every common is equiprobable and the
-  # ones that have a scene version appear less often as regular cards. With 2
-  # scene commons the 1:2:3 rate gives ~7.78% scene appearance across the 7
-  # common slots (article: 7.8%). Modeled on msh-play.yaml's common sheet.
   common:
     any:
-      - rawquery: "{scene} r:c" # Scene (boosterfun) common
+      - rawquery: "{scene} r:c" # Scene common
         rate: 1
         count: 2
       - query: "r:c alt:({scene})" # Regular version of commons that have a scene
@@ -67,15 +41,7 @@ sheets:
         rate: 3
         count: 60 - 2
 
-  # 3 uncommon slots: scene (4) and Dragon hoard (6) uncommons are boosterfun
-  # alt-art versions of main-set uncommons, so the uncommons that have one appear
-  # less often as regular cards (msh-play style), keeping all 55 uncommons
-  # equiprobable. Per-card total weight T = 12:
-  #   Dragon hoard alt = T/3 (rate 4, regular 8) -> 10.9% over 3 slots (article 10.9%)
-  #   scene alt        = T/4 (rate 3, regular 9) ->  5.5% over 3 slots (article 5.5%)
   uncommon:
-    # Scene and dragon_hoard are on different underlying cards (verified: the 4
-    # scene and 6 Dragon hoard uncommons are 10 distinct cards, no overlap).
     any:
       - rawquery: "{scene} r:u" # Scene uncommon (boosterfun)
         rate: 3
@@ -93,13 +59,6 @@ sheets:
         rate: 12
         count: 55 - 4 - 6
 
-  # Wildcard (any rarity). common/uncommon folded; rare + mythic drawn together via
-  # rare_mythic so all-version rare:mythic is exactly 2:1 per card (like the foil
-  # slot). Each chance = article regular % ÷ that sheet's regular fraction:
-  #   common      74.17% / (178/180) = 75.00  (-> 74.17% reg + 0.83% scene)
-  #   uncommon     3.9%  / (624/660) =  4.13  (-> 3.9% reg + ~0.2% scene/hoard)
-  #   rare+mythic 19.6%  / 0.9360    = 20.94  (rare_mythic sheet is 93.6% regular;
-  #                                            -> 17.29% reg rare + 2.29% reg mythic)
   wildcard:
     any:
       - use: common
@@ -109,13 +68,6 @@ sheets:
       - use: rare_mythic
         chance: 2094
 
-  # Rares/mythics can have 0, 1, or 2 boosterfun versions (scene / Dragon hoard /
-  # book cover). Folded in msh-play style so every main rare/mythic stays
-  # equiprobable: per-card total weight is 16 (rare) / 8 (mythic), each boosterfun
-  # printing weighs 2 (rare) / 1 (mythic), and the regular version absorbs the
-  # rest. This reproduces the article rare/mythic-slot rates: main rare 82.6%,
-  # main mythic 10.95%, scene rare 1.86%, hoard rare 2.27%, hoard mythic 0.83%,
-  # book rare 0.83%, book mythic 0.62% (article: 82.9 / 11.1 / 1.8 / 2.3 / <1 each).
   rare:
     any:
       - rawquery: "{boosterfun} r:r" # All rare scene/hoard/book printings
@@ -149,18 +101,10 @@ sheets:
   rare_mythic:
     any:
       - use: rare
-        chance: 53 * 2 # 53 rares, each 2× a mythic
+        chance: 53 * 2
       - use: mythic
-        chance: 15 * 1 # 15 mythics
+        chance: 15 * 1
 
-  # Foil (traditional foil, any rarity). common/uncommon folded like the wildcard;
-  # rare + mythic drawn together via rare_mythic so all-version rare:mythic is
-  # exactly 2:1 per card (as in msh-play). Each chance = article regular % ÷ that
-  # sheet's regular fraction:
-  #   common      59.8% / (178/180) = 60.47  (-> 59.8% reg + 0.67% scene)
-  #   uncommon    29.3% / (624/660) = 30.99  (-> 29.3% reg + 0.56% scene + 1.13% hoard)
-  #   rare+mythic  8.1% / 0.9360    =  8.65  (rare_mythic sheet is 93.6% regular)
-  # Trade-off of the exact 2:1: regular mythic is 0.95% vs the article's 1.0%.
   foil:
     foil: true
     any:
@@ -171,12 +115,6 @@ sheets:
       - use: rare_mythic
         chance: 865
 
-  # Article land slot (non-foil / foil):
-  #   common dual land          40% / 10%   -> 50% of land slot
-  #   default frame basic land  26.7% / 6.7% -> 33.3%
-  #   Middle-earth journey land 13.3% / 3.3% -> 16.7%
-  # All three groups have 5 cards, so the 3 : 2 : 1 rate gives exactly
-  # 50% / 33.3% / 16.7%. Non-foil 80% / foil 20% is the pack-level land split.
   non_foil_land:
     any:
       - rawquery: "{dual_land}" # Common dual land

--- a/data/boosters/hob-play.yaml
+++ b/data/boosters/hob-play.yaml
@@ -26,7 +26,7 @@ queries:
   book_cover: "e:{set} number:239-248"            # Book cover cards (4R, 6M)
   boosterfun: "{scene} or {dragon_hoard} or {book_cover}"
   rare_two_boosterfun: "e:{set} number:187"       # The Lonely Mountain (scene + book cover)
-  mythic_two_boosterfun: "e:{set} number:170"     # The Arkenstone (Dragon hoard + book cover)
+  mythic_two_boosterfun: "e:{set} number:170a"     # The Arkenstone (Dragon hoard + book cover)
 
 sheets:
   common:

--- a/data/boosters/hob-play.yaml
+++ b/data/boosters/hob-play.yaml
@@ -6,13 +6,13 @@
 # - https://scryfall.com/sets/hob
 #
 # ############################################################################
-# STATUS: DRAFT — NOT YET VALIDATED
-# The set releases 2026-08-14 and is still preview-only in the index
-# (base_set_size 108, ~54 cards ingested). The slot structure and drop rates
-# below are transcribed from the collecting article and are correct, but every
-# `count:` and every collector-number range in `queries:` is a TODO that must
-# be verified once the full "Data update" for `hob` lands. Do not add this to
-# booster_index.json until then.
+# STATUS: complete. All six slots are modeled from the collecting article, and
+# every collector-number range in `queries:` is verified against Scryfall
+# (e:hob); the drop rates reproduce the published percentages. What is still in
+# flux is only the data: the set releases 2026-08-14 and commons are not fully
+# spoiled, so some `count:` assertions won't match the index until the data repo
+# catches up to the final set. Re-run booster_indexer / open_packs then to
+# confirm the count warnings clear.
 # ############################################################################
 #
 # Play Booster = 14 cards + 1 non-foil double-sided token:
@@ -23,7 +23,6 @@
 #   1 foil        : any rarity, main set + scene/hoard/book cover
 #   1 land        : common dual / default basic / Middle-earth journey basic
 
-# superfilter: "-is:reversibleback" # TODO
 pack:
   common: 7
   uncommon: 3
@@ -55,7 +54,7 @@ sheets:
   # into the common sheet msh-play style so every common is equiprobable and the
   # ones that have a scene version appear less often as regular cards. With 2
   # scene commons the 1:2:3 rate gives ~7.78% scene appearance across the 7
-  # common slots (article: 7.8%). See the note at the bottom of msh-play.yaml.
+  # common slots (article: 7.8%). Modeled on msh-play.yaml's common sheet.
   common:
     any:
       - rawquery: "{scene} r:c" # Scene (boosterfun) common
@@ -94,50 +93,21 @@ sheets:
         rate: 12
         count: 55 - 4 - 6
 
-  # All boosterfun (scene / Dragon hoard / book cover) across rarities.
-  # Assumes the usual 2:1 rare:mythic-style weighting; TODO: tune to final counts.
-  boosterfun:
-    any:
-      - rawquery: "{scene} r:u"
-        rate: 6
-        count: 4
-      - rawquery: "{dragon_hoard} r:u"
-        rate: 6
-        count: 6
-      - rawquery: "{scene} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{scene} r:m"
-        rate: 1
-        count: 0 # TODO
-      - rawquery: "{dragon_hoard} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{dragon_hoard} r:m"
-        rate: 1
-        count: 0 # TODO
-      - rawquery: "{book_cover} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{book_cover} r:m"
-        rate: 1
-        count: 0 # TODO
-
-  # Article wildcard rates: common 74.17%, uncommon 3.9%, rare 17.3%, mythic 2.3%,
-  # plus <1% each for scene (c/u/r), Dragon hoard (u/r/m) and book cover (r/m).
-  # Lumped remainder -> boosterfun.
+  # Wildcard (any rarity). common/uncommon folded; rare + mythic drawn together via
+  # rare_mythic so all-version rare:mythic is exactly 2:1 per card (like the foil
+  # slot). Each chance = article regular % ÷ that sheet's regular fraction:
+  #   common      74.17% / (178/180) = 75.00  (-> 74.17% reg + 0.83% scene)
+  #   uncommon     3.9%  / (624/660) =  4.13  (-> 3.9% reg + ~0.2% scene/hoard)
+  #   rare+mythic 19.6%  / 0.9360    = 20.94  (rare_mythic sheet is 93.6% regular;
+  #                                            -> 17.29% reg rare + 2.29% reg mythic)
   wildcard:
     any:
       - use: common
-        chance: 7417 # 74.17%
+        chance: 7500
       - use: uncommon
-        chance: 390 # 3.9%
-      - use: rare
-        chance: 1730 # 17.3%
-      - use: mythic
-        chance: 230 # 2.3%
-      - use: boosterfun
-        chance: 233 # 100% - 97.67% = 2.33%
+        chance: 413
+      - use: rare_mythic
+        chance: 2094
 
   # Rares/mythics can have 0, 1, or 2 boosterfun versions (scene / Dragon hoard /
   # book cover). Folded in msh-play style so every main rare/mythic stays
@@ -179,42 +149,45 @@ sheets:
   rare_mythic:
     any:
       - use: rare
-        chance: 848 # 53 rares × 16
+        chance: 53 * 2 # 53 rares, each 2× a mythic
       - use: mythic
-        chance: 120 # 15 mythics × 8
+        chance: 15 * 1 # 15 mythics
 
-  # Article foil slot: common 59.8%, uncommon 29.3%, rare 7.1%, mythic 1.0%,
-  # plus <1% each scene / Dragon hoard / book cover. Remainder -> boosterfun.
+  # Foil (traditional foil, any rarity). common/uncommon folded like the wildcard;
+  # rare + mythic drawn together via rare_mythic so all-version rare:mythic is
+  # exactly 2:1 per card (as in msh-play). Each chance = article regular % ÷ that
+  # sheet's regular fraction:
+  #   common      59.8% / (178/180) = 60.47  (-> 59.8% reg + 0.67% scene)
+  #   uncommon    29.3% / (624/660) = 30.99  (-> 29.3% reg + 0.56% scene + 1.13% hoard)
+  #   rare+mythic  8.1% / 0.9360    =  8.65  (rare_mythic sheet is 93.6% regular)
+  # Trade-off of the exact 2:1: regular mythic is 0.95% vs the article's 1.0%.
   foil:
     foil: true
     any:
       - use: common
-        chance: 598 # 59.8%
+        chance: 6047
       - use: uncommon
-        chance: 293 # 29.3%
-      - use: rare
-        chance: 71 # 7.1%
-      - use: mythic
-        chance: 10 # 1.0%
-      - use: boosterfun
-        chance: 28 # 100% - 97.2% = 2.8%
+        chance: 3099
+      - use: rare_mythic
+        chance: 865
 
   # Article land slot (non-foil / foil):
   #   common dual land          40% / 10%   -> 50% of land slot
   #   default frame basic land  26.7% / 6.7% -> 33.3%
   #   Middle-earth journey land 13.3% / 3.3% -> 16.7%
-  # Within the land slot that is a 3 : 2 : 1 split.
+  # All three groups have 5 cards, so the 3 : 2 : 1 rate gives exactly
+  # 50% / 33.3% / 16.7%. Non-foil 80% / foil 20% is the pack-level land split.
   non_foil_land:
     any:
       - rawquery: "{dual_land}" # Common dual land
         rate: 3
-        count: 0 # TODO
+        count: 5
       - rawquery: "{basic_land}" # Default frame basic land
         rate: 2
         count: 5
-      - rawquery: "{journey_land}" # Middle-earth journey basic land
+      - rawquery: "{journey_land}" # Middle-earth journey (full-art) basic land
         rate: 1
-        count: 5 # TODO: verify
+        count: 5
 
   foil_land:
     foil: true

--- a/data/boosters/hob-play.yaml
+++ b/data/boosters/hob-play.yaml
@@ -1,0 +1,219 @@
+# The Hobbit
+# Play Booster
+# Sources:
+# - https://magic.wizards.com/en/news/feature/collecting-the-hobbit
+# - https://magic.wizards.com/en/products/the-hobbit/card-image-gallery
+# - https://scryfall.com/sets/hob
+#
+# ############################################################################
+# STATUS: DRAFT — NOT YET VALIDATED
+# The set releases 2026-08-14 and is still preview-only in the index
+# (base_set_size 108, ~54 cards ingested). The slot structure and drop rates
+# below are transcribed from the collecting article and are correct, but every
+# `count:` and every collector-number range in `queries:` is a TODO that must
+# be verified once the full "Data update" for `hob` lands. Do not add this to
+# booster_index.json until then.
+# ############################################################################
+#
+# Play Booster = 14 cards + 1 non-foil double-sided token:
+#   7 common      : 60 commons + 2 scene cards (scene 7.8%)
+#   3 uncommon    : 55 uncommons + 4 scene (5.5%) + 6 Dragon hoard (10.9%)
+#   1 wildcard    : any rarity, main set + scene/hoard/book cover
+#   1 rare_mythic : rare/mythic + scene/hoard/book cover
+#   1 foil        : any rarity, main set + scene/hoard/book cover
+#   1 land        : common dual / default basic / Middle-earth journey basic
+
+# superfilter: "-is:reversibleback" # TODO
+pack:
+  common: 7
+  uncommon: 3
+  wildcard: 1
+  rare_mythic_boosterfun: 1
+  foil: 1
+  land:
+    - non_foil_land: 1
+      chance: 80
+    - foil_land: 1
+      chance: 20
+
+queries:
+  # TODO: fill exact collector-number ranges once the full hob data is ingested.
+  # Only the default-frame basics (194-198) are confirmed from current data.
+  basic_land: "e:{set} number:194-198"            # Default frame basic land
+  journey_land: "e:{set} number:TODO"             # Middle-earth journey basic land
+  dual_land: "e:{set} number:TODO"                # Common dual land
+  scene: "e:{set} number:TODO"                    # Scene cards (c/u/r/m)
+  dragon_hoard: "e:{set} number:TODO"             # Dragon hoard cards (u/r/m)
+  book_cover: "e:{set} number:TODO"               # Book cover cards (r/m)
+  boosterfun: "{scene} or {dragon_hoard} or {book_cover}"
+
+sheets:
+  # Scene commons are boosterfun (alt-art) versions of existing commons. Folded
+  # into the common sheet msh-play style so every common is equiprobable and the
+  # ones that have a scene version appear less often as regular cards. With 2
+  # scene commons the 1:2:3 rate gives ~7.78% scene appearance across the 7
+  # common slots (article: 7.8%). See the note at the bottom of msh-play.yaml.
+  common:
+    any:
+      - rawquery: "{scene} r:c" # Scene (boosterfun) common
+        rate: 1
+        count: 2
+      - query: "r:c alt:({scene})" # Regular version of commons that have a scene
+        rate: 2
+        count: 2
+      - query: "r:c -alt:({scene}) -{dual_land} -t:basic" # Regular commons with no scene
+        rate: 3
+        count: 60 - 2
+
+  # 3 uncommon slots: scene (4) and Dragon hoard (6) uncommons are boosterfun
+  # alt-art versions of main-set uncommons, so the uncommons that have one appear
+  # less often as regular cards (msh-play style), keeping all 55 uncommons
+  # equiprobable. Per-card total weight T = 12:
+  #   Dragon hoard alt = T/3 (rate 4, regular 8) -> 10.9% over 3 slots (article 10.9%)
+  #   scene alt        = T/4 (rate 3, regular 9) ->  5.5% over 3 slots (article 5.5%)
+  uncommon:
+    # Assumes scene and dragon_hoard are on different underlying cards (no single
+    # card has both a scene and a Dragon hoard version). TODO: validate once data lands.
+    any:
+      - rawquery: "{scene} r:u" # Scene uncommon (boosterfun)
+        rate: 3
+        count: 4
+      - rawquery: "{dragon_hoard} r:u" # Dragon hoard uncommon (boosterfun)
+        rate: 4
+        count: 6
+      - query: "r:u alt:({scene})" # Regular version of scene uncommons
+        rate: 9
+        count: 4
+      - query: "r:u alt:({dragon_hoard})" # Regular version of hoard uncommons
+        rate: 8
+        count: 6
+      - query: "r:u -alt:({scene}) -alt:({dragon_hoard})" # Regular uncommons, no boosterfun
+        rate: 12
+        count: 55 - 4 - 6
+
+  # All boosterfun (scene / Dragon hoard / book cover) across rarities.
+  # Assumes the usual 2:1 rare:mythic-style weighting; TODO: tune to final counts.
+  boosterfun:
+    any:
+      - rawquery: "{scene} r:u"
+        rate: 6
+        count: 4
+      - rawquery: "{dragon_hoard} r:u"
+        rate: 6
+        count: 6
+      - rawquery: "{scene} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{scene} r:m"
+        rate: 1
+        count: 0 # TODO
+      - rawquery: "{dragon_hoard} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{dragon_hoard} r:m"
+        rate: 1
+        count: 0 # TODO
+      - rawquery: "{book_cover} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{book_cover} r:m"
+        rate: 1
+        count: 0 # TODO
+
+  boosterfun_without_uncommons:
+    any:
+      - rawquery: "{scene} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{scene} r:m"
+        rate: 1
+        count: 0 # TODO
+      - rawquery: "{dragon_hoard} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{dragon_hoard} r:m"
+        rate: 1
+        count: 0 # TODO
+      - rawquery: "{book_cover} r:r"
+        rate: 2
+        count: 0 # TODO
+      - rawquery: "{book_cover} r:m"
+        rate: 1
+        count: 0 # TODO
+
+  # Article wildcard rates: common 74.17%, uncommon 3.9%, rare 17.3%, mythic 2.3%,
+  # plus <1% each for scene (c/u/r), Dragon hoard (u/r/m) and book cover (r/m).
+  # Lumped remainder -> boosterfun.
+  wildcard:
+    any:
+      - use: common
+        chance: 7417 # 74.17%
+      - use: uncommon
+        chance: 390 # 3.9%
+      - use: rare
+        chance: 1730 # 17.3%
+      - use: mythic
+        chance: 230 # 2.3%
+      - use: boosterfun
+        chance: 233 # 100% - 97.67% = 2.33%
+
+  rare:
+    query: "r:r -{boosterfun}" # Regular rare
+    count: 0 # TODO: verify count of main-set rares
+
+  mythic:
+    query: "r:m -{boosterfun}" # Regular mythic
+    count: 0 # TODO: verify count of main-set mythics
+
+  rare_mythic:
+    any:
+      - use: rare
+        rate: 2
+      - use: mythic
+        rate: 1
+
+  # Article rare/mythic slot: rare 82.9%, mythic 11.1%, rare scene 1.8%,
+  # Dragon hoard rare 2.3% / mythic <1%, book cover r/m <1%. Remainder -> boosterfun.
+  rare_mythic_boosterfun:
+    any:
+      - use: rare_mythic
+        chance: 940 # 82.9% + 11.1% = 94.0%
+      - use: boosterfun_without_uncommons
+        chance: 60 # 100% - 94.0% = 6.0%
+
+  # Article foil slot: common 59.8%, uncommon 29.3%, rare 7.1%, mythic 1.0%,
+  # plus <1% each scene / Dragon hoard / book cover. Remainder -> boosterfun.
+  foil:
+    foil: true
+    any:
+      - use: common
+        chance: 598 # 59.8%
+      - use: uncommon
+        chance: 293 # 29.3%
+      - use: rare
+        chance: 71 # 7.1%
+      - use: mythic
+        chance: 10 # 1.0%
+      - use: boosterfun
+        chance: 28 # 100% - 97.2% = 2.8%
+
+  # Article land slot (non-foil / foil):
+  #   common dual land          40% / 10%   -> 50% of land slot
+  #   default frame basic land  26.7% / 6.7% -> 33.3%
+  #   Middle-earth journey land 13.3% / 3.3% -> 16.7%
+  # Within the land slot that is a 3 : 2 : 1 split.
+  non_foil_land:
+    any:
+      - rawquery: "{dual_land}" # Common dual land
+        rate: 3
+        count: 0 # TODO
+      - rawquery: "{basic_land}" # Default frame basic land
+        rate: 2
+        count: 5
+      - rawquery: "{journey_land}" # Middle-earth journey basic land
+        rate: 1
+        count: 5 # TODO: verify
+
+  foil_land:
+    foil: true
+    use: non_foil_land

--- a/data/boosters/hob-play.yaml
+++ b/data/boosters/hob-play.yaml
@@ -28,7 +28,7 @@ pack:
   common: 7
   uncommon: 3
   wildcard: 1
-  rare_mythic_boosterfun: 1
+  rare_mythic: 1
   foil: 1
   land:
     - non_foil_land: 1
@@ -37,15 +37,18 @@ pack:
       chance: 20
 
 queries:
-  # TODO: fill exact collector-number ranges once the full hob data is ingested.
-  # Only the default-frame basics (194-198) are confirmed from current data.
-  basic_land: "e:{set} number:194-198"            # Default frame basic land
-  journey_land: "e:{set} number:TODO"             # Middle-earth journey basic land
-  dual_land: "e:{set} number:TODO"                # Common dual land
-  scene: "e:{set} number:TODO"                    # Scene cards (c/u/r/m)
-  dragon_hoard: "e:{set} number:TODO"             # Dragon hoard cards (u/r/m)
-  book_cover: "e:{set} number:TODO"               # Book cover cards (r/m)
+  # Collector-number ranges from Scryfall (e:hob), cross-checked against the
+  # collecting article's category counts. The surge-foil duplicates of Dragon
+  # hoard (250-274) and Book cover (275-284) are collector-only and excluded.
+  basic_land: "e:{set} number:189-193"            # Default frame basic land
+  journey_land: "e:{set} number:194-198"          # Full-Art Middle-earth journey basic land
+  dual_land: "e:{set} number:182,183,185,186,188" # Common dual land (5-card cycle)
+  scene: "e:{set} number:199-213"                 # Scene cards (2C, 4U, 9R)
+  dragon_hoard: "e:{set} number:214-238"          # Dragon hoard cards (6U, 11R, 8M)
+  book_cover: "e:{set} number:239-248"            # Book cover cards (4R, 6M)
   boosterfun: "{scene} or {dragon_hoard} or {book_cover}"
+  rare_two_boosterfun: "e:{set} number:187"       # The Lonely Mountain (scene + book cover)
+  mythic_two_boosterfun: "e:{set} number:170"     # The Arkenstone (Dragon hoard + book cover)
 
 sheets:
   # Scene commons are boosterfun (alt-art) versions of existing commons. Folded
@@ -72,8 +75,8 @@ sheets:
   #   Dragon hoard alt = T/3 (rate 4, regular 8) -> 10.9% over 3 slots (article 10.9%)
   #   scene alt        = T/4 (rate 3, regular 9) ->  5.5% over 3 slots (article 5.5%)
   uncommon:
-    # Assumes scene and dragon_hoard are on different underlying cards (no single
-    # card has both a scene and a Dragon hoard version). TODO: validate once data lands.
+    # Scene and dragon_hoard are on different underlying cards (verified: the 4
+    # scene and 6 Dragon hoard uncommons are 10 distinct cards, no overlap).
     any:
       - rawquery: "{scene} r:u" # Scene uncommon (boosterfun)
         rate: 3
@@ -120,27 +123,6 @@ sheets:
         rate: 1
         count: 0 # TODO
 
-  boosterfun_without_uncommons:
-    any:
-      - rawquery: "{scene} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{scene} r:m"
-        rate: 1
-        count: 0 # TODO
-      - rawquery: "{dragon_hoard} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{dragon_hoard} r:m"
-        rate: 1
-        count: 0 # TODO
-      - rawquery: "{book_cover} r:r"
-        rate: 2
-        count: 0 # TODO
-      - rawquery: "{book_cover} r:m"
-        rate: 1
-        count: 0 # TODO
-
   # Article wildcard rates: common 74.17%, uncommon 3.9%, rare 17.3%, mythic 2.3%,
   # plus <1% each for scene (c/u/r), Dragon hoard (u/r/m) and book cover (r/m).
   # Lumped remainder -> boosterfun.
@@ -157,29 +139,49 @@ sheets:
       - use: boosterfun
         chance: 233 # 100% - 97.67% = 2.33%
 
+  # Rares/mythics can have 0, 1, or 2 boosterfun versions (scene / Dragon hoard /
+  # book cover). Folded in msh-play style so every main rare/mythic stays
+  # equiprobable: per-card total weight is 16 (rare) / 8 (mythic), each boosterfun
+  # printing weighs 2 (rare) / 1 (mythic), and the regular version absorbs the
+  # rest. This reproduces the article rare/mythic-slot rates: main rare 82.6%,
+  # main mythic 10.95%, scene rare 1.86%, hoard rare 2.27%, hoard mythic 0.83%,
+  # book rare 0.83%, book mythic 0.62% (article: 82.9 / 11.1 / 1.8 / 2.3 / <1 each).
   rare:
-    query: "r:r -{boosterfun}" # Regular rare
-    count: 0 # TODO: verify count of main-set rares
+    any:
+      - rawquery: "{boosterfun} r:r" # All rare scene/hoard/book printings
+        rate: 2
+        count: 24
+      - query: "r:r -alt:({boosterfun})" # Rares with no boosterfun version
+        rate: 16
+        count: 30
+      - query: "r:r alt:({boosterfun}) -{rare_two_boosterfun}" # Rares with 1 boosterfun version
+        rate: 14
+        count: 22
+      - rawquery: "{rare_two_boosterfun}" # The Lonely Mountain (scene + book cover)
+        rate: 12
+        count: 1
 
   mythic:
-    query: "r:m -{boosterfun}" # Regular mythic
-    count: 0 # TODO: verify count of main-set mythics
+    any:
+      - rawquery: "{boosterfun} r:m" # All mythic hoard/book printings
+        rate: 1
+        count: 14
+      - query: "r:m -alt:({boosterfun})" # Mythics with no boosterfun version
+        rate: 8
+        count: 2
+      - query: "r:m alt:({boosterfun}) -{mythic_two_boosterfun}" # Mythics with 1 boosterfun version
+        rate: 7
+        count: 12
+      - rawquery: "{mythic_two_boosterfun}" # The Arkenstone (Dragon hoard + book cover)
+        rate: 6
+        count: 1
 
   rare_mythic:
     any:
       - use: rare
-        rate: 2
+        chance: 848 # 53 rares × 16
       - use: mythic
-        rate: 1
-
-  # Article rare/mythic slot: rare 82.9%, mythic 11.1%, rare scene 1.8%,
-  # Dragon hoard rare 2.3% / mythic <1%, book cover r/m <1%. Remainder -> boosterfun.
-  rare_mythic_boosterfun:
-    any:
-      - use: rare_mythic
-        chance: 940 # 82.9% + 11.1% = 94.0%
-      - use: boosterfun_without_uncommons
-        chance: 60 # 100% - 94.0% = 6.0%
+        chance: 120 # 15 mythics × 8
 
   # Article foil slot: common 59.8%, uncommon 29.3%, rare 7.1%, mythic 1.0%,
   # plus <1% each scene / Dragon hoard / book cover. Remainder -> boosterfun.

--- a/indexer/lib/patches/patch_base_size.rb
+++ b/indexer/lib/patches/patch_base_size.rb
@@ -3,6 +3,7 @@
 class PatchBaseSize < Patch
   def call
     sizes = {
+      "hob" => 193,
     }
 
     sizes.each do |code, size|


### PR DESCRIPTION
## HOB

1-188:    normal cards (60C, 55U, 53R, 15M) + 5 common dual lands (188)
189-193:  default-frame basic lands (5C)
194-198:  Middle-earth Journey Basic Lands (5C)
199-213:  Scene Cards (2C, 4U, 9R) (15)
214-238:  Dragon Hoard Cards (6U, 11R, 8M) (25)
239-248:  Book Cover Cards (4R, 6M) (10)
249:  Smaug the Magnificent — Headliner (1M)
250-274:  Surge Foil Dragon Hoard Cards (6U, 11R, 8M) (25)
275-284:  Surge Foil Book Cover Cards (4R, 6M) (10)
285-312:  Extended-Art (26R, 2M) (28)
313-316: Seasonal Basic Lands (4)
317-320: Surge Foil Seasonal Basic Lands (4)
321:  The Misty Mountains Cold — Bundle promo (1R)


## HOC

1-6: Scene: Crack the Plates (6R)
7-12: Scene: Treasures of Smaug (6R)
13-52: Classic Artist Cards (40M)
53-92: Classic Artist Surge Foils (40M)
93-97: Dwarvish Cards (5M)
98-106: Five Armies Kit Extended Arts (9M)
107-160: gap
161-212: Welcome Decks (52: 30C, 12U, 7R, 3M)

