### PR TITLE
Correct Aftermath Epilogue Booster Fun rarity odds

### DIFF
--- a/data/boosters/mat.yaml
+++ b/data/boosters/mat.yaml
@@ -13,8 +13,15 @@ pack:
 sheets:
   booster_fun:
     filter: "e:{set} promo:boosterfun -is:foilonly -frame:extendedart"
-    use: base_1248_by_rarity
     count: 50
+    # R/M is 1 in 6, independently of the 1-in-6 foil upgrade.
+    any:
+    - query: "r:u"
+      count: 15
+      chance: 5
+    - use: rare_mythic
+      count: 35
+      chance: 1
   booster_fun_foil:
     foil: true
     use: booster_fun


### PR DESCRIPTION
Set the Booster Fun slot to rare/mythic in one sixth of Epilogue Boosters, independently of its one-in-six foil upgrade. The previous generic rarity weighting substantially overstated rare/mythic Booster Fun cards.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-march-of-the-machine-the-aftermath

Validation: Compiled all 50 existing 2023 booster definitions and both new LCI Bundle definitions. Focused pool/probability assertions pass; pack sizes remain unchanged. Unpublished detailed collation remains modeled, not certified as official odds.
