### PR TITLE
Correct Doctor Who TARDIS weights and sampler rarity

### DIFF
--- a/data/boosters/who-collector-sample.yaml
+++ b/data/boosters/who-collector-sample.yaml
@@ -1,15 +1,25 @@
 # Data from https://magic.wizards.com/en/news/feature/collecting-magic-the-gathering-doctor-who
 pack:
-- alternate_frame: 2
-  chance: 2
 - alternate_frame: 1
-  alternate_frame_foil: 1
+  rare_mythic_frame: 1
+  chance: 4
+- alternate_frame: 1
+  rare_mythic_frame_foil: 1
+  chance: 1
+- alternate_frame_foil: 1
+  rare_mythic_frame: 1
   chance: 1
 sheets:
+  alternate_frame_foil:
+    foil: true
+    use: alternate_frame
   alternate_frame:
     filter: "e:who promo:boosterfun -is:foilonly"
     use: base_1248_by_rarity
-  alternate_frame_foil:
-    foil: true
+  # At least one of the two cards must be rare/mythic.
+  rare_mythic_frame:
     filter: "e:who promo:boosterfun -is:foilonly"
-    use: base_1248_by_rarity
+    use: rare_mythic
+  rare_mythic_frame_foil:
+    foil: true
+    use: rare_mythic_frame

--- a/data/boosters/who-collector.yaml
+++ b/data/boosters/who-collector.yaml
@@ -100,17 +100,18 @@ sheets:
     foil: true
     filter: "e:who promo:surgefoil -frame:showcase -frame:extendedart -r:basic"
     use: base_1248_by_rarity
+  # All 30 TARDIS cards are equally likely within each finish.
   tardis:
-    filter: "e:who frame:showcase -promo:surgefoil -number:/z/"
-    use: base_1248_by_rarity
+    rawquery: "e:who frame:showcase -promo:surgefoil -number:/z/"
+    count: 30
   foil_tardis:
     foil: true
-    filter: "e:who frame:showcase -promo:surgefoil -number:/z/"
-    use: base_1248_by_rarity
+    rawquery: "e:who frame:showcase -promo:surgefoil -number:/z/"
+    count: 30
   surge_tardis:
     foil: true
-    filter: "e:who frame:showcase promo:surgefoil -number:/z/"
-    use: base_1248_by_rarity
+    rawquery: "e:who frame:showcase promo:surgefoil -number:/z/"
+    count: 30
   serialized:
     foil: true
     rawquery: "e:who number:/z/"


### PR DESCRIPTION
Give all 30 TARDIS treatments equal probability within each nonfoil, foil and surge-foil sheet. Require at least one rare/mythic in every two-card Collector Sample Booster while retaining nonfoil and traditional-foil uncommon eligibility. Preserve the existing total sampler foil rate; the split between its two mixed-finish branches is modeled equally.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-magic-the-gathering-doctor-who

Validation: Compiled all 50 existing 2023 booster definitions and both new LCI Bundle definitions. Focused pool/probability assertions pass; pack sizes remain unchanged. Unpublished detailed collation remains modeled, not certified as official odds.
