### PR TITLE
bro-set: include Ultra Magnus in the Transformers wildcard

### DIFF
--- a/data/boosters/bro-set.yaml
+++ b/data/boosters/bro-set.yaml
@@ -138,8 +138,8 @@ sheets:
     # slots (non-foil, no shattered glass) -- so it's a top-level wildcard
     # outcome, not part of the rare/mythic tier. With 2 wildcard slots,
     # chance 54 (~5.12% per wildcard) gives ~10% per pack.
-    - rawquery: "e:bot number<=15"
-      count: 14
+    - rawquery: "e:bot number<16"
+      count: 15
       chance: 54
   brr_retro_artifact:
     filter: "e:brr -number:/z/"


### PR DESCRIPTION
## Bug

The Set Booster's Transformers wildcard slot queried `e:bot number<=15` (count 14), which silently **drops card #15, Ultra Magnus** — so the simulation can never produce it from that slot.

The Transformers are transforming cards, so their collector numbers carry face suffixes (`15a`, `15b`). The search engine orders numbers as (numeric, suffix), so `15a`/`15b` sort *above* bare `15`, and `number<=15` stops at `14b`. The Collector booster already avoids this by using `number<16`.

Because `count: 14` matched the buggy query's 14 results, the count check never flagged it.

## Fix

```diff
-    - rawquery: "e:bot number<=15"
-      count: 14
+    - rawquery: "e:bot number<16"
+      count: 15
       chance: 54
```

## Verification

- All 15 standard Transformers are now reachable; Ultra Magnus appears (was 0).
- The aggregate rate is unchanged at ~10% per pack — `chance: 54` is the subsheet weight, now spread over 15 cards instead of 14 (measured ~10.3% over 200k packs).
- Re-index touches only `bro-set`; no other booster changes.