### PR TITLE
LTR improvements

### DIFF
--- a/data/boosters/ltr-collector-special.yaml
+++ b/data/boosters/ltr-collector-special.yaml
@@ -1,7 +1,6 @@
 # Data from https://magic.wizards.com/en/news/feature/collecting-the-lord-of-the-rings-tales-of-middle-earth#ltrupdate
 name: "{set_name} Special Edition Collector Booster"
 filter: "(e:ltr number:452-833) or (e:ltc number:411-558) or (e:ltc number:/z/ -(Sol Ring))"
-
 pack:
   showcase_common: 2
   silver_showcase_common: 2

--- a/data/boosters/ltr-collector-special.yaml
+++ b/data/boosters/ltr-collector-special.yaml
@@ -1,6 +1,7 @@
 # Data from https://magic.wizards.com/en/news/feature/collecting-the-lord-of-the-rings-tales-of-middle-earth#ltrupdate
 name: "{set_name} Special Edition Collector Booster"
 filter: "(e:ltr number:452-833) or (e:ltc number:411-558) or (e:ltc number:/z/ -(Sol Ring))"
+
 pack:
   showcase_common: 2
   silver_showcase_common: 2
@@ -55,10 +56,17 @@ sheets:
     use: showcase_uncommon
     count: 79 + 9
   showcase_rare_mythic:
-    use: rare_mythic
+    any:
+    - rawquery: "((e:ltr number:452-712) or (e:ltc number:411-490)) r:r"
+      rate: 2
+      count: 60 + 72
+    - rawquery: "((e:ltr number:452-712) or (e:ltc number:411-490)) r:m"
+      rate: 1
+      count: 20 + 8
   silver_showcase_rare_mythic:
     foil: true
     use: showcase_rare_mythic
+    count: 60 + 20 + 72 + 8
   surge_map_land:
     foil: true
     rawquery: "e:ltr number:713-722"

--- a/data/boosters/ltr-draft.yaml
+++ b/data/boosters/ltr-draft.yaml
@@ -14,11 +14,14 @@ pack:
 sheets:
   with_showcase:
     any:
-    - query: "promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
+    # Scene range is 405-447 only: the Bilbo's Birthday Party (399-404) and
+    # Mount Doom (448-451) scenes are NOT in Draft Boosters (per the card image
+    # gallery), so their borderless scene cards are excluded here.
+    - query: "promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
       rate: 1
-    - query: "(number:302-331,340-345) -alt:(e:{set} number:399-451)"
+    - query: "(number:302-331,340-345) -alt:(e:{set} number:405-447)"
       rate: 2
-    - query: "-alt:(e:{set} number:302-331,340-345) number:399-451"
+    - query: "-alt:(e:{set} number:302-331,340-345) number:405-447"
       rate: 2
     # No count: this sheet is used via `use:` with per-rarity filters
     # (common/uncommon/rare/mythic_with_showcase), so these queries resolve to a

--- a/data/boosters/ltr-set.yaml
+++ b/data/boosters/ltr-set.yaml
@@ -54,24 +54,15 @@ sheets:
       chance: 1
   common_uncommon_showcase:
     any:
-    - rawquery: "e:{set} r:c -alt:(number:302-331,340-345) number:405-447"
+    - rawquery: "e:{set} r:c number:405-447"   # Borderless scene commons
       count: 8
       rate: 4
-    - rawquery: "e:{set} r:c number:302-331,340-345 -alt:(e:{set} number:405-447)"
-      rate: 4
-    - rawquery: "e:{set} r:c promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
-      rate: 2
-    - rawquery: "e:{set} r:u -alt:(number:302-331,340-345) number:405-447"
+    - rawquery: "e:{set} r:u number:405-447"   # Borderless scene uncommons
       count: 9
       rate: 2
-    - rawquery: "e:{set} r:u number:302-331,340-345 -alt:(e:{set} number:405-447)"
+    - rawquery: "e:{set} r:u number:302-331"   # Showcase Ring uncommons
       count: 10
       rate: 2
-    # Empty now that scenes 1 & 7 are excluded: no uncommon in 405-447 has a
-    # Showcase Ring alt, so there are no "both treatments" uncommons. Left in
-    # place (rate*0 = 0, auto-filtered) to mirror the r:c ring/both entries above.
-    - rawquery: "e:{set} r:u promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
-      rate: 1
   mythic_with_showcase:
     filter: "e:{set} r:m -number>451"
     use: with_showcase

--- a/data/boosters/ltr-set.yaml
+++ b/data/boosters/ltr-set.yaml
@@ -22,11 +22,14 @@ sheets:
     count: 101
   with_showcase:
     any:
-    - query: "promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
+    # Scene range is 405-447 only: the Bilbo's Birthday Party (399-404) and
+    # Mount Doom (448-451) scenes are NOT in Set Boosters (per the card image
+    # gallery), so their borderless scene cards are excluded here.
+    - query: "promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
       rate: 1
-    - query: "(number:302-331,340-345) -alt:(e:{set} number:399-451)"
+    - query: "(number:302-331,340-345) -alt:(e:{set} number:405-447)"
       rate: 2
-    - query: "-alt:(e:{set} number:302-331,340-345) number:399-451"
+    - query: "-alt:(e:{set} number:302-331,340-345) number:405-447"
       rate: 2
     # No count: this sheet is used via `use:` with per-rarity filters
     # (common/uncommon/rare/mythic_with_showcase), so these queries resolve to a
@@ -51,21 +54,23 @@ sheets:
       chance: 1
   common_uncommon_showcase:
     any:
-    - rawquery: "e:{set} r:c -alt:(number:302-331,340-345) number:399-451"
-      count: 9
+    - rawquery: "e:{set} r:c -alt:(number:302-331,340-345) number:405-447"
+      count: 8
       rate: 4
-    - rawquery: "e:{set} r:c number:302-331,340-345 -alt:(e:{set} number:399-451)"
+    - rawquery: "e:{set} r:c number:302-331,340-345 -alt:(e:{set} number:405-447)"
       rate: 4
-    - rawquery: "e:{set} r:c promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
+    - rawquery: "e:{set} r:c promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
       rate: 2
-    - rawquery: "e:{set} r:u -alt:(number:302-331,340-345) number:399-451"
+    - rawquery: "e:{set} r:u -alt:(number:302-331,340-345) number:405-447"
+      count: 9
+      rate: 2
+    - rawquery: "e:{set} r:u number:302-331,340-345 -alt:(e:{set} number:405-447)"
       count: 10
       rate: 2
-    - rawquery: "e:{set} r:u number:302-331,340-345 -alt:(e:{set} number:399-451)"
-      count: 6
-      rate: 2
-    - rawquery: "e:{set} r:u promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:399-451) -number:299-300 -number>451"
-      count: 8
+    # Empty now that scenes 1 & 7 are excluded: no uncommon in 405-447 has a
+    # Showcase Ring alt, so there are no "both treatments" uncommons. Left in
+    # place (rate*0 = 0, auto-filtered) to mirror the r:c ring/both entries above.
+    - rawquery: "e:{set} r:u promo:boosterfun alt:(number:302-331,340-345) alt:(e:{set} number:405-447) -number:299-300 -number>451"
       rate: 1
   mythic_with_showcase:
     filter: "e:{set} r:m -number>451"


### PR DESCRIPTION
Exclude scenes 1 & 7 from LTR Draft and Set Boosters

The Bilbo's Birthday Party (399–404) and Mount Doom (448–451) borderless scene cards do not appear in Draft or Set Boosters (confirmed against the Wizards card image gallery).


https://magic.wizards.com/en/products/the-lord-of-the-rings-tales-of-middle-earth/card-image-gallery?cigtreatment=scene-card

Also made some simplifications in the Set Booster config file.