### PR TITLE
tmt: add the Pizza Bundle foil promos booster

### DIFF
--- a/data/boosters/tmt-pizza-bundle.yaml
+++ b/data/boosters/tmt-pizza-bundle.yaml
@@ -1,0 +1,12 @@
+# The Teenage Mutant Ninja Turtles Pizza Bundle came with 2 foil pizza-themed
+# promo cards, drawn from a 6-card pool (TMC 131-136): Dark Ritual, Waste Not,
+# Food Chain, Supreme Verdict, Commander's Plate, and Sword of Hearth and Home.
+# All are foil-only "inverted" (pizza-box) frame mythics.
+name: "Teenage Mutant Ninja Turtles Pizza Bundle promos"
+pack:
+  pizza: 2
+sheets:
+  pizza:
+    foil: true
+    rawquery: "e:tmc number>=131 number<=136"
+    count: 6


### PR DESCRIPTION
## What

Adds `data/boosters/tmt-pizza-bundle.yaml` (code `pizza-bundle`) — the 2 foil pizza-themed promo cards from the Teenage Mutant Ninja Turtles Pizza Bundle.

## Why

mtg-sealed-content models the promos as a generic `other: "2 of 6 pizza-themed promo cards"` note. This booster lets it reference a real pack instead.

## Pool

2 cards drawn (without replacement) from the 6-card pool `e:tmc number>=131 number<=136`:
Dark Ritual, Waste Not, Food Chain, Supreme Verdict, Commander's Plate, Sword of Hearth and Home — all foil-only "inverted" (pizza-box) frame mythics.

## Verification

- Re-index adds exactly the `tmt-pizza-bundle` key; nothing else changes.
- Pack builds to exactly 2 cards, 100% foil, 0% duplicate cards, uniform over all 6 (~16.7% each).