### PR TITLE
mh3-play-arena: keep fetchlands out of the new-to-Modern slot

### DIFF
--- a/data/boosters/mh3-play-arena.yaml
+++ b/data/boosters/mh3-play-arena.yaml
@@ -52,8 +52,10 @@ sheets:
       query: "r:u is:reprint"
       count: 20
     - chance: 213
-      query: "r:r is:reprint -is:foilonly"
-      count: 23
+      # Fetchlands are reprints, but they are not new-to-Modern, so they belong
+      # in the new_rare_mythic slot (as in mh3-play), not this one.
+      query: "r:r is:reprint -is:foilonly -is:fetchland"
+      count: 18
     - chance: 23
       query: "r:m is:reprint -is:foilonly"
       count: 4


### PR DESCRIPTION
Fixes the fetchland misclassification in the MH3 Arena Play Booster reported by @jrisi256 in #437 ([comment](https://github.com/taw/magic-search-engine/issues/437#issuecomment-5246306739)) — https://mtg.wtf/pack/mh3-play-arena.

## Problem

The `reprint` slot (MH3's new-to-Modern reprint slot) queried:

```yaml
query: "r:r is:reprint -is:foilonly"
count: 23
```

The five allied fetchlands **are** reprints, so they matched — but they were already Modern legal (Khans of Tarkir), so they are *not* new-to-Modern and don't belong in that slot.

They are simultaneously in `new_rare_mythic` via `(is:fetchland or -is:reprint)`, so they were being offered from **both** slots.

`mh3-play` was fixed the same way in 84757b789 ("Moved fetchlands in mh3-play from reprint slot to new_rare_mythic slot"). When `mh3-play-arena` was added in #544 it inherited the paper fix in its `new_rare_mythic` and `wildcard` sheets, but not in its `reprint` sheet — which is why the bug reappeared on Arena only.

## Fix

```diff
     - chance: 213
-      query: "r:r is:reprint -is:foilonly"
-      count: 23
+      # Fetchlands are reprints, but they are not new-to-Modern, so they belong
+      # in the new_rare_mythic slot (as in mh3-play), not this one.
+      query: "r:r is:reprint -is:foilonly -is:fetchland"
+      count: 18
```

## Verification

The rare pools now partition the set exactly:

| pool | before | after |
|---|---|---|
| `new_rare_mythic` / `wildcard` rare (new + fetchlands) | 60 | 60 |
| `reprint` rare (new-to-Modern) | 23 | **18** |
| **total** | 83 ✗ | **78** ✓ |

78 is every `e:mh3 is:baseset r:r -is:foilonly` card — previously the 5 fetchlands were counted twice.

Per-sheet fetchland audit now matches paper `mh3-play` exactly:

| sheet | mh3-play | mh3-play-arena (after) |
|---|---|---|
| `new_rare_mythic` | has | has |
| `wildcard` | has | has |
| foil slot | has | has |
| `reprint` | none | **none** (was: all 5) |

- Re-index changes only the `mh3-play-arena` key; every other booster regenerates byte-identically.
- The `count: 18` assertion is enforced (deliberately setting it to 99 reports `Expected query ... to return 99, got 18`).
- Packs still open at 14 cards; `rspec spec/booster_spec.rb spec/pack_factory_spec.rb spec/booster_query_spec.rb` → 84 examples, 0 failures.
- `mh3-play-arena` is the only Arena booster with a new-to-Modern reprint slot, so no other Arena pack is affected.

`index/booster_index.json` is left out of this PR — regenerate as usual.