### PR TITLE
MH3 Play and Collector Booster improvements

### DIFF
--- a/data/boosters/mh3-collector.yaml
+++ b/data/boosters/mh3-collector.yaml
@@ -8,33 +8,49 @@ pack:
   foil_rare_mythic: 1
   showcase_commander_slot:
   - showcase_commander: 1
-    chance: 238
+    chance: 903
   - showcase_commander_foil: 1
-    chance: 23
+    chance: 98
   showcase_rm: 2
   foil_showcase_rm: 1
+queries:
+  # The four Booster Fun treatment blocks, by collector number.
+  bl_frames: "(e:{set} number:320-361,381-383,442-446a)"   # borderless + concept Eldrazi + flip walkers
+  profile: "(e:{set} number:362-380)"                      # borderless profile
+  retro: "(e:{set} number:384-441)"                        # '97 retro frame
+  extended: "(e:{set} number:447-467)"                     # extended art
+  treatments: "e:{set} number:320-467"
+  # How many of the four treatments a card has. Cards are weighted so that every
+  # rare totals 12 and every mythic 6 no matter how many versions exist.
+  in_two: "((alt:{bl_frames} alt:{profile}) or (alt:{bl_frames} alt:{retro}) or (alt:{profile} alt:{retro}) or (alt:{extended} alt:{bl_frames}) or (alt:{extended} alt:{profile}) or (alt:{extended} alt:{retro}))"
+  in_three: "((alt:{bl_frames} alt:{profile} alt:{retro}) or (alt:{bl_frames} alt:{profile} alt:{extended}) or (alt:{bl_frames} alt:{retro} alt:{extended}) or (alt:{profile} alt:{retro} alt:{extended}))"
+  in_exactly_two: "((alt:{bl_frames} alt:{profile} -alt:{retro} -alt:{extended}) or (alt:{bl_frames} -alt:{profile} alt:{retro} -alt:{extended}) or (-alt:{bl_frames} alt:{profile} alt:{retro} -alt:{extended}) or (alt:{bl_frames} -alt:{profile} -alt:{retro} alt:{extended}) or (-alt:{bl_frames} alt:{profile} -alt:{retro} alt:{extended}) or (-alt:{bl_frames} -alt:{profile} alt:{retro} alt:{extended}))"
+  in_exactly_one: "(({bl_frames} -alt:{profile} -alt:{retro} -alt:{extended}) or (-alt:{bl_frames} {profile} -alt:{retro} -alt:{extended}) or (-alt:{bl_frames} -alt:{profile} {retro} -alt:{extended}) or (-alt:{bl_frames} -alt:{profile} -alt:{retro} {extended}))"
 sheets:
   foil_eldrazi_land:
     foil: true
     rawquery: "e:mh3 number:304-308"
     count: 5
   retro_cu:
+    # Article slot 9/10: retro commons 30.7%, retro uncommons 31.6%, new-to-Modern
+    # retro uncommons 10.5%, H2R commons 8.8%, H2R uncommons 15.8%, Wastes 2.6%.
+    # That is a 5:3 common:uncommon ratio per card, not 2:1.
     any:
     - rawquery: "e:mh3 r:u number:384-441"
       count: 16
-      rate: 1
+      rate: 3
     - rawquery: "e:mh3 r:c number:384-441"
       count: 7
-      rate: 2
+      rate: 5
     - rawquery: "e:mh3 number:309"
       count: 1
-      rate: 1
+      rate: 3
     - rawquery: "e:h2r r:u"
       count: 6
-      rate: 1
+      rate: 3
     - rawquery: "e:h2r r:c"
       count: 2
-      rate: 2
+      rate: 5
   foil_retro_cu:
     foil: true
     use: retro_cu
@@ -71,23 +87,23 @@ sheets:
   showcase_rm:
     any:
     - # two versions mythic
-      rawquery: "e:mh3 number:320-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:320-361,381-383,442-446a)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:384-441))) -is:foilonly"
+      rawquery: "{treatments} r:m alt:{in_two} -is:foilonly"
       count: 14
       rate: 3
     - # one version mythic
-      rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+      rawquery: "e:mh3 r:m {in_exactly_one} -is:foilonly"
       count: 17
       rate: 6
     - # three versions rare
-      rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+      rawquery: "{treatments} r:r alt:{in_three} -is:foilonly"
       count: 15
       rate: 4
     - # two versions rare
-      rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
+      rawquery: "{treatments} r:r alt:{in_exactly_two} -is:foilonly"
       count: 36
       rate: 6
     - # one version rare
-      rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
+      rawquery: "e:mh3 r:r {in_exactly_one} -is:foilonly"
       count: 43
       rate: 12
     - rawquery: "e:h2r r:m"
@@ -97,53 +113,37 @@ sheets:
       count: 2
       rate: 12
   foil_showcase_rm:
+    # Article slot 15. Sub-chances are the published percentages x10:
+    #   showcase R/M 78.6 - foil-etched rare 9.3 - foil-etched mythic 3.9
+    #   - Special Guests 4.4 - textured SPG Elemental 1.9 - textured DFC walker 1.9
+    # The showcase pool is the one slots 13-14 draw from, in foil, so it is reused
+    # rather than duplicated; it keeps its equiprobable 12-per-rare / 6-per-mythic
+    # weighting.
     foil: true
     any:
-    - chance: 999
+    # Serialized titans are chance 1 against 1999 -> 0.05% of the slot, so each of
+    # the three is 1 in 6000 boosters.
+    - chance: 1999
       any:
-      - # two versions mythic
-        rawquery: "e:mh3 number:320-467 r:m alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:320-361,381-383,442-446a)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:362-380)) or (alt:(e:mh3 number:447-467) alt:(e:mh3 number:384-441))) -is:foilonly"
-        count: 14
-        rate: 3
-      - # one version mythic
-        rawquery: "e:mh3 r:m (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
-        count: 17
-        rate: 6
-      - # three versions rare
-        rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
-        count: 15
-        rate: 4
-      - # two versions rare
-        rawquery: "e:mh3 number:320-467 r:r alt:((alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) alt:(e:mh3 number:384-441) alt:(e:mh3 number:447-467))) -is:foilonly"
-        count: 36
-        rate: 6
-      - # one version rare
-        rawquery: "e:mh3 r:r (((e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) (e:mh3 number:362-380) -alt:(e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) (e:mh3 number:384-441) -alt:(e:mh3 number:447-467)) or (-alt:(e:mh3 number:320-361,381-383,442-446a) -alt:(e:mh3 number:362-380) -alt:(e:mh3 number:384-441) (e:mh3 number:447-467))) -is:foilonly"
-        count: 43
-        rate: 12
-      - rawquery: "e:h2r r:m"
-        count: 6
-        rate: 6
-      - rawquery: "e:h2r r:r"
-        count: 2
-        rate: 12
+      - use: showcase_rm
+        chance: 786
       - rawquery: "e:mh3 is:etched r:r"
         count: 12
         etched: true
-        rate: 6
+        chance: 93
       - rawquery: "e:mh3 is:etched r:m"
         count: 10
         etched: true
-        rate: 3
+        chance: 39
       - set: spg
         code: "MHTHREE"
-        rate: 3
+        chance: 44
       - set: spg
         code: "MHTHREECOLLECTOR"
-        rate: 3
+        chance: 19
       - rawquery: "e:mh3 number:468-472"
         count: 5
-        rate: 3
+        chance: 19
     - chance: 1
       rawquery: "e:mh3 number:381-383 number:/z/"
       count: 3

--- a/data/boosters/mh3-play.yaml
+++ b/data/boosters/mh3-play.yaml
@@ -19,180 +19,300 @@ pack:
   wildcard: 1
   foil_with_showcase: 1
 queries:
+  # -- treatment blocks, by collector number --
   borderless: "e:{set} number:320-361,442-446"
   profile: "e:{set} number:362-383 -number:/z/"
   old_border: "e:{set} number:384-441"
+  showcase_frames: "({borderless} or {profile})"
   any_showcase: "{borderless} or {profile} or {old_border}"
+  showcase_no_retro: "({showcase_frames} -is:foilonly)"
   two_instances: "{any_showcase} ((alt:{borderless} alt:{profile}) or (alt:{borderless} alt:{old_border}) or (alt:{profile} alt:{old_border}))"
+  # -- card pools --
+  main_only: "-is:reprint -is:foilonly"                      # MH3-designed cards
+  rare_pool: "(is:fetchland or -is:reprint) -is:foilonly"    # as main_only, but keeps the fetchlands
+  reprint_pool: "is:reprint -is:foilonly"                    # the new-to-Modern reprints
+  snow_wastes: "e:{set} number:309"
+  basic_lands: "e:{set} number:304-319 -number:309"
 sheets:
   common:
     query: "r:c"
     count: 80
   land:
-    rawquery: "e:mh3 number:304-319 -number:309"
+    rawquery: "{basic_lands}"
     count: 15
   foil_land:
     foil: true
-    rawquery: "e:mh3 number:304-319 -number:309"
-    count: 15
+    use: land
   new_uncommon:
     query: "r:u -is:reprint"
     count: 101
-  new_rare_mythic:
+  dfc_uncommon:
+    # The 20 double-faced uncommons. No new-to-Modern card is a DFC, so this pool is
+    # identical in the wildcard and foil slots, and none of them has a retro version.
+    query: "r:u is:dfc"
+    count: 20
+  commander_mythic:
+    # The 8 M3C face commanders, regular and borderless-profile versions.
     any:
-    - rawquery: "r:r (is:fetchland or -is:reprint) -is:foilonly {two_instances}"
+    - rawquery: "e:m3c number:1-8"
+      count: 8
+      rate: 4
+    - rawquery: "e:m3c number:9-16"
+      count: 8
+      rate: 2
+  new_rare_mythic:
+    # Equiprobable collation: every rare shares total weight 40, every mythic total
+    # weight 20, so a card is equally likely regardless of how many alt-art versions
+    # it has. Alt printings are carved OUT of that total (alt fraction 4/40 = 1/10),
+    # so a card with alts appears correspondingly less in its base frame. This
+    # reproduces the article's slot-3 split: regular rare 79.8%, mythic 13.0%,
+    # Booster Fun 7.2%. Only the base rates encode the fraction; alt-printing rates
+    # are the per-treatment alt weight (2 alts of a card each carry half).
+    any:
+    - rawquery: "r:r {rare_pool} {two_instances}"
       count: 46
       rate: 2
-    - rawquery: "r:r -is:reprint -is:foilonly {any_showcase} -{two_instances}"
+    - rawquery: "r:r {main_only} {any_showcase} -{two_instances}"
       count: 18
       rate: 4
-    - query: "r:r (is:fetchland or -is:reprint) -is:foilonly alt:{any_showcase}"
+    - query: "r:r {rare_pool} alt:{any_showcase}"
       count: 41
-      rate: 8
-    - query: "r:r -is:reprint -is:foilonly -alt:{any_showcase}"
+      rate: 36
+    - query: "r:r {main_only} -alt:{any_showcase}"
       count: 19
-      rate: 12
-    - rawquery: "r:m -is:reprint -is:foilonly {two_instances}"
+      rate: 40
+    - rawquery: "r:m {main_only} {two_instances}"
       count: 12
       rate: 1
-    - rawquery: "r:m -is:reprint -is:foilonly {any_showcase} -{two_instances}"
+    - rawquery: "r:m {main_only} {any_showcase} -{two_instances}"
       count: 13
       rate: 2
-    - query: "r:m -is:reprint -is:foilonly alt:{any_showcase}"
+    - query: "r:m {main_only} alt:{any_showcase}"
       count: 19
-      rate: 4
-    - query: "r:m -is:reprint -is:foilonly -alt:{any_showcase}"
+      rate: 18
+    - query: "r:m {main_only} -alt:{any_showcase}"
       count: 1
-      rate: 6
+      rate: 20
   reprint:
+    # New-to-Modern slot. Equiprobable within each rarity band: every uncommon shares
+    # weight 120, every rare 40, every mythic 20 (mythics half as likely as rares per
+    # card). Alt printings are carved OUT of a card's total at 1/10 rather than added
+    # on top, so a card with a retro/borderless version appears correspondingly less
+    # in its base frame. Article slot-4 split: regular U 75%, R 21.3%, M 2.3%,
+    # Booster Fun ~1.4% (frame break / profile / retro).
+    #
+    # NOTE: the article lists no *uncommon* Booster Fun for this slot, yet 4 of the 20
+    # new-to-Modern uncommons do have retro printings. They are kept here (at the same
+    # 1/10 carve-out) so the slot's card pool is unchanged; the cost is that Booster Fun
+    # lands slightly above the published 1.4%.
     any:
-    - chance: 750
-      any:
-      - rate: 1
-        rawquery: "e:mh3 r:u number:384-441 is:reprint"
-        count: 4
-      - rate: 2
-        query: "r:u alt:(e:mh3 number:384-441) is:reprint"
-        count: 4
-      - rate: 3
-        query: "r:u is:reprint -alt:(e:mh3 number:384-441)"
-        count: 16
-    - chance: 213
-      any:
-      - rawquery: "r:r is:reprint -is:foilonly {any_showcase} -{two_instances}"
-        count: 10
-        rate: 2
-      - query: "r:r is:reprint -is:foilonly alt:{any_showcase} -is:fetchland"
-        count: 10
-        rate: 4
-      - query: "r:r is:reprint -is:foilonly -alt:{any_showcase}"
-        count: 8
-        rate: 6
-    - chance: 23
-      any:
-      - rawquery: "r:m is:reprint -is:foilonly {two_instances}"
-        count: 2
-        rate: 1
-      - rawquery: "r:m is:reprint -is:foilonly {any_showcase} -{two_instances}"
-        count: 3
-        rate: 2
-      - query: "r:m is:reprint -is:foilonly alt:{any_showcase}"
-        count: 4
-        rate: 4
+    # -- uncommons: total 120 each; the 4 with a retro version carve out 1/10 --
+    - query: "r:u is:reprint -alt:{old_border}"
+      count: 16
+      rate: 120
+    - query: "r:u is:reprint alt:{old_border}"
+      count: 4
+      rate: 108
+    - rawquery: "{old_border} r:u is:reprint"
+      count: 4
+      rate: 12
+    # -- rares: total 40 each (base-with-alt 36 + alt 4) --
+    - rawquery: "r:r {reprint_pool} {any_showcase} -{two_instances}"
+      count: 10
+      rate: 4
+    - query: "r:r {reprint_pool} alt:{any_showcase} -is:fetchland"
+      count: 10
+      rate: 36
+    - query: "r:r {reprint_pool} -alt:{any_showcase}"
+      count: 8
+      rate: 40
+    # -- mythics: total 20 each; all 4 have alts (Kaalia carries 2 at rate 1 each) --
+    - rawquery: "r:m {reprint_pool} {two_instances}"
+      count: 2
+      rate: 1
+    - rawquery: "r:m {reprint_pool} {any_showcase} -{two_instances}"
+      count: 3
+      rate: 2
+    - query: "r:m {reprint_pool} alt:{any_showcase}"
+      count: 4
+      rate: 18
   wildcard:
-    # Rarity/treatment mix per the WOTC "Collecting Modern Horizons 3" article's
-    # Wildcard slot. Each treatment is its own top-level chance, so the marginal
-    # probabilities match the published percentages exactly.
+    # Equiprobable within every rarity band: a card's alt-art printings are carved
+    # OUT of its per-card total, so a card that HAS a retro/borderless version shows
+    # up less in its base frame rather than more. Treatment printings are therefore
+    # rarity-weighted (a retro mythic is NOT as easy to pull as a retro common).
+    # Per-card total is 105 in every band; a retro printing takes 30/105 (~2/7) and
+    # a borderless/profile printing 7/105 (~1/16). Band chances then reproduce the
+    # article's published wildcard buckets:
+    #   common 41.7 - uncommon 33.4 - DFC uncommon 8.3 - rare 6.7 - mythic 1.1
+    #   - borderless/profile 0.4 - retro 4.2 - commander 4.2 - wastes <0.1
     # https://magic.wizards.com/en/news/feature/collecting-modern-horizons-3
     any:
-    - # common 41.7%
-      chance: 417
-      query: "r:c"
-      count: 80
-    - # uncommon 33.4%
-      chance: 334
-      query: "r:u -is:reprint -is:dfc"
-      count: 81
-    - # double-faced uncommon 8.3%
-      chance: 83
-      query: "r:u -is:reprint is:dfc"
-      count: 20
-    - # rare 6.7% (fetchlands included; new-to-Modern reprints have their own slot)
-      chance: 67
-      query: "r:r (is:fetchland or -is:reprint) -is:foilonly"
-      count: 60
-    - # mythic 1.1%
-      chance: 11
-      query: "r:m -is:reprint -is:foilonly"
-      count: 20
-    - # borderless / profile showcase rare or mythic 0.4%
-      chance: 4
-      rawquery: "e:mh3 -is:reprint -is:foilonly (r:r or r:m) ({borderless} or {profile})"
-      count: 52
-    - # retro frame, any rarity 4.2%
-      chance: 42
-      rawquery: "e:mh3 number:384-441"
-      count: 58
-    - # Commander mythic 4.2%
-      chance: 42
+    - # commons + their retro printings
+      chance: 4273
       any:
-      - rawquery: "e:m3c number:1-8"
-        count: 8
-        rate: 4
-      - rawquery: "e:m3c number:9-16"
-        count: 8
-        rate: 2
+      - query: "r:c -alt:{old_border}"
+        count: 73
+        rate: 105
+      - query: "r:c alt:{old_border}"
+        count: 7
+        rate: 75
+      - rawquery: "{old_border} r:c"
+        count: 7
+        rate: 30
+    - # non-DFC uncommons + all retro uncommon printings (incl. new-to-Modern)
+      chance: 3534
+      any:
+      - query: "r:u -is:reprint -is:dfc -alt:{old_border}"
+        count: 69
+        rate: 105
+      - query: "r:u -is:reprint -is:dfc alt:{old_border}"
+        count: 12
+        rate: 75
+      - rawquery: "{old_border} r:u"
+        count: 16
+        rate: 30
+    - # double-faced uncommons (no retro versions exist)
+      chance: 830
+      use: dfc_uncommon
+    - # rares + their retro and borderless/profile printings
+      chance: 800
+      any:
+      - query: "r:r {rare_pool} -alt:{old_border} -alt:{showcase_no_retro}"
+        count: 19
+        rate: 105
+      - query: "r:r {rare_pool} alt:{old_border} -alt:{showcase_no_retro}"
+        count: 1
+        rate: 75
+      - query: "r:r {rare_pool} -alt:{old_border} alt:{showcase_no_retro}"
+        count: 17
+        rate: 98
+      - query: "r:r {rare_pool} alt:{old_border} alt:{showcase_no_retro}"
+        count: 23
+        rate: 68
+      - rawquery: "{old_border} r:r"
+        count: 26
+        rate: 30
+      - rawquery: "e:mh3 r:r {main_only} {showcase_no_retro}"
+        count: 35
+        rate: 7
+    - # mythics + their retro and borderless/profile printings
+      chance: 134
+      any:
+      - query: "r:m {main_only} -alt:{old_border} -alt:{showcase_no_retro}"
+        count: 1
+        rate: 105
+      - query: "r:m {main_only} alt:{old_border} -alt:{showcase_no_retro}"
+        count: 2
+        rate: 75
+      - query: "r:m {main_only} -alt:{old_border} alt:{showcase_no_retro}"
+        count: 11
+        rate: 98
+      - query: "r:m {main_only} alt:{old_border} alt:{showcase_no_retro}"
+        count: 6
+        rate: 68
+      - rawquery: "{old_border} r:m"
+        count: 9
+        rate: 30
+      - rawquery: "e:mh3 r:m {main_only} {showcase_no_retro}"
+        count: 17
+        rate: 7
+    - # Commander mythic 4.2%
+      chance: 420
+      use: commander_mythic
     - # full-art Snow-Covered Wastes <0.1%
-      chance: 1
-      rawquery: "e:mh3 number:309"
+      chance: 10
+      rawquery: "{snow_wastes}"
       count: 1
   foil_with_showcase:
-    # Traditional foil slot. The article says it mirrors the Wildcard slot's
-    # contents (plus foil new-to-Modern cards) but publishes no separate per-rarity
-    # numbers, so it reuses the Wildcard slot's treatment weighting. Unlike the
-    # Wildcard slot it keeps the new-to-Modern reprints (they appear here in foil).
+    # Traditional foil slot. Mirrors the Wildcard slot but ALSO keeps the
+    # new-to-Modern reprints (they appear here in foil), so every band except
+    # commons and DFC uncommons draws from a larger pool.
+    #
+    # Same equiprobable collation as the wildcard: alt-art printings are carved OUT
+    # of a card's per-card total (105 in every band) rather than added on top, and
+    # treatment printings are rarity-weighted. The fractions differ from the
+    # wildcard's because the pools are bigger while the retro/borderless pools are
+    # not: a retro printing takes 35/105 (~1/3) and a borderless one 7/105 (~1/16).
+    # WOTC publishes no per-rarity numbers for this slot, so the band chances
+    # preserve the bucket marginals this slot already had.
     foil: true
     any:
-    - # common 41.7%
-      chance: 417
-      query: "r:c"
-      count: 80
-    - # uncommon 33.4%
-      chance: 334
-      query: "r:u -is:dfc"
-      count: 101
-    - # double-faced uncommon 8.3%
-      chance: 83
-      query: "r:u is:dfc"
-      count: 20
-    - # rare 6.7%
-      chance: 67
-      query: "r:r -is:foilonly"
-      count: 78
-    - # mythic 1.1%
-      chance: 11
-      query: "r:m -is:foilonly"
-      count: 24
-    - # borderless / profile showcase rare or mythic 0.4%
-      chance: 4
-      rawquery: "e:mh3 -is:foilonly (r:r or r:m) ({borderless} or {profile})"
-      count: 69
-    - # retro frame, any rarity 4.2%
-      chance: 42
-      rawquery: "e:mh3 number:384-441"
-      count: 58
-    - # Commander mythic 4.2%
-      chance: 42
+    - # commons + their retro printings
+      chance: 4292
       any:
-      - rawquery: "e:m3c number:1-8"
-        count: 8
-        rate: 4
-      - rawquery: "e:m3c number:9-16"
-        count: 8
-        rate: 2
+      - query: "r:c -alt:{old_border}"
+        count: 73
+        rate: 105
+      - query: "r:c alt:{old_border}"
+        count: 7
+        rate: 70
+      - rawquery: "{old_border} r:c"
+        count: 7
+        rate: 35
+    - # non-DFC uncommons (incl. new-to-Modern) + all retro uncommon printings
+      chance: 3525
+      any:
+      - query: "r:u -is:dfc -alt:{old_border}"
+        count: 85
+        rate: 105
+      - query: "r:u -is:dfc alt:{old_border}"
+        count: 16
+        rate: 70
+      - rawquery: "{old_border} r:u"
+        count: 16
+        rate: 35
+    - # double-faced uncommons (no retro versions exist)
+      chance: 830
+      use: dfc_uncommon
+    - # rares (incl. new-to-Modern) + their retro and borderless/profile printings
+      chance: 790
+      any:
+      - query: "r:r -is:foilonly -alt:{old_border} -alt:{showcase_no_retro}"
+        count: 27
+        rate: 105
+      - query: "r:r -is:foilonly alt:{old_border} -alt:{showcase_no_retro}"
+        count: 3
+        rate: 70
+      - query: "r:r -is:foilonly -alt:{old_border} alt:{showcase_no_retro}"
+        count: 25
+        rate: 98
+      - query: "r:r -is:foilonly alt:{old_border} alt:{showcase_no_retro}"
+        count: 23
+        rate: 63
+      - rawquery: "{old_border} r:r"
+        count: 26
+        rate: 35
+      - rawquery: "e:mh3 r:r -is:foilonly {showcase_no_retro}"
+        count: 48
+        rate: 7
+    - # mythics (incl. new-to-Modern) + their retro and borderless/profile printings
+      chance: 134
+      any:
+      - query: "r:m -is:foilonly -alt:{old_border} -alt:{showcase_no_retro}"
+        count: 1
+        rate: 105
+      - query: "r:m -is:foilonly alt:{old_border} -alt:{showcase_no_retro}"
+        count: 3
+        rate: 70
+      - query: "r:m -is:foilonly -alt:{old_border} alt:{showcase_no_retro}"
+        count: 14
+        rate: 98
+      - query: "r:m -is:foilonly alt:{old_border} alt:{showcase_no_retro}"
+        count: 6
+        rate: 63
+      - rawquery: "{old_border} r:m"
+        count: 9
+        rate: 35
+      - rawquery: "e:mh3 r:m -is:foilonly {showcase_no_retro}"
+        count: 21
+        rate: 7
+    - # Commander mythic 4.2%
+      chance: 420
+      use: commander_mythic
     - # full-art Snow-Covered Wastes <0.1%
-      chance: 1
-      rawquery: "e:mh3 number:309"
+      chance: 10
+      rawquery: "{snow_wastes}"
       count: 1
   special_guest:
     set: spg


### PR DESCRIPTION
Two commits against the MH3 booster definitions, checked against [Collecting Modern Horizons 3](https://magic.wizards.com/en/news/feature/collecting-modern-horizons-3).

**No card is added to or removed from any sheet in either file. Only weights change.** Verified by exporting both revisions with `bin/human_export_sealed_data` and diffing the card set of every sheet:

| file | sheets | card sets identical | cards reweighted |
|---|---|---|---|
| `mh3-play.yaml` | 9 | ✅ all | 976 |
| `mh3-collector.yaml` | 10 | ✅ all | 242 |

`booster_indexer` reports no count-assertion or unresolved-template warnings for either.

---

# 1. Play Booster — carve alt-art printings out of each card's rate

Booster Fun printings (borderless / profile / retro frame) were **added on top of** a card's base rate, so a card with an alt-art version was strictly more likely to be opened than one without. In the wildcard slot a rare with a retro version came out **1.7×** a rare without one, and a mythic **2.5×**.

All four slots now use **equiprobable collation**: a card's alt printings are carved **out of** its per-card total, so it appears *less* in its base frame rather than *more*, and every card of a rarity keeps the same overall rate.

### Slot 3 — rare/mythic

Folded at ~1/3, putting Booster Fun far above the published rate.

| | before | after | article |
|---|---|---|---|
| regular rare | 66.2% | **79.6%** | 79.8% |
| regular mythic | 10.0% | **13.3%** | 13.0% |
| retro frame | 7.1% | **2.1%** | 2.1% |
| borderless family | 16.7% | **5.0%** | 5.1% |
| **Booster Fun total** | **24.1%** | **7.2%** | **7.2%** |

### Slot 4 — new-to-Modern

| | before | after | article |
|---|---|---|---|
| regular uncommon | 71.0% | **73.5%** | 75% |
| regular rare | 17.6% | **21.3%** | 21.3% |
| regular mythic | 1.6% | **2.3%** | 2.3% |
| **Booster Fun total** | **9.9%** | **3.0%** | ~1.4% |

### Slot 5 — wildcard

All nine published buckets **preserved** (each within 0.04pp), while per-card fairness is fixed:

| bucket | after | article |
|---|---|---|
| common | 41.66% | 41.7% |
| uncommon | 33.37% | 33.4% |
| DFC uncommon | 8.30% | 8.3% |
| rare | 6.70% | 6.7% |
| mythic | 1.10% | 1.1% |
| borderless / profile | 0.38% | 0.4% |
| retro frame | 4.19% | 4.2% |
| Commander mythic | 4.20% | 4.2% |
| Snow-Covered Wastes | 0.10% | <0.1% |

### Slot 6 — traditional foil

No per-rarity numbers are published for this slot, so its existing bucket marginals are preserved (within 0.04pp) while it is converted off the additive model.

### Per-card equiprobability (max/min rate within a rarity)

| slot | C | U | R | M |
|---|---|---|---|---|
| rare/mythic | – | – | 1.00 → 1.00 | 1.00 → 1.00 |
| new-to-Modern | – | 1.00 → 1.00 | 1.00 → 1.00 | 1.00 → 1.00 |
| wildcard | 1.14 → **1.00** | 1.42 → 1.28 | 1.72 → **1.07** | 2.46 → **1.00** |
| foil | 1.14 → **1.00** | 1.52 → 1.29 | 1.91 → **1.00** | 2.71 → **1.07** |

### The retro bucket was rarity-blind

The wildcard/foil retro bucket drew **uniformly over all 58 retro cards**, so a retro mythic was exactly as easy to pull as a retro common (0.072% each). Because that *exceeded* the mythic base rate (1.1% ÷ 20 = 0.055%), equiprobability was arithmetically impossible — equalising would have required a negative base weight. Weighting retro printings by rarity fixes it: a retro common is now ~8.5× a retro mythic, the mythic base stays positive, and the retro bucket total is unchanged at 4.2%.

---

# 2. Collector Booster — fix three slot rates, dedupe showcase queries

### Slot 9/10 — retro frame C/U: ratio was 2:1, should be 5:3

| | before | after | article |
|---|---|---|---|
| MH3 retro commons | 34.15% | **30.70%** | 30.7% |
| MH3 retro uncommons | 29.27% | **31.58%** | 31.6% |
| new-to-Modern retro uncommons | 9.76% | **10.53%** | 10.5% |
| H2R commons | 9.76% | **8.77%** | 8.8% |
| H2R uncommons | 14.63% | **15.79%** | 15.8% |
| Snow-Covered Wastes | 2.44% | **2.63%** | 2.6% |

### Slot 12 — Commander: foil share was 8.8%, should be 9.8%

`chance: 238/23` → `903/98`. Foil sub-rates go 3.07 → **3.41** (etched, article 3.3), 3.07 → **3.41** (borderless, 3.5), 2.68 → **2.98** (extended, 3.0).

### Slot 15 — foil showcase R/M: specials were crowded out

The showcase pool took 85.9% where the article leaves it 78.6%:

| | before | after | article |
|---|---|---|---|
| showcase R/M | 85.92% | **78.52%** | 78.6% |
| foil-etched rare | 6.21% | **9.29%** | 9.3% |
| foil-etched mythic | 2.59% | **3.90%** | 3.9% |
| Special Guests | 2.59% | **4.40%** | 4.4% |
| textured SPG Elemental | 1.29% | **1.90%** | 1.9% |
| textured DFC walker | 1.29% | **1.90%** | 1.9% |


### Query dedupe

Slot 15 carried a **verbatim copy of the entire `showcase_rm` sheet** — five rawqueries up to **832 characters** each. It now does `use: showcase_rm` with sub-chances written as the article's percentages ×10 (786/93/39/44/19/19). The remaining queries use named templates for the four treatment blocks (`bl_frames`, `profile`, `retro`, `extended`) and the version-count tests (`in_two`, `in_three`, `in_exactly_two`, `in_exactly_one`):

```yaml
- rawquery: "{treatments} r:r alt:{in_exactly_two} -is:foilonly"   # was 832 chars
```

Total query text **−82%** (3123 → 551 chars); longest query **832 → 70 chars**.

### Serialized Eldrazi

Halved to **1 in 6,000** boosters each (`chance: 1` against `1999`). This rate is not published by WotC, so it is a judgement call rather than a correction — flagging it explicitly in case you'd rather it stayed at 1 in 3,000.
