### PR TITLE
Include all Fallout surge extended-art reprints in wildcard

### DIFF
--- a/data/boosters/pip-collector.yaml
+++ b/data/boosters/pip-collector.yaml
@@ -86,8 +86,9 @@ sheets:
     count: 85
     foil: true
   surge_wildcard:
-    rawquery: "e:pip number:529-854,890-975 -t:basic"
-    count: 402
+    # All surge-foil standard and extended-art cards; exclude basics and showcase cards.
+    rawquery: "e:pip number:529-854,890-1056 -t:basic"
+    count: 483
     foil: true
   showcase:
     rawquery: "e:pip number:327-361"


### PR DESCRIPTION
The Fallout Collector Booster surge-foil wildcard ends its extended-art range at 975, admitting only the first extended-art reprint and omitting the remaining 81. Extend the range through 1056 and update the physical-card pool count from 402 to 483.

[Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-magic-the-gathering-fallout) specifies a surge-foil wildcard excluding basic lands, Pip-Boy showcase cards and borderless Vault Boy cards. The corrected range includes all standard-frame and extended-art surge foils while preserving those exclusions. These reprints were already available in the dedicated extended-art reprint slot; this fixes their eligibility in the additional wildcard slot.

Validation: both Fallout booster definitions compile; verified all 81 reprints numbered 976–1056 appear in the corrected 483-card wildcard, the exclusions hold, and Collector Boosters still contain 15 cards. `git diff --check` passed.
