### PR TITLE
Correct Ixalan Collector pools and add Bundle Jurassic cards

### DIFF
--- a/data/boosters/lci-bundle-promo-foil.yaml
+++ b/data/boosters/lci-bundle-promo-foil.yaml
@@ -1,0 +1,9 @@
+# https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan
+name: "{set_name} Gift Bundle Jurassic World Foil Card"
+pack:
+  jurassic_world: 1
+sheets:
+  jurassic_world:
+    foil: true
+    rawquery: "e:rex r:r -promo:embossed -is:reversibleback"
+    count: 20

--- a/data/boosters/lci-bundle-promo.yaml
+++ b/data/boosters/lci-bundle-promo.yaml
@@ -1,0 +1,8 @@
+# https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan
+name: "{set_name} Bundle Jurassic World Card"
+pack:
+  jurassic_world: 1
+sheets:
+  jurassic_world:
+    rawquery: "e:rex r:r -promo:embossed -is:reversibleback"
+    count: 20

--- a/data/boosters/lci-collector.yaml
+++ b/data/boosters/lci-collector.yaml
@@ -46,46 +46,46 @@ sheets:
     any:
     - rawquery: "e:{set} is:showcase t:legendary r:u"
       count: 8
-      rate: 55
+      chance: 55
     - rawquery: "e:{set} is:borderless t:dinosaur r:u"
       count: 6
-      rate: 41
+      chance: 41
     - rawquery: "e:spg sheet:LCI r:u"
       count: 5
-      rate: 3
+      chance: 3
   foil_extended_commander_rare_mythic:
     foil: true
-    # The traditional-foil version of this slot is not just the extended-art
-    # commanders: the article says it also includes "the new Commander content
-    # found in Set Boosters" - i.e. the regular #1-16 and showcase #17-20
-    # commander cards - in foil. Without number:1-20 their foils are productless.
-    filter: "e:lcc (number:1-20 or frame:extendedart)"
+    # 6 rares and 14 mythics: extended art plus the four alternate commanders.
+    filter: "e:lcc (number:17-20 or frame:extendedart)"
+    count: 20
     use: rare_mythic
   showcase_rare_mythic:
     any:
-    - rawquery: "e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:r"
+    - rawquery: "e:lci promo:boosterfun -frame:extendedart -promo:neonink r:r"
+      count: 26
       rate: 4
-    - rawquery: 'e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:m -name:"Quintorius Kand"'
-      count: 4
+    - rawquery: 'e:lci promo:boosterfun -frame:extendedart -promo:neonink r:m -name:"Quintorius Kand"'
+      count: 19
       rate: 2
-    - rawquery: 'e:lcc promo:boosterfun -frame:extendedart -promo:neonink r:m name:"Quintorius Kand"'
+    - rawquery: 'e:lci promo:boosterfun -frame:extendedart -promo:neonink r:m name:"Quintorius Kand"'
+      count: 2
       rate: 1
   jurrasic_world:
     any:
-    - rawquery: "e:rex -t:basic -promo:embossed -is:reversibleback"
-      count: 21
+    - rawquery: "e:rex -t:land -promo:embossed -is:reversibleback"
+      count: 20
       rate: 1
-    - rawquery: "e:rex t:basic -promo:embossed -is:reversibleback"
-      count: 5
+    - rawquery: "e:rex t:land -promo:embossed -is:reversibleback"
+      count: 6
       rate: 4
   foil_jurrasic_world:
     foil: true
     any:
-    - rawquery: "e:rex -t:basic -promo:embossed -is:reversibleback"
-      count: 21
+    - rawquery: "e:rex -t:land -promo:embossed -is:reversibleback"
+      count: 20
       rate: 1
-    - rawquery: "e:rex t:basic -promo:embossed -is:reversibleback"
-      count: 5
+    - rawquery: "e:rex t:land -promo:embossed -is:reversibleback"
+      count: 6
       rate: 4
   emblem_jurrasic_world:
     foil: true


### PR DESCRIPTION
Use LCI instead of LCC for the main-set showcase slot, narrow the Commander foil pool to 20 eligible printings, apply published uncommon category percentages as category weights, and count Jurassic World as a land in the REX weighting. Add separate one-card Bundle pools with all 20 nonfoil/foil REX rares. The rounded 55/41/3 uncommon figures are normalized; unpublished detailed odds remain modeled.

Sources:
- https://magic.wizards.com/en/news/feature/collecting-the-lost-caverns-of-ixalan

Validation: Compiled all 50 existing 2023 booster definitions and both new LCI Bundle definitions. Focused pool/probability assertions pass; pack sizes remain unchanged. Unpublished detailed collation remains modeled, not certified as official odds.
