### PR TITLE
Add Hobbit prerelease promo definition

### DIFF
--- a/data/boosters/hob-prerelease.yaml
+++ b/data/boosters/hob-prerelease.yaml
@@ -1,0 +1,15 @@
+# The Hobbit Prerelease promo: one traditional-foil base-set rare or mythic.
+# The four fixed seasonal lands are mapped separately in sealed-content.
+# Source: https://magic.wizards.com/en/news/feature/collecting-the-hobbit
+pack:
+  promo: 1
+sheets:
+  promo:
+    foil: true
+    any:
+    - rawquery: "e:hob r:r is:baseset"
+      rate: 2
+      count: 53
+    - rawquery: "e:hob r:m is:baseset"
+      rate: 1
+      count: 15


### PR DESCRIPTION
Add the missing The Hobbit prerelease promo definition referenced by sealed-content: one traditional-foil base-set rare or mythic. Use the existing prerelease convention of weight 2 per rare and 1 per mythic. The fixed seasonal lands are mapped separately in sealed-content.

Source: https://magic.wizards.com/en/news/feature/collecting-the-hobbit

Validation: compiled with the current card database and PackFactory; sheet counts resolve to 53 rare and 15 mythic physical printings, all foil (68 total). No exact prerelease odds are published; the relative weights follow the existing set prerelease definitions.
