### PR TITLE
bro: add the Gift Bundle foil Transformers booster

### DIFF
--- a/data/boosters/bro-gift-bundle-transformers.yaml
+++ b/data/boosters/bro-gift-bundle-transformers.yaml
@@ -1,0 +1,12 @@
+# The Brothers' War Gift Bundle came with one foil Transformers bonus card,
+# drawn from the 15 standard Transformers cards (BOT 1-15). The Shattered Glass
+# versions (BOT >=16) were Collector Booster exclusive, so they're excluded here
+# -- same "no shattered glass" assumption as the Set Booster wildcard.
+name: "The Brothers' War Gift Bundle Transformers card"
+pack:
+  transformers: 1
+sheets:
+  transformers:
+    foil: true
+    rawquery: "e:bot number<16"
+    count: 15


### PR DESCRIPTION
## What

Adds `data/boosters/bro-gift-bundle-transformers.yaml` (code `gift-bundle-transformers`) — the foil Transformers bonus card that shipped in The Brothers' War Gift Bundle.

## Why

mtg-sealed-content models the Gift Bundle promo as a generic `other: "Foil Mythic Rare Transformers Card"` note, which can't resolve to actual cards. This booster lets it reference a real pack instead.

## Pool

One foil card drawn uniformly from the **15 standard Transformers cards** (`e:bot number<16`). The Shattered Glass versions (`e:bot number>=16`) were Collector Booster exclusive, so they're excluded — the same "no shattered glass" assumption the Set Booster wildcard already uses.

Note `number<16` rather than `number<=15`: the transforming cards carry `a`/`b` face suffixes, so `number<=15` sorts `15a`/`15b` above bare `15` and silently drops card #15 (Ultra Magnus). `number<16` includes all 15.

## Verification

- Re-index adds exactly the `bro-gift-bundle-transformers` key; nothing else changes.
- Pack builds to 1 card, 100% foil, uniform over all 15 characters (~6.7% each), Ultra Magnus included.