### PR TITLE
Correct Dominaria Remastered Draft foil and retro slots

### DIFF
--- a/data/boosters/dmr-draft.yaml
+++ b/data/boosters/dmr-draft.yaml
@@ -1,6 +1,5 @@
 # Data from https://magic.wizards.com/en/news/feature/collecting-dominaria-remastered-and-product-overview
 # "Each Draft Booster contains 1 retro frame card of any rarity and 1 retro frame land"
-# This doesn't handle retro frames for nonland cards
 # For retro basics, there are no other basics anyway, so it works without explicit checks
 #
 # Retro basics at 402-411 are included
@@ -25,11 +24,29 @@ pack:
   retro:
   - common_uncommon_retro: 1
     rare_mythic_with_showcase: 1
-    chance: 1
+    chance: 79
   - common: 1
     rare_mythic_retro: 1
-    chance: 1
+    chance: 21
 sheets:
+  # 21% * (20 mythics / (2*60 rares + 20 mythics)) = 3% retro mythics.
+  foil:
+    foil: true
+    # Draft foils include retro/borderless nonlands, but never foil basics.
+    filter: "e:dmr number:1-401 -t:basic"
+    any:
+    - use: common_with_showcase
+      chance: 12
+    - use: uncommon_with_showcase
+      chance: 5
+    - use: rare_mythic_with_showcase_foil
+      chance: 3
+  rare_mythic_with_showcase_foil:
+    any:
+    - use: rare_with_showcase
+      rate: 2
+    - use: mythic_with_showcase
+      rate: 1
   common_uncommon_borderless:
     filter: "e:{set} is:borderless"
     use: common_uncommon


### PR DESCRIPTION
Allow all 446 eligible base, retro and borderless nonland foils in Draft Boosters, excluding foil basic lands and the Buy-a-Box promo. Set the nonfoil retro R/M branch to 21%, yielding the published 3% retro-mythic rate under the existing 2:1 rare/mythic weighting. Detailed foil rarity/variant collation remains a modeling convention.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-dominaria-remastered-and-product-overview

Validation: Compiled all 50 existing 2023 booster definitions and both new LCI Bundle definitions. Focused pool/probability assertions pass; pack sizes remain unchanged. Unpublished detailed collation remains modeled, not certified as official odds.
