### PR TITLE
Add foil OTC face commanders to sample packs

### DIFF
--- a/data/boosters/otj-collector-sample.yaml
+++ b/data/boosters/otj-collector-sample.yaml
@@ -27,4 +27,20 @@ sheets:
       rate: 1
   foil_rare_mythic_showcase:
     foil: true
-    use: rare_mythic_showcase
+    any:
+    - rawquery: "e:otp r:r number<=65"
+      count: 30
+      rate: 2
+    - rawquery: "e:otp r:m number<=65"
+      count: 15
+      rate: 1
+    - rawquery: "e:otj r:r number:287-367"
+      count: 60
+      rate: 2
+    - rawquery: "e:otj r:m number:287-367"
+      count: 21
+      rate: 1
+    # Face commanders are available in foil in decks and sample packs.
+    - rawquery: "e:otc number:1-4"
+      count: 4
+      rate: 1


### PR DESCRIPTION
Add the four traditional-foil borderless OTC face commanders to Thunder Junction Collector Booster Sample Packs. The foil slot previously included only OTJ and OTP cards, excluding all four despite [Wizards’ collecting guide](https://magic.wizards.com/en/news/feature/collecting-outlaws-of-thunder-junction) explicitly identifying sample packs as a source.

Keep the nonfoil pool unchanged and give the added commanders the existing mythic `rate: 1` convention. This is a modeling convention, not a newly published sample-pack probability.

Validation: all four OTJ paper booster definitions compile; verified OTC 1–4 are present only in foil in samples, and sampled packs contain two cards. `git diff --check` passed.
