### PR TITLE
SLD: add the early (pre-October 2022) Surprise Slivers bonus pool

### DIFF
--- a/data/boosters/sld-surprise-slivers-early.yaml
+++ b/data/boosters/sld-surprise-slivers-early.yaml
@@ -1,0 +1,68 @@
+# Secret Lair "Surprise Slivers" bonus pool -- the EARLY (pre-October 2022) window.
+# The 2022-2023 Secret Lair drops came with a random foil extended-art Sliver
+# bonus card (Scryfall's "Surprise Slivers" grouping). The pool grew Superdrop by
+# Superdrop, so drops that only shipped early could not contain slivers printed in
+# a later wave. This is the general pool restricted to that early window; drops
+# still shipping later use the full `sld-surprise-slivers` pool instead.
+#
+# Cutoff: the drops that reference this pool shipped 2022-07-22 .. 2022-09-13
+# (e.g. Astrology Lands Aries/Pisces/Taurus, Li'l Walkers, Pictures of the
+# Floating World, Rule the Room, The Tokyo Lands). By 2022-09-13 only the July
+# (2022-07-15) and August (2022-08-11..08-19) waves existed; the October wave
+# (from 2022-10-28) was not yet available. The first drop to use the full pool is
+# Astrology Lands Gemini (2022-09-23), confirming the boundary sits just before
+# the October 2022 Superdrop.
+#
+# As in the full pool, slivers tied to a specific drop keep their per-product
+# variable pools in mtg-sealed-content and are excluded here (e.g. Diffusion 618,
+# Manaweft 650, Might 652 on "Just Some Totally Normal Guys"). Chances are carried
+# over unchanged from the full pool (inverse-price foil weights, top chase = 1).
+name: "SLD Surprise Slivers (early, pre-October 2022)"
+pack:
+  slivers: 1
+sheets:
+  slivers:
+    foil: true
+    any:
+    - rawquery: "e:sld number:657" # Tempered Sliver
+      count: 1
+      chance: 129
+    - rawquery: "e:sld number:646" # Two-Headed Sliver
+      count: 1
+      chance: 83
+    - rawquery: "e:sld number:628" # Winged Sliver
+      count: 1
+      chance: 73
+    - rawquery: "e:sld number:617" # Ward Sliver
+      count: 1
+      chance: 59
+    - rawquery: "e:sld number:647" # Brood Sliver
+      count: 1
+      chance: 33
+    - rawquery: "e:sld number:664" # Hibernation Sliver
+      count: 1
+      chance: 27
+    - rawquery: "e:sld number:660" # Cloudshredder Sliver
+      count: 1
+      chance: 24
+    - rawquery: "e:sld number:649" # Horned Sliver
+      count: 1
+      chance: 23
+    - rawquery: "e:sld number:654" # Predatory Sliver
+      count: 1
+      chance: 22
+    - rawquery: "e:sld number:634" # Syphon Sliver
+      count: 1
+      chance: 11
+    - rawquery: "e:sld number:661" # Crystalline Sliver
+      count: 1
+      chance: 9
+    - rawquery: "e:sld number:663" # Harmonic Sliver
+      count: 1
+      chance: 9
+    - rawquery: "e:sld number:643" # Spiteful Sliver
+      count: 1
+      chance: 8
+    - rawquery: "e:sld number:668" # Sliver Hive
+      count: 1
+      chance: 1


### PR DESCRIPTION
## What

Adds `data/boosters/sld-surprise-slivers-early.yaml`, the `surprise-slivers-early` bonus pool for the early (pre-October 2022) Secret Lair drops. (Regenerate `index/booster_index.json` as usual; it's left out of this PR.)

## Why

mtg-sealed-content already references `surprise-slivers-early` on 26 SLD products (Astrology Lands Aries/Pisces/Taurus, Li'l Walkers, Pictures of the Floating World, Rule the Room, The Tokyo Lands, Special Guest Kelogsloops/Yuko Shimizu, the NEO/SNC showcase drops, etc.), but no booster ever defined it — only the full `sld-surprise-slivers` pool existed. The contents compiler logged `Booster code surprise-slivers-early not found in set sld` on every run.

## Deriving the pool

The 2022–2023 Surprise Slivers bonus grew Superdrop by Superdrop, so a drop that only shipped early couldn't contain a later wave. Waves (from `is:sldbonus` release dates):

| wave | date | cumulative |
|---|---|---|
| July | 2022-07-15 | 6 |
| August | 2022-08-11 … 08-19 | 19 |
| **cutoff** | | |
| October | 2022-10-28 … 11-05 | 28 |
| December | 2022-12-15 … 12-30 | 52 |
| 2023 | Sedge, Screeching, +3 step-compleat foils | 53 (+3) |

The full list (SLD #610–668) matches [mtg.wiki's Surprise Slivers entry](https://mtg.wiki/page/Secret_Lair/Bonus_cards).

The cutoff is fixed by the drops themselves: every drop that uses `surprise-slivers-early` shipped **2022-07-22 … 2022-09-13**, and the first drop to use the full pool is Astrology Lands Gemini (**2022-09-23**) — the boundary sits just before the October Superdrop. The Astrology Lands series confirms the gradient: Capricorn/Aquarius (Apr–May) get no slivers, Aries/Pisces/Taurus (Jul–Sep) get `-early`, Gemini onward get the full pool.

Applying the same drop-tied exclusions as the full pool (slivers like Diffusion 618, Manaweft 650, Might 652 keep their per-product variable pools on drops such as "Just Some Totally Normal Guys") leaves **14 slivers**, with `chance` weights carried over unchanged from the full pool.

## Verification

- Re-indexing adds exactly the `sld-surprise-slivers-early` key; no existing booster changed.
- Pack builds to 14 distinct slivers with the expected weighted spread (Tempered ~25% top, Sliver Hive 0.16% rarest).
- `rspec spec/pack_factory_spec.rb spec/booster_spec.rb spec/booster_query_spec.rb` → 83 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)