### PR TITLE
Restore regular-frame foil mythics in RVR Draft Boosters

### DIFF
--- a/data/boosters/rvr-draft.yaml
+++ b/data/boosters/rvr-draft.yaml
@@ -82,9 +82,10 @@ sheets:
       - rawquery: "e:{set} r:m is:borderless -is:foilonly -frame:extendedart is:paper"
         count: 13
         rate: 1
-      - query: "r:r alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+      - query: "r:m alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+        count: 13
         rate: 2
-      - query: "r:r -alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
-        count: 71
+      - query: "r:m -alt:(e:{set} r:m is:borderless -is:foilonly -frame:extendedart)"
+        count: 7
         rate: 3
       chance: 3


### PR DESCRIPTION
Ravnica Remastered Draft Boosters currently cannot produce any regular-frame traditional-foil mythic rares: both corresponding branches in `foil_with_showcase` query `r:r` instead of `r:m`, so one is empty and the other duplicates rares.

Correct both rarity filters and their pool counts (13 mythics with borderless counterparts and seven without), retaining the existing relative rates. This restores all 20 regular-frame foil mythics to Draft Booster availability.

Source: [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-ravnica-remastered), which allows traditional-foil cards of any rarity in Draft Boosters.

Validation: compiled RVR Draft and Collector boosters against the fresh index; confirmed regular-frame foil mythic availability increases from zero to all 20. Both corrected pool counts validate. `git diff --check` passed.

Separate audit follow-up: foil retro-frame cards are also missing from the Draft definition. Their allocation needs further collation research; this PR only corrects the two demonstrably wrong rarity queries.
